### PR TITLE
feat(executor): Make email search max_results configurable

### DIFF
--- a/config/agents/executor.yaml
+++ b/config/agents/executor.yaml
@@ -15,6 +15,11 @@ tools:
   require_confirmation: true
   dry_run: false
 
+# Email-specific settings
+email:
+  max_results: 20       # Max emails to fetch from Gmail API
+  max_display: 10       # Max emails to show in formatted output
+
 timeouts:
   agent_response: 60.0
   llm_call: 30.0

--- a/src/klabautermann/agents/executor.py
+++ b/src/klabautermann/agents/executor.py
@@ -61,6 +61,10 @@ ERROR HANDLING:
 3. If MCP fails: Report the specific error, don't retry automatically
 """
 
+    # Default email configuration values
+    DEFAULT_EMAIL_MAX_RESULTS = 20
+    DEFAULT_EMAIL_MAX_DISPLAY = 10
+
     def __init__(
         self,
         name: str = "executor",
@@ -83,8 +87,19 @@ ERROR HANDLING:
                 self.model = model_config.get("primary", "claude-3-5-sonnet-20241022")
             else:
                 self.model = model_config or "claude-3-5-sonnet-20241022"
+
+            # Load email configuration
+            email_config = self.config.get("email", {})
+            self.email_max_results = email_config.get(
+                "max_results", self.DEFAULT_EMAIL_MAX_RESULTS
+            )
+            self.email_max_display = email_config.get(
+                "max_display", self.DEFAULT_EMAIL_MAX_DISPLAY
+            )
         else:
             self.model = "claude-3-5-sonnet-20241022"
+            self.email_max_results = self.DEFAULT_EMAIL_MAX_RESULTS
+            self.email_max_display = self.DEFAULT_EMAIL_MAX_DISPLAY
 
     async def process_message(self, msg: AgentMessage) -> AgentMessage | None:
         """
@@ -392,13 +407,17 @@ ERROR HANDLING:
             # Execute search using the built query
             emails = await self.google.search_emails(
                 query=gmail_query,
-                max_results=10,
+                max_results=self.email_max_results,
                 context=invocation_ctx,
             )
 
             # Format results using EmailFormatter with full body content
             formatted = EmailFormatter.format_email_list(
-                emails, max_display=5, include_body=True, body_max_length=500
+                emails,
+                max_display=self.email_max_display,
+                include_body=True,
+                body_max_length=500,
+                total_available=self.email_max_results,  # Hint for "may have more"
             )
 
             logger.info(

--- a/src/klabautermann/agents/gmail_handlers.py
+++ b/src/klabautermann/agents/gmail_handlers.py
@@ -363,6 +363,7 @@ class EmailFormatter:
         include_snippet: bool = True,
         include_body: bool = False,
         body_max_length: int = 500,
+        total_available: int | None = None,
     ) -> str:
         """
         Format list of emails for display.
@@ -373,6 +374,7 @@ class EmailFormatter:
             include_snippet: Whether to include preview snippets
             include_body: Whether to include full body content (preferred over snippet)
             body_max_length: Maximum length for body content truncation
+            total_available: Max emails that could be fetched (hints if more exist)
 
         Returns:
             Formatted string for display
@@ -385,7 +387,16 @@ class EmailFormatter:
         if not emails:
             return "No emails found."
 
-        lines = [f"Found {len(emails)} email(s):"]
+        # Header with count info
+        displayed = min(len(emails), max_display)
+        if len(emails) == displayed and (total_available is None or len(emails) < total_available):
+            # Showing all fetched, but more may exist
+            lines = [f"Showing {displayed} email(s):"]
+        elif len(emails) > max_display:
+            # More fetched than displayed
+            lines = [f"Showing {displayed} of {len(emails)} email(s):"]
+        else:
+            lines = [f"Found {len(emails)} email(s):"]
 
         for i, email in enumerate(emails[:max_display]):
             lines.append("")  # Blank line between emails
@@ -414,7 +425,12 @@ class EmailFormatter:
         # Add overflow indicator
         if len(emails) > max_display:
             lines.append("")
-            lines.append(f"... and {len(emails) - max_display} more")
+            lines.append(f"... and {len(emails) - max_display} more in results")
+
+        # Hint if there may be more emails not fetched
+        if total_available and len(emails) >= total_available:
+            lines.append("")
+            lines.append("(More emails may exist - ask for more results if needed)")
 
         return "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- Add `email.max_results` and `email.max_display` configuration to executor.yaml
- Default to 20 results fetched from Gmail API (up from 10)
- Default to 10 emails displayed (up from 5)
- Update EmailFormatter to show "Showing X of Y" when more results exist
- Add hint when more emails may exist beyond the fetched limit

## Test plan

- [ ] Verify email search returns up to 20 results by default
- [ ] Verify only 10 emails are displayed in formatted output
- [ ] Test custom config values in executor.yaml
- [ ] Verify "Showing X of Y" appears when appropriate
- [ ] Verify hint about more emails appears when results hit limit

Fixes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)