### PR TITLE
fix(cli): Improve output readability and ANSI rendering

### DIFF
--- a/src/klabautermann/__main__.py
+++ b/src/klabautermann/__main__.py
@@ -28,7 +28,7 @@ from klabautermann.channels.cli_driver import CLIDriver
 from klabautermann.config.manager import ConfigManager
 from klabautermann.config.quartermaster import Quartermaster
 from klabautermann.core.exceptions import GraphConnectionError, StartupError
-from klabautermann.core.logger import logger
+from klabautermann.core.logger import logger, set_cli_log_level
 from klabautermann.memory.graphiti_client import GraphitiClient
 from klabautermann.memory.neo4j_client import Neo4jClient
 
@@ -336,6 +336,9 @@ async def main() -> int:
     """
     # Parse arguments
     args = parse_args()
+
+    # Set CLI-appropriate log level (WARNING by default to reduce noise)
+    set_cli_log_level()
 
     # Note: session_id support will be implemented in Sprint 3 with thread persistence
     if args.session:

--- a/src/klabautermann/channels/cli_driver.py
+++ b/src/klabautermann/channels/cli_driver.py
@@ -76,6 +76,7 @@ class CLIDriver(BaseChannel):
         self._running = False
         # Check for NO_SPINNER env var to disable animated spinner
         import os
+
         no_spinner = os.getenv("KLABAUTERMANN_NO_SPINNER", "").lower() in ("1", "true", "yes")
         self.renderer = CLIRenderer(no_spinner=no_spinner)
         self._prompt_session: PromptSession[str] | None = None
@@ -160,6 +161,9 @@ class CLIDriver(BaseChannel):
                             suppress_console_logging()
                             self.renderer.render_info("Logs disabled")
                         continue
+
+                    # Echo user input with distinct styling
+                    self.renderer.render_user_input(user_input)
 
                     # Process the message with spinner
                     response = await self.receive_message(

--- a/src/klabautermann/channels/cli_renderer.py
+++ b/src/klabautermann/channels/cli_renderer.py
@@ -9,12 +9,15 @@ Reference: specs/architecture/CHANNELS.md, specs/branding/PERSONALITY.md
 
 from __future__ import annotations
 
+import os
+import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
+from rich.rule import Rule
 from rich.theme import Theme
 
 from klabautermann.core.logger import restore_console_logging, suppress_console_logging
@@ -24,6 +27,22 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from rich.status import Status
+
+
+def _should_use_color() -> bool:
+    """Determine if color output should be used.
+
+    Respects NO_COLOR (https://no-color.org/) and FORCE_COLOR environment variables.
+    Falls back to TTY detection.
+    """
+    # NO_COLOR takes precedence (accessibility standard)
+    if os.getenv("NO_COLOR"):
+        return False
+    # FORCE_COLOR enables color even in non-TTY environments
+    if os.getenv("FORCE_COLOR"):
+        return True
+    # Fall back to TTY detection
+    return sys.stdout.isatty()
 
 
 # Nautical color theme (deeper palette matching Go TUI)
@@ -74,7 +93,15 @@ class CLIRenderer:
         Args:
             no_spinner: If True, disable animated spinner (for terminals with issues).
         """
-        self.console = Console(theme=NAUTICAL_THEME)
+        use_color = _should_use_color()
+        # force_terminal ensures Rich doesn't disable features when stdout isn't a TTY
+        # but FORCE_COLOR is set (e.g., in CI or when user knows terminal supports it)
+        force_terminal = bool(os.getenv("FORCE_COLOR"))
+        self.console = Console(
+            theme=NAUTICAL_THEME,
+            force_terminal=force_terminal,
+            no_color=not use_color,
+        )
         self.no_spinner = no_spinner
 
     def render_banner(self) -> None:
@@ -118,6 +145,15 @@ class CLIRenderer:
 """
         self.console.print(Markdown(help_md))
 
+    def render_user_input(self, content: str) -> None:
+        """
+        Echo user input with distinct styling.
+
+        Args:
+            content: User's input text.
+        """
+        self.console.print(f"[bold cyan]▶[/] [dim]{content}[/]")
+
     def render_response(self, content: str) -> None:
         """
         Render AI response with markdown formatting.
@@ -128,6 +164,8 @@ class CLIRenderer:
         self.console.print()
         self.console.print(Markdown(content))
         self.console.print()
+        # Add subtle separator for readability
+        self.console.print(Rule(style="dim"))
 
     def render_error(self, message: str) -> None:
         """

--- a/src/klabautermann/core/logger.py
+++ b/src/klabautermann/core/logger.py
@@ -247,6 +247,20 @@ def restore_console_logging() -> None:
         logger.addHandler(_console_handler)
 
 
+def set_cli_log_level() -> None:
+    """Set log level appropriate for CLI mode.
+
+    In CLI mode, only show warnings and errors by default to avoid
+    cluttering the interactive output. Users can override with LOG_LEVEL
+    environment variable or toggle with /logs command.
+    """
+    # Respect explicit LOG_LEVEL setting
+    if os.getenv("LOG_LEVEL"):
+        return
+    # Default CLI mode to WARNING (only [SWELL], [STORM], [SHIPWRECK])
+    logger.setLevel(logging.WARNING)
+
+
 # ===========================================================================
 # Convenience Functions
 # ===========================================================================
@@ -287,6 +301,7 @@ __all__ = [
     "log_with_context",
     "logger",
     "restore_console_logging",
+    "set_cli_log_level",
     "setup_logger",
     "suppress_console_logging",
 ]


### PR DESCRIPTION
## Summary

- Add NO_COLOR and FORCE_COLOR environment variable support for accessibility
- Configure Rich Console with proper TTY detection to fix ANSI escape code rendering
- Echo user input with distinct styling (▶ prefix) for clear visual distinction
- Add visual separator between exchanges for improved readability
- Default CLI mode to WARNING log level to reduce noise in interactive sessions

## Test plan

- [ ] Run CLI and verify ANSI codes render correctly (colors, spinners)
- [ ] Test with `NO_COLOR=1` to verify graceful degradation
- [ ] Test with `FORCE_COLOR=1` in piped output
- [ ] Verify user input shows with ▶ prefix
- [ ] Verify log noise is reduced (only warnings/errors shown by default)
- [ ] Test `/logs` toggle still works to enable verbose output

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)