### PR TITLE
[AGT-P-001] Remove keyword-based intent classification - use pure LLM

### DIFF
--- a/specs/architecture/AGENTS.md
+++ b/specs/architecture/AGENTS.md
@@ -614,19 +614,9 @@ personality: klabautermann
 temperature: 0.7
 
 intent_classification:
-  search_keywords:
-    - "who"
-    - "what"
-    - "when"
-    - "where"
-    - "find"
-    - "tell me about"
-  action_keywords:
-    - "send"
-    - "email"
-    - "schedule"
-    - "create"
-    - "draft"
+  # AI-first: Uses LLM semantic understanding, no keyword matching
+  model: claude-3-5-haiku-20241022  # Fast model for classification
+  timeout: 5.0  # Seconds before graceful degradation
 
 delegation:
   search: researcher

--- a/src/klabautermann/agents/orchestrator/_orchestrator.py
+++ b/src/klabautermann/agents/orchestrator/_orchestrator.py
@@ -823,10 +823,11 @@ class Orchestrator(BaseAgent):
         trace_id: str,
     ) -> IntentClassification:
         """
-        Classify user intent using LLM with structured JSON output.
+        Classify user intent using LLM with structured JSON output (AI-first).
 
-        Uses Claude Haiku for fast, semantic intent classification. Falls back
-        to simple heuristics if LLM call fails.
+        Uses Claude Haiku for fast, semantic intent classification. On failure,
+        retries once then gracefully degrades to low-confidence CONVERSATION.
+        No keyword-based heuristics - pure LLM semantic understanding.
 
         Args:
             text: User's message text.
@@ -883,67 +884,54 @@ class Orchestrator(BaseAgent):
             )
 
         except Exception as e:
-            # Fallback to simple heuristics if LLM fails
+            # AI-first: Retry once with LLM, then gracefully degrade
+            # No keyword-based fallback - use pure semantic understanding
             logger.warning(
-                f"[SWELL] LLM classification failed, using fallback: {e}",
+                f"[SWELL] LLM classification failed, attempting retry: {e}",
                 extra={"trace_id": trace_id, "agent_name": self.name},
             )
-            return self._classify_intent_fallback(text, trace_id)
 
-    def _classify_intent_fallback(self, text: str, trace_id: str) -> IntentClassification:
-        """
-        Simple fallback classification when LLM is unavailable.
+            try:
+                # Single retry - gives LLM another chance for transient errors
+                response_text = await self._call_classification_model(
+                    self.CLASSIFICATION_PROMPT.format(message=text), trace_id
+                )
+                json_str = response_text.strip()
+                if json_str.startswith("```"):
+                    lines = json_str.split("\n")
+                    json_lines = [line for line in lines if not line.startswith("```")]
+                    json_str = "\n".join(json_lines)
 
-        Uses basic heuristics - much less accurate than LLM but works offline.
-        """
-        text_lower = text.lower().strip()
+                import json as json_module
 
-        # Question mark -> SEARCH
-        if "?" in text:
-            logger.debug(
-                "[WHISPER] Fallback: question mark -> SEARCH",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return IntentClassification(
-                type=IntentType.SEARCH,
-                confidence=0.6,
-                query=text,
-            )
+                parsed = json_module.loads(json_str)
+                if "intent_type" in parsed and isinstance(parsed["intent_type"], str):
+                    parsed["intent_type"] = parsed["intent_type"].lower()
+                json_str = json_module.dumps(parsed)
 
-        # Action keywords
-        action_starts = ("send", "email", "schedule", "create", "draft", "book")
-        if any(text_lower.startswith(kw) for kw in action_starts):
-            logger.debug(
-                "[WHISPER] Fallback: action keyword -> ACTION",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return IntentClassification(
-                type=IntentType.ACTION,
-                confidence=0.6,
-                action=text,
-            )
+                result = IntentClassificationResponse.model_validate_json(json_str)
+                logger.info(
+                    f"[CHART] LLM retry succeeded: {result.intent_type.value}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+                return IntentClassification(
+                    type=result.intent_type,
+                    confidence=result.confidence,
+                    query=result.extracted_query,
+                    action=result.extracted_action,
+                )
 
-        # Ingestion keywords
-        ingest_starts = ("i met", "i talked", "i spoke", "i learned", "i just")
-        if any(text_lower.startswith(kw) for kw in ingest_starts):
-            logger.debug(
-                "[WHISPER] Fallback: ingestion keyword -> INGESTION",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return IntentClassification(
-                type=IntentType.INGESTION,
-                confidence=0.6,
-            )
-
-        # Default to conversation
-        logger.debug(
-            "[WHISPER] Fallback: default -> CONVERSATION",
-            extra={"trace_id": trace_id, "agent_name": self.name},
-        )
-        return IntentClassification(
-            type=IntentType.CONVERSATION,
-            confidence=0.5,
-        )
+            except Exception as retry_error:
+                # Graceful degradation - return low-confidence CONVERSATION
+                # This signals to upstream that classification was uncertain
+                logger.error(
+                    f"[STORM] LLM classification retry failed, graceful degradation: {retry_error}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+                return IntentClassification(
+                    type=IntentType.CONVERSATION,
+                    confidence=0.3,  # Low confidence signals uncertainty
+                )
 
     # =========================================================================
     # Intent Handlers (T021 - Full Delegation)

--- a/src/klabautermann/agents/orchestrator/prompts.py
+++ b/src/klabautermann/agents/orchestrator/prompts.py
@@ -130,10 +130,11 @@ CORE RULES:
 3. INGEST IN BACKGROUND: When the user mentions new information (people, events, projects), dispatch to the Ingestor asynchronously - don't make the user wait.
 4. ACTION REQUIRES CONTEXT: Before the Executor sends an email or creates an event, ensure the Researcher has verified the recipient's email or the calendar availability.
 
-INTENT CLASSIFICATION:
-- Search intents: "who", "what", "when", "where", "find", "tell me about", "remind me"
-- Action intents: "send", "email", "schedule", "create", "draft", "remind"
-- Ingestion triggers: "I met", "I talked to", "I'm working on", "I learned", mentions of new people/projects
+INTENT CLASSIFICATION (AI-FIRST - Use semantic understanding, NOT keywords):
+- Search: User wants to retrieve information from knowledge graph (questions, fact lookups)
+- Action: User wants to interact with external services (email, calendar operations)
+- Ingestion: User is sharing new information to store (mentions of people, projects, facts)
+- Conversation: General chat, greetings, or unclear intent requiring clarification
 
 PERSONALITY:
 - You are a salty, efficient helper - witty but never annoying

--- a/tests/integration/test_sprint2_agents.py
+++ b/tests/integration/test_sprint2_agents.py
@@ -264,6 +264,29 @@ class TestIntentClassification:
             assert intent.type == IntentType.CONVERSATION
             assert intent.confidence == 0.7
 
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_llm_failure(
+        self,
+        orchestrator: Orchestrator,
+    ) -> None:
+        """AI-first: LLM failures gracefully degrade to low-confidence CONVERSATION.
+
+        When the LLM fails both the initial call and the retry, we return
+        CONVERSATION with 0.3 confidence (not keyword-based heuristics).
+        """
+        with patch.object(
+            orchestrator, "_call_classification_model", new_callable=AsyncMock
+        ) as mock_llm:
+            # Simulate LLM failure on both initial call and retry
+            mock_llm.side_effect = Exception("LLM unavailable")
+            intent = await orchestrator._classify_intent("Send email to John", None, "test-trace")
+            # Should gracefully degrade to CONVERSATION with low confidence
+            # NOT use keyword-based heuristics (which would return ACTION)
+            assert intent.type == IntentType.CONVERSATION
+            assert intent.confidence == 0.3  # Low confidence signals uncertainty
+            # LLM should have been called twice (initial + retry)
+            assert mock_llm.call_count == 2
+
 
 # ====================
 # AGENT DELEGATION TESTS


### PR DESCRIPTION
## Summary

Implements AI-first intent classification by removing the keyword-based fallback mechanism.

- Removes `_classify_intent_fallback()` method with hardcoded keywords (`send`, `email`, `schedule`, etc.)
- Implements LLM retry on first failure for transient error handling
- Graceful degradation to low-confidence CONVERSATION (0.3) when both attempts fail
- Updates SYSTEM_PROMPT to use semantic intent descriptions instead of keyword lists
- Updates specs/architecture/AGENTS.md to remove deprecated keyword config example
- Adds test for graceful degradation behavior

## Changes

| File | Change |
|------|--------|
| `src/klabautermann/agents/orchestrator/_orchestrator.py` | Removed keyword fallback, added LLM retry logic |
| `src/klabautermann/agents/orchestrator/prompts.py` | Updated INTENT CLASSIFICATION to AI-first |
| `specs/architecture/AGENTS.md` | Removed deprecated keyword config example |
| `tests/integration/test_sprint2_agents.py` | Added graceful degradation test |

## AI-First Approach

The new implementation:
1. Attempts LLM classification (Claude Haiku)
2. On failure, retries once (handles transient errors)
3. If both fail, returns `IntentClassification(type=CONVERSATION, confidence=0.3)`

The low confidence (0.3) signals uncertainty to upstream handlers, allowing them to ask for clarification rather than guessing based on keywords.

## Test plan

- [x] Existing intent classification tests pass (mocked LLM)
- [x] New test verifies graceful degradation on LLM failure
- [x] Code compiles and imports correctly
- [x] Ruff linter passes

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)