### PR TITLE
feat(test): Add coverage threshold and show_missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ help:
 	@echo ""
 	@echo "Quality:"
 	@echo "  make test         Run all tests"
+	@echo "  make test-cov     Run tests with coverage report"
 	@echo "  make lint         Run linter (ruff)"
 	@echo "  make type-check   Run type checker (mypy)"
 	@echo "  make format       Format code (ruff format)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,8 @@ omit = [
 ]
 
 [tool.coverage.report]
+fail_under = 50
+show_missing = true
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",


### PR DESCRIPTION
## Summary

- Add `fail_under = 50` threshold to coverage configuration (will fail CI if coverage drops below 50%)
- Add `show_missing = true` to show uncovered lines in coverage reports
- Update Makefile help to document the existing `test-cov` target

Note: pytest-cov dependency, coverage configuration, and htmlcov/ gitignore were already present in the codebase.

## Test plan

- [ ] Run `make test-cov` and verify coverage report is generated
- [ ] Verify HTML report is created in `htmlcov/`
- [ ] Verify fail_under threshold works (coverage must be >= 50%)
- [ ] Verify show_missing displays uncovered lines

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)