### PR TITLE
[SKILL-001] Create schedule-meeting skill

### DIFF
--- a/.claude/skills/schedule-meeting/SKILL.md
+++ b/.claude/skills/schedule-meeting/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: schedule-meeting
+description: Schedule a calendar meeting. Use when user says "schedule meeting", "book meeting", "set up meeting", or wants to create a calendar event.
+user-invocable: true
+klabautermann-task-type: execute
+klabautermann-agent: executor
+klabautermann-blocking: true
+klabautermann-requires-confirmation: true
+klabautermann-payload-schema:
+  action_type:
+    type: string
+    required: true
+    default: calendar_create
+  title:
+    type: string
+    required: true
+    extract-from: user-message
+    description: Meeting title extracted from user message
+  start_time:
+    type: string
+    required: true
+    extract-from: user-message
+    description: Start time in natural language (e.g., "tomorrow at 2pm", "next Monday 10am")
+  end_time:
+    type: string
+    required: false
+    extract-from: user-message
+    description: End time (defaults to 1 hour after start if not specified)
+  attendees:
+    type: array
+    required: false
+    extract-from: user-message
+    description: List of attendee names or emails
+  location:
+    type: string
+    required: false
+    extract-from: user-message
+    description: Meeting location or video call link
+  description:
+    type: string
+    required: false
+    extract-from: user-message
+    description: Meeting description or agenda
+---
+
+# Schedule Meeting Skill
+
+Schedule calendar meetings with natural language time parsing.
+
+## Triggers
+
+This skill activates when the user wants to:
+- Schedule a meeting
+- Book a calendar event
+- Set up a call or appointment
+- Create a calendar entry
+
+## Examples
+
+- "Schedule a meeting with Sarah tomorrow at 2pm"
+- "Book a standup for Monday 10am"
+- "Set up a 30-minute call with John at 3pm"
+- "Create a team sync for next Friday 11am-12pm"
+
+## Behavior
+
+1. **Extract meeting details** from user message:
+   - Title/subject
+   - Start time (required)
+   - End time (optional, defaults to +1 hour)
+   - Attendees (optional)
+   - Location (optional)
+
+2. **Check for conflicts** with existing calendar events
+
+3. **Confirm before creating** if attendees or important details are unclear
+
+4. **Create the event** via Google Calendar API
+
+## Payload Schema
+
+```json
+{
+  "action_type": "calendar_create",
+  "title": "Meeting with Sarah",
+  "start_time": "tomorrow at 2pm",
+  "end_time": "tomorrow at 3pm",
+  "attendees": ["sarah@example.com"],
+  "location": "Zoom",
+  "description": "Weekly sync"
+}
+```
+
+## Response Format
+
+On success:
+```
+Meeting scheduled: "Team Standup"
+When: Monday, Jan 20, 2025 10:00 AM - 11:00 AM
+Link: https://calendar.google.com/event?eid=xxx
+```
+
+On conflict:
+```
+Conflict detected: You have "Lunch with John" at 12:00 PM
+Would you like to schedule anyway or pick a different time?
+```

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,9 @@ Thumbs.db
 docs/_build/
 site/
 
-# Ignore AI agent-specific directories
-.claude/
+# Ignore AI agent-specific directories (but keep skills/)
+.claude/*
+!.claude/skills/
 
 # Ignore git worktrees directory
 worktrees/

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -394,3 +394,91 @@ class TestSkillAwarePlanner:
         assert "send-email" in context
         assert "research" in context
         assert "execute" in context
+
+
+class TestScheduleMeetingSkill:
+    """Tests for the schedule-meeting skill."""
+
+    @pytest.fixture
+    def planner_with_schedule_skill(self, tmp_path: Path) -> SkillAwarePlanner:
+        """Create planner with schedule-meeting skill loaded."""
+        skill_dir = tmp_path / "schedule-meeting"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            dedent("""
+            ---
+            name: schedule-meeting
+            description: Schedule a calendar meeting. Use when user says "schedule meeting", "book meeting", "set up meeting".
+            klabautermann-task-type: execute
+            klabautermann-agent: executor
+            klabautermann-blocking: true
+            klabautermann-requires-confirmation: true
+            klabautermann-payload-schema:
+              action_type:
+                type: string
+                required: true
+                default: calendar_create
+              title:
+                type: string
+                required: true
+                extract-from: user-message
+              start_time:
+                type: string
+                required: true
+                extract-from: user-message
+            ---
+
+            # Schedule Meeting
+
+            Schedule calendar meetings.
+        """).strip()
+        )
+
+        loader = SkillLoader(project_skills_dir=tmp_path, personal_skills_dir=tmp_path / "none")
+        return SkillAwarePlanner(loader)
+
+    def test_match_schedule_meeting(self, planner_with_schedule_skill: SkillAwarePlanner) -> None:
+        """Test matching schedule-meeting skill by description pattern."""
+        skill = planner_with_schedule_skill.match_skill("schedule a meeting with Sarah tomorrow")
+        assert skill is not None
+        assert skill.name == "schedule-meeting"
+
+    def test_match_book_meeting(self, planner_with_schedule_skill: SkillAwarePlanner) -> None:
+        """Test matching by 'book meeting' pattern."""
+        skill = planner_with_schedule_skill.match_skill("book a meeting for Monday 10am")
+        assert skill is not None
+        assert skill.name == "schedule-meeting"
+
+    def test_match_by_command(self, planner_with_schedule_skill: SkillAwarePlanner) -> None:
+        """Test matching by explicit /schedule-meeting command."""
+        skill = planner_with_schedule_skill.match_skill("/schedule-meeting Team standup")
+        assert skill is not None
+        assert skill.name == "schedule-meeting"
+
+    def test_skill_config(self, planner_with_schedule_skill: SkillAwarePlanner) -> None:
+        """Test schedule-meeting skill configuration."""
+        skill = planner_with_schedule_skill.match_skill("/schedule-meeting")
+        assert skill is not None
+        assert skill.klabautermann.task_type == "execute"
+        assert skill.klabautermann.agent == "executor"
+        assert skill.klabautermann.blocking is True
+        assert skill.klabautermann.requires_confirmation is True
+
+    def test_skill_to_planned_task(self, planner_with_schedule_skill: SkillAwarePlanner) -> None:
+        """Test converting schedule-meeting skill to PlannedTask."""
+        skill = planner_with_schedule_skill.match_skill("/schedule-meeting")
+        assert skill is not None
+
+        task = planner_with_schedule_skill.skill_to_planned_task(
+            skill,
+            {
+                "action_type": "calendar_create",
+                "title": "Team standup",
+                "start_time": "tomorrow at 10am",
+            },
+        )
+        assert task.task_type == "execute"
+        assert task.agent == "executor"
+        assert task.blocking is True
+        assert task.payload["action_type"] == "calendar_create"
+        assert task.payload["title"] == "Team standup"


### PR DESCRIPTION
## Summary

Creates a new skill for scheduling calendar meetings with natural language support.

## Changes

| File | Change |
|------|--------|
| `.claude/skills/schedule-meeting/SKILL.md` | New skill definition with payload schema |
| `.gitignore` | Allow `.claude/skills/` directory to be tracked |
| `tests/unit/test_skills.py` | Add tests for schedule-meeting skill |

## Skill Features

- **Triggers**: "schedule meeting", "book meeting", "set up meeting"
- **Payload schema**: title, start_time, end_time, attendees, location, description
- **Executor integration**: Uses `calendar_create` action type
- **Confirmation required**: Prevents accidental event creation

## Example Usage

```
User: "Schedule a meeting with Sarah tomorrow at 2pm"
→ Skill matches, extracts payload, sends to executor
→ Executor creates calendar event
```

## Test plan

- [x] Skill matches by pattern ("schedule meeting")
- [x] Skill matches by command (`/schedule-meeting`)
- [x] Config correctly specifies executor agent
- [x] Payload schema validates correctly

Fixes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)