### PR TITLE
feat(skills): Add 4 skills and AI-first skill discovery

### DIFF
--- a/.claude/skills/add-task/SKILL.md
+++ b/.claude/skills/add-task/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: add-task
+description: Create a new task or todo item
+version: "1.0.0"
+executor: ingestor
+
+parameters:
+  - name: title
+    type: string
+    required: true
+    description: Task title/description
+  - name: due_date
+    type: datetime
+    required: false
+    description: When the task is due
+  - name: priority
+    type: enum
+    values: [low, medium, high]
+    required: false
+    default: medium
+    description: Task priority level
+  - name: assignee
+    type: string
+    required: false
+    description: Person responsible for the task
+  - name: blocked_by
+    type: string
+    required: false
+    description: What/who is blocking this task
+---
+
+# Add Task Skill
+
+Creates tasks and todo items in the knowledge graph.
+
+## Usage Examples
+
+- "Add a task to review the PR"
+- "Create a todo: Send report to Sarah by Friday"
+- "Remind me to follow up with John next week"
+- "Add high priority task: Fix the login bug"
+
+## Executor Integration
+
+Routes to the `ingestor` agent which:
+1. Creates a Task node
+2. Extracts related entities (people, deadlines)
+3. Creates blocking relationships if specified
+
+## Task Entity
+
+```cypher
+(:Task {
+  id: string,
+  title: string,
+  status: "pending" | "in_progress" | "completed",
+  priority: "low" | "medium" | "high",
+  due_date: datetime,
+  created_at: datetime
+})
+```
+
+## Relationships
+
+- `(Task)-[:ASSIGNED_TO]->(Person)`
+- `(Task)-[:BLOCKED_BY]->(Task|Person|Topic)`
+- `(Task)-[:RELATES_TO]->(Topic|Project)`
+
+## Response Format
+
+Returns confirmation with:
+- Task ID
+- Due date (if set)
+- Assigned to (if set)
+- Related entities

--- a/.claude/skills/create-note/SKILL.md
+++ b/.claude/skills/create-note/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: create-note
+description: Create and save a text note to the knowledge graph
+version: "1.0.0"
+executor: ingestor
+
+parameters:
+  - name: content
+    type: string
+    required: true
+    description: The note content/text
+  - name: title
+    type: string
+    required: false
+    description: Optional title for the note
+  - name: tags
+    type: array[string]
+    required: false
+    description: Tags for categorization
+  - name: related_to
+    type: string
+    required: false
+    description: Person or topic this note relates to
+---
+
+# Create Note Skill
+
+Saves text notes to the knowledge graph with entity extraction.
+
+## Usage Examples
+
+- "Create a note about the project meeting"
+- "Save this: John mentioned the deadline is moved to Friday"
+- "Remember this for later: API key is in the config file"
+- "Write a note about Sarah's feedback on the design"
+
+## Executor Integration
+
+Routes to the `ingestor` agent which:
+1. Extracts entities (people, orgs, dates, etc.)
+2. Creates a Note node in the graph
+3. Links to related entities via relationships
+
+## Entity Extraction
+
+The ingestor will automatically extract:
+- Person mentions → Person nodes
+- Organization mentions → Organization nodes
+- Date references → Temporal edges
+- Topic keywords → Tags
+
+## Response Format
+
+Returns confirmation with:
+- Note ID
+- Extracted entities
+- Related nodes created

--- a/.claude/skills/schedule-meeting/SKILL.md
+++ b/.claude/skills/schedule-meeting/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: schedule-meeting
+description: Schedule a calendar meeting or event
+version: "1.0.0"
+executor: calendar
+
+parameters:
+  - name: title
+    type: string
+    required: true
+    description: Title/subject of the meeting
+  - name: start_time
+    type: datetime
+    required: true
+    description: Meeting start time (ISO 8601 format)
+  - name: end_time
+    type: datetime
+    required: false
+    description: Meeting end time (defaults to 1 hour after start)
+  - name: attendees
+    type: array[string]
+    required: false
+    description: List of attendee email addresses
+  - name: location
+    type: string
+    required: false
+    description: Physical location or video call URL
+  - name: description
+    type: string
+    required: false
+    description: Meeting description/agenda
+---
+
+# Schedule Meeting Skill
+
+Creates calendar events and meetings via the Google Calendar MCP integration.
+
+## Usage Examples
+
+- "Schedule a meeting with John tomorrow at 2pm"
+- "Book a call with the team on Friday at 10am for 30 minutes"
+- "Create an event called 'Project Review' next Monday at 3pm"
+
+## Executor Integration
+
+Routes to the `calendar` executor which uses the Google Calendar MCP server:
+
+```
+mcp://google-calendar/create-event
+```
+
+## Response Format
+
+Returns confirmation with:
+- Event ID
+- Calendar link
+- Attendee notification status

--- a/.claude/skills/search-contacts/SKILL.md
+++ b/.claude/skills/search-contacts/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: search-contacts
+description: Search for contacts and people in the knowledge graph
+version: "1.0.0"
+executor: researcher
+
+parameters:
+  - name: query
+    type: string
+    required: true
+    description: Name or identifying information to search
+  - name: organization
+    type: string
+    required: false
+    description: Filter by organization/company
+  - name: role
+    type: string
+    required: false
+    description: Filter by job role/title
+  - name: limit
+    type: integer
+    required: false
+    default: 10
+    description: Maximum number of results
+---
+
+# Search Contacts Skill
+
+Finds people and contacts stored in the knowledge graph.
+
+## Usage Examples
+
+- "Find John's contact info"
+- "Who works at Acme Corp?"
+- "Search for engineers I've talked to"
+- "Look up Sarah from marketing"
+
+## Executor Integration
+
+Routes to the `researcher` agent which queries the Neo4j knowledge graph:
+
+```cypher
+MATCH (p:Person)
+WHERE p.name CONTAINS $query OR p.email CONTAINS $query
+OPTIONAL MATCH (p)-[:WORKS_AT]->(o:Organization)
+RETURN p, o
+LIMIT $limit
+```
+
+## Response Format
+
+Returns structured contact information:
+- Name
+- Email (if known)
+- Organization
+- Role/title
+- Last interaction date

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,9 @@ Thumbs.db
 docs/_build/
 site/
 
-# Ignore AI agent-specific directories
-.claude/
+# Ignore AI agent-specific directories (except skills)
+.claude/*
+!.claude/skills/
 
 # Ignore git worktrees directory
 worktrees/

--- a/src/klabautermann/skills/__init__.py
+++ b/src/klabautermann/skills/__init__.py
@@ -5,15 +5,21 @@ Provides skill discovery, loading, and orchestrator integration using
 the standard Claude Code SKILL.md format with custom klabautermann-* fields.
 
 Usage:
-    from klabautermann.skills import SkillLoader, SkillAwarePlanner
+    from klabautermann.skills import SkillLoader, SkillDiscovery
 
     loader = SkillLoader()
     skills = loader.load_all()
 
+    # AI-first skill discovery (recommended)
+    discovery = SkillDiscovery(loader)
+    skill = await discovery.discover_skill("Who is Sarah?", trace_id)
+
+    # Legacy pattern-based matching (deprecated)
     planner = SkillAwarePlanner(loader)
     task = planner.match_and_convert("Who is Sarah?", trace_id)
 """
 
+from klabautermann.skills.discovery import SkillDiscovery
 from klabautermann.skills.loader import SkillLoader
 from klabautermann.skills.models import (
     KlabautermannSkillConfig,
@@ -29,6 +35,7 @@ __all__ = [
     "LoadedSkill",
     "PayloadField",
     "SkillAwarePlanner",
+    "SkillDiscovery",
     "SkillLoader",
     "SkillMetadata",
 ]

--- a/src/klabautermann/skills/discovery.py
+++ b/src/klabautermann/skills/discovery.py
@@ -1,0 +1,300 @@
+"""
+AI-first skill discovery using LLM semantic matching.
+
+Replaces keyword/regex-based pattern matching with pure LLM understanding
+of user intent and skill capabilities. This ensures accurate skill matching
+even for novel phrasings and edge cases.
+
+Usage:
+    discovery = SkillDiscovery(loader)
+    skill = await discovery.discover_skill("Who is Sarah?", trace_id)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from anthropic import AsyncAnthropic
+
+from klabautermann.core.config import get_settings
+from klabautermann.core.logger import logger
+from klabautermann.skills.loader import SkillLoader
+
+
+if TYPE_CHECKING:
+    from klabautermann.skills.models import LoadedSkill
+
+
+class SkillDiscovery:
+    """
+    AI-first skill discovery using LLM semantic matching.
+
+    Uses Claude to understand user intent and match to the most appropriate
+    skill based on semantic similarity, not keyword patterns.
+    """
+
+    def __init__(
+        self,
+        loader: SkillLoader | None = None,
+        model: str | None = None,
+    ) -> None:
+        """
+        Initialize skill discovery.
+
+        Args:
+            loader: SkillLoader instance. Creates new one if not provided.
+            model: LLM model for discovery. Defaults to fast model from settings.
+        """
+        self.loader = loader or SkillLoader()
+        self.settings = get_settings()
+        self.model = model or self.settings.fast_model
+        self.client = AsyncAnthropic(api_key=self.settings.anthropic_api_key)
+
+    def _build_skills_context(self) -> str:
+        """
+        Build context string listing available skills for LLM.
+
+        Returns:
+            Formatted string with skill names and descriptions.
+        """
+        self.loader.load_all()
+        skills = self.loader.registry.skills.values()
+
+        if not skills:
+            return "No skills available."
+
+        lines = []
+        for skill in skills:
+            lines.append(f"- {skill.name}: {skill.description}")
+
+        return "\n".join(lines)
+
+    def _build_discovery_prompt(self, user_input: str, skills_context: str) -> str:
+        """
+        Build the LLM prompt for skill discovery.
+
+        Args:
+            user_input: User's message.
+            skills_context: Formatted list of available skills.
+
+        Returns:
+            Complete prompt for skill matching.
+        """
+        return f"""Analyze the user's request and determine which skill (if any) best matches their intent.
+
+Available skills:
+{skills_context}
+
+User said: "{user_input}"
+
+Instructions:
+1. Understand the semantic meaning of the user's request
+2. Match it to the most appropriate skill based on what the skill does, not keyword matching
+3. Consider the user's likely intent, not just surface-level words
+4. If no skill is a good match, respond with "none"
+
+Respond with ONLY a JSON object in this format:
+{{"skill": "skill-name-or-none", "confidence": 0.0-1.0, "reasoning": "brief explanation"}}
+
+Examples:
+- "Can you find John's email?" -> {{"skill": "search-contacts", "confidence": 0.9, "reasoning": "User wants to look up contact information"}}
+- "What's the weather?" -> {{"skill": "none", "confidence": 0.95, "reasoning": "No skill handles weather queries"}}
+- "Set up a call with Sarah tomorrow" -> {{"skill": "schedule-meeting", "confidence": 0.85, "reasoning": "User wants to schedule a meeting/call"}}"""
+
+    async def discover_skill(
+        self,
+        user_input: str,
+        trace_id: str,
+        min_confidence: float = 0.5,
+    ) -> LoadedSkill | None:
+        """
+        Use LLM to discover the most appropriate skill for user input.
+
+        Args:
+            user_input: User's message text.
+            trace_id: Request trace ID for logging.
+            min_confidence: Minimum confidence threshold (0.0-1.0).
+
+        Returns:
+            Matched LoadedSkill or None if no confident match.
+        """
+        skills_context = self._build_skills_context()
+
+        # No skills available
+        if skills_context == "No skills available.":
+            logger.debug(
+                "[WHISPER] No skills available for discovery",
+                extra={"trace_id": trace_id},
+            )
+            return None
+
+        prompt = self._build_discovery_prompt(user_input, skills_context)
+
+        try:
+            response = await self.client.messages.create(
+                model=self.model,
+                max_tokens=256,
+                messages=[{"role": "user", "content": prompt}],
+            )
+
+            response_text = response.content[0].text.strip()
+
+            # Parse JSON response
+            result = self._parse_discovery_response(response_text)
+
+            if not result:
+                logger.warning(
+                    "[SWELL] Failed to parse skill discovery response",
+                    extra={"trace_id": trace_id, "response": response_text},
+                )
+                return None
+
+            skill_name = result.get("skill", "none")
+            confidence = result.get("confidence", 0.0)
+            reasoning = result.get("reasoning", "")
+
+            logger.info(
+                "[CHART] Skill discovery result",
+                extra={
+                    "trace_id": trace_id,
+                    "skill": skill_name,
+                    "confidence": confidence,
+                    "reasoning": reasoning,
+                },
+            )
+
+            # No match or low confidence
+            if skill_name == "none" or confidence < min_confidence:
+                return None
+
+            # Get the skill from loader
+            skill = self.loader.get(skill_name)
+            if not skill:
+                logger.warning(
+                    "[SWELL] LLM matched non-existent skill",
+                    extra={"trace_id": trace_id, "skill": skill_name},
+                )
+                return None
+
+            return skill
+
+        except Exception as e:
+            logger.warning(
+                "[SWELL] Skill discovery LLM call failed",
+                extra={"trace_id": trace_id, "error": str(e)},
+            )
+            return None
+
+    def _parse_discovery_response(self, response_text: str) -> dict[str, Any] | None:
+        """
+        Parse JSON response from discovery LLM.
+
+        Args:
+            response_text: Raw LLM response text.
+
+        Returns:
+            Parsed dict or None if parsing fails.
+        """
+        try:
+            # Try direct JSON parse
+            result: dict[str, Any] = json.loads(response_text)
+            return result
+        except json.JSONDecodeError:
+            pass
+
+        # Try to extract JSON from markdown code block
+        import re
+
+        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", response_text, re.DOTALL)
+        if json_match:
+            try:
+                result = json.loads(json_match.group(1))
+                return result
+            except json.JSONDecodeError:
+                pass
+
+        # Try to find raw JSON object
+        json_match = re.search(r"\{[^{}]*\}", response_text)
+        if json_match:
+            try:
+                result = json.loads(json_match.group(0))
+                return result
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
+    async def extract_payload_with_llm(
+        self,
+        skill: LoadedSkill,
+        user_input: str,
+        trace_id: str,
+    ) -> dict[str, Any]:
+        """
+        Use LLM to extract payload values from user input.
+
+        More sophisticated than simple pattern matching - understands
+        context and extracts structured data from natural language.
+
+        Args:
+            skill: Target skill with payload schema.
+            user_input: User's message text.
+            trace_id: Request trace ID for logging.
+
+        Returns:
+            Extracted payload dict.
+        """
+        # Get the skill's parameters from metadata (not klabautermann config)
+        # Since we're using simpler SKILL.md format without klabautermann-* fields
+        metadata = skill.metadata.model_dump()
+        parameters = metadata.get("parameters", [])
+
+        if not parameters:
+            return {"query": user_input}
+
+        # Build extraction prompt
+        param_desc = []
+        for param in parameters:
+            if isinstance(param, dict):
+                name = param.get("name", "unknown")
+                ptype = param.get("type", "string")
+                required = param.get("required", False)
+                desc = param.get("description", "")
+                param_desc.append(
+                    f"- {name} ({ptype}, {'required' if required else 'optional'}): {desc}"
+                )
+
+        prompt = f"""Extract parameters from the user's message for the "{skill.name}" skill.
+
+Parameters to extract:
+{chr(10).join(param_desc)}
+
+User said: "{user_input}"
+
+Respond with ONLY a JSON object containing the extracted values.
+Use null for optional parameters that cannot be determined.
+Example: {{"title": "Meeting with John", "start_time": null}}"""
+
+        try:
+            response = await self.client.messages.create(
+                model=self.model,
+                max_tokens=256,
+                messages=[{"role": "user", "content": prompt}],
+            )
+
+            response_text = response.content[0].text.strip()
+            result = self._parse_discovery_response(response_text)
+
+            if result:
+                # Filter out null values
+                return {k: v for k, v in result.items() if v is not None}
+
+        except Exception as e:
+            logger.warning(
+                "[SWELL] Payload extraction failed",
+                extra={"trace_id": trace_id, "error": str(e)},
+            )
+
+        # Fallback: return user input as query
+        return {"query": user_input}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from textwrap import dedent
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from klabautermann.skills.discovery import SkillDiscovery
 from klabautermann.skills.loader import SkillLoader
 from klabautermann.skills.models import (
     KlabautermannSkillConfig,
@@ -394,3 +396,177 @@ class TestSkillAwarePlanner:
         assert "send-email" in context
         assert "research" in context
         assert "execute" in context
+
+
+class TestSkillDiscovery:
+    """Tests for AI-first skill discovery."""
+
+    @pytest.fixture
+    def discovery_with_skills(self, tmp_path: Path) -> SkillDiscovery:
+        """Create discovery with test skills loaded."""
+        # Create test skills
+        for skill_data in [
+            ("schedule-meeting", "Schedule calendar meetings and events"),
+            ("search-contacts", "Find contacts and people in the knowledge graph"),
+            ("create-note", "Create and save notes to the knowledge graph"),
+            ("add-task", "Create tasks and todo items"),
+        ]:
+            skill_dir = tmp_path / skill_data[0]
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                dedent(f"""
+                ---
+                name: {skill_data[0]}
+                description: {skill_data[1]}
+                ---
+
+                # {skill_data[0]}
+
+                Skill content.
+            """).strip()
+            )
+
+        loader = SkillLoader(project_skills_dir=tmp_path, personal_skills_dir=tmp_path / "none")
+        return SkillDiscovery(loader=loader)
+
+    def test_build_skills_context(self, discovery_with_skills: SkillDiscovery) -> None:
+        """Build context string for LLM."""
+        context = discovery_with_skills._build_skills_context()
+
+        assert "schedule-meeting" in context
+        assert "search-contacts" in context
+        assert "create-note" in context
+        assert "add-task" in context
+
+    def test_build_skills_context_empty(self, tmp_path: Path) -> None:
+        """Handle no skills available."""
+        loader = SkillLoader(
+            project_skills_dir=tmp_path / "empty", personal_skills_dir=tmp_path / "none"
+        )
+        discovery = SkillDiscovery(loader=loader)
+        context = discovery._build_skills_context()
+
+        assert context == "No skills available."
+
+    def test_parse_discovery_response_json(self, discovery_with_skills: SkillDiscovery) -> None:
+        """Parse clean JSON response."""
+        result = discovery_with_skills._parse_discovery_response(
+            '{"skill": "schedule-meeting", "confidence": 0.9, "reasoning": "test"}'
+        )
+
+        assert result is not None
+        assert result["skill"] == "schedule-meeting"
+        assert result["confidence"] == 0.9
+
+    def test_parse_discovery_response_code_block(
+        self, discovery_with_skills: SkillDiscovery
+    ) -> None:
+        """Parse JSON in markdown code block."""
+        result = discovery_with_skills._parse_discovery_response(
+            dedent("""
+            Here's the match:
+            ```json
+            {"skill": "search-contacts", "confidence": 0.85, "reasoning": "user wants contact info"}
+            ```
+        """)
+        )
+
+        assert result is not None
+        assert result["skill"] == "search-contacts"
+
+    def test_parse_discovery_response_invalid(self, discovery_with_skills: SkillDiscovery) -> None:
+        """Handle invalid response."""
+        result = discovery_with_skills._parse_discovery_response("I don't understand")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_discover_skill_success(self, discovery_with_skills: SkillDiscovery) -> None:
+        """Discover skill with LLM (mocked)."""
+        # Mock the Anthropic client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text='{"skill": "search-contacts", "confidence": 0.9, "reasoning": "user wants contact"}'
+            )
+        ]
+
+        with patch.object(
+            discovery_with_skills.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            skill = await discovery_with_skills.discover_skill("Who is John?", "test-trace-123")
+
+        assert skill is not None
+        assert skill.name == "search-contacts"
+
+    @pytest.mark.asyncio
+    async def test_discover_skill_no_match(self, discovery_with_skills: SkillDiscovery) -> None:
+        """No skill matches user input."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text='{"skill": "none", "confidence": 0.95, "reasoning": "no matching skill"}'
+            )
+        ]
+
+        with patch.object(
+            discovery_with_skills.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            skill = await discovery_with_skills.discover_skill(
+                "What's the weather?", "test-trace-123"
+            )
+
+        assert skill is None
+
+    @pytest.mark.asyncio
+    async def test_discover_skill_low_confidence(
+        self, discovery_with_skills: SkillDiscovery
+    ) -> None:
+        """Reject low confidence matches."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text='{"skill": "search-contacts", "confidence": 0.3, "reasoning": "uncertain"}'
+            )
+        ]
+
+        with patch.object(
+            discovery_with_skills.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            skill = await discovery_with_skills.discover_skill(
+                "Do something", "test-trace-123", min_confidence=0.5
+            )
+
+        assert skill is None
+
+    @pytest.mark.asyncio
+    async def test_discover_skill_llm_error(self, discovery_with_skills: SkillDiscovery) -> None:
+        """Handle LLM call failure gracefully."""
+        with patch.object(
+            discovery_with_skills.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.side_effect = Exception("API error")
+            skill = await discovery_with_skills.discover_skill("Find John", "test-trace-123")
+
+        assert skill is None
+
+    @pytest.mark.asyncio
+    async def test_discover_skill_nonexistent_skill(
+        self, discovery_with_skills: SkillDiscovery
+    ) -> None:
+        """Handle LLM returning non-existent skill name."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"skill": "nonexistent-skill", "confidence": 0.9, "reasoning": "oops"}')
+        ]
+
+        with patch.object(
+            discovery_with_skills.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            skill = await discovery_with_skills.discover_skill("Find something", "test-trace-123")
+
+        assert skill is None


### PR DESCRIPTION
## Summary

- Create schedule-meeting skill for calendar events (closes #291)
- Create search-contacts skill for knowledge graph lookups (closes #292)
- Create create-note skill for note storage with entity extraction (closes #293)
- Create add-task skill for task/todo management (closes #294)
- Implement AI-first skill discovery using LLM semantic matching (closes #296)

## Implementation Details

### Skills Created

| Skill | Description | Executor |
|-------|-------------|----------|
| schedule-meeting | Schedule calendar meetings/events | calendar (MCP) |
| search-contacts | Find people in knowledge graph | researcher |
| create-note | Save notes with entity extraction | ingestor |
| add-task | Create tasks/todos | ingestor |

### AI-First Discovery (#296)

Added `SkillDiscovery` class that uses pure LLM semantic understanding instead of keyword/regex patterns:

- Builds context of available skills for LLM
- LLM determines best skill match with confidence score
- Configurable minimum confidence threshold
- Graceful fallback when no match or LLM error
- LLM-based payload extraction from natural language

```python
discovery = SkillDiscovery(loader)
skill = await discovery.discover_skill("Who is John?", trace_id)
# Returns search-contacts skill via semantic matching
```

### Files Changed

- `.claude/skills/*/SKILL.md` - 4 new skill definitions
- `src/klabautermann/skills/discovery.py` - New AI-first discovery
- `src/klabautermann/skills/__init__.py` - Export SkillDiscovery
- `tests/unit/test_skills.py` - Discovery unit tests
- `.gitignore` - Allow .claude/skills/ to be tracked

## Test plan

- [x] SKILL.md files have valid YAML frontmatter
- [x] SkillLoader can load new skills
- [x] SkillDiscovery builds correct context
- [x] SkillDiscovery parses JSON responses
- [x] SkillDiscovery handles errors gracefully
- [ ] Integration: skills route to correct agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)