### PR TITLE
feat(core): Implement graceful shutdown manager (#152)

### DIFF
--- a/src/klabautermann/__main__.py
+++ b/src/klabautermann/__main__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import os
 import signal
 import sys
@@ -29,6 +30,7 @@ from klabautermann.config.manager import ConfigManager
 from klabautermann.config.quartermaster import Quartermaster
 from klabautermann.core.exceptions import GraphConnectionError, StartupError
 from klabautermann.core.logger import logger, set_cli_log_level
+from klabautermann.core.shutdown import ShutdownManager
 from klabautermann.memory.graphiti_client import GraphitiClient
 from klabautermann.memory.neo4j_client import Neo4jClient
 
@@ -62,9 +64,16 @@ class Klabautermann:
         self.agents: dict[str, BaseAgent] = {}
         self.agent_tasks: list[asyncio.Task[Any]] = []
 
-        # Shutdown coordination
+        # Shutdown manager for graceful shutdown
+        self._shutdown_manager = ShutdownManager(
+            timeout_seconds=30.0,
+            drain_timeout_seconds=10.0,
+        )
+
+        # Legacy shutdown event (for signal handlers)
         self._shutdown_event = asyncio.Event()
         self._cli_task: asyncio.Task[Any] | None = None
+        self._cli: CLIDriver | None = None
 
     @property
     def anthropic(self) -> Any:
@@ -104,6 +113,8 @@ class Klabautermann:
             password=os.getenv("NEO4J_PASSWORD", ""),
         )
         await self.neo4j.connect()
+        # Register for graceful shutdown
+        self._shutdown_manager.register_client("neo4j", self.neo4j.disconnect)
 
         # Initialize Graphiti (optional - may fail if OpenAI key not set)
         if os.getenv("OPENAI_API_KEY"):
@@ -116,6 +127,8 @@ class Klabautermann:
                     openai_api_key=os.getenv("OPENAI_API_KEY"),
                 )
                 await self.graphiti.connect()
+                # Register for graceful shutdown
+                self._shutdown_manager.register_client("graphiti", self.graphiti.disconnect)
             except Exception as e:
                 logger.warning(
                     f"[SWELL] Graphiti initialization failed (entity extraction disabled): {e}"
@@ -168,7 +181,6 @@ class Klabautermann:
                 name="ingestor",
                 config=get_config_dict("ingestor"),
                 graphiti_client=self.graphiti,
-                llm_client=self.anthropic,
             )
         else:
             logger.warning("[SWELL] Ingestor not created - Graphiti unavailable")
@@ -189,6 +201,10 @@ class Klabautermann:
         )
 
         logger.info(f"[CHART] Created {len(self.agents)} agents")
+
+        # Register agents for graceful shutdown (in creation order)
+        for name, agent in self.agents.items():
+            self._shutdown_manager.register_agent(name, agent)
 
     def _wire_agent_registry(self) -> None:
         """Wire up agent registry for message routing."""
@@ -229,54 +245,79 @@ class Klabautermann:
         orchestrator = self.agents["orchestrator"]
         if not isinstance(orchestrator, Orchestrator):
             raise StartupError("orchestrator agent must be an Orchestrator instance")
-        cli = CLIDriver(orchestrator)
+        self._cli = CLIDriver(orchestrator)
+
+        # Register CLI for graceful shutdown
+        self._shutdown_manager.register_channel("cli", self._cli)
 
         try:
             # Run CLI in the main task
-            await cli.start()
+            await self._cli.start()
         except asyncio.CancelledError:
             logger.info("[CHART] CLI cancelled")
 
     def _handle_shutdown(self) -> None:
-        """Handle shutdown signal."""
+        """Handle shutdown signal (SIGINT/SIGTERM)."""
         logger.info("[CHART] Shutdown signal received")
+
+        # Request graceful shutdown via manager
+        self._shutdown_manager.request_shutdown()
         self._shutdown_event.set()
+
+        # Stop CLI if running (allows graceful exit from REPL)
+        if self._cli:
+            # Create task to stop CLI asynchronously
+            self._cli_task = asyncio.create_task(self._cli.stop())
 
         # Cancel all agent tasks
         for task in self.agent_tasks:
             task.cancel()
 
     async def shutdown(self) -> None:
-        """Clean shutdown of all components."""
+        """
+        Clean shutdown of all components using ShutdownManager.
+
+        Shutdown order (reverse of startup):
+        1. Channels (stops accepting new requests)
+        2. Drain pending messages from agent queues
+        3. Agents (in reverse registration order)
+        4. Clients (Neo4j, Graphiti)
+        5. Support services (quartermaster)
+        """
         logger.info("[CHART] Shutting down Klabautermann...")
 
-        # Stop agents
-        for name, agent in self.agents.items():
-            await agent.stop()
-            logger.debug(f"[WHISPER] Stopped {name}")
+        # Use ShutdownManager for orderly shutdown
+        result = await self._shutdown_manager.shutdown()
 
-        # Wait for tasks to complete
+        # Wait for agent tasks to complete
         if self.agent_tasks:
-            await asyncio.gather(*self.agent_tasks, return_exceptions=True)
+            # Give tasks a chance to complete gracefully
+            done, pending = await asyncio.wait(
+                self.agent_tasks,
+                timeout=5.0,
+                return_when=asyncio.ALL_COMPLETED,
+            )
 
-        # Stop hot-reload
+            # Cancel any still-pending tasks
+            for task in pending:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+            logger.debug(
+                f"[WHISPER] Agent tasks completed: {len(done)} done, {len(pending)} cancelled"
+            )
+
+        # Stop hot-reload (not managed by shutdown manager)
         if self.quartermaster:
             self.quartermaster.stop()
+            logger.debug("[WHISPER] Quartermaster stopped")
 
-        # Close clients
-        if self.graphiti:
-            try:
-                await self.graphiti.disconnect()
-            except Exception as e:
-                logger.warning(f"[SWELL] Graphiti disconnect error: {e}")
-
-        if self.neo4j:
-            try:
-                await self.neo4j.disconnect()
-            except Exception as e:
-                logger.warning(f"[SWELL] Neo4j disconnect error: {e}")
-
-        logger.info("[BEACON] Klabautermann shutdown complete")
+        if not result.success:
+            logger.warning(
+                f"[SWELL] Shutdown completed with errors: {result.error}",
+                extra={"phase": result.phase.value},
+            )
 
     async def run(self) -> None:
         """Main entry point."""

--- a/src/klabautermann/core/shutdown.py
+++ b/src/klabautermann/core/shutdown.py
@@ -1,0 +1,475 @@
+"""
+Graceful shutdown management for Klabautermann.
+
+Coordinates orderly shutdown of all system components with:
+- Reverse-order component shutdown
+- Pending message draining
+- Timeout handling
+- Detailed status logging
+
+Reference: Issue #152, specs/architecture/CHANNELS.md Section 5.2
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from klabautermann.core.logger import logger
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from klabautermann.agents.base_agent import BaseAgent
+    from klabautermann.channels.base_channel import BaseChannel
+
+
+class ShutdownPhase(Enum):
+    """Phases of the shutdown process."""
+
+    INITIATED = "initiated"
+    CHANNELS_STOPPING = "channels_stopping"
+    DRAINING_QUEUES = "draining_queues"
+    AGENTS_STOPPING = "agents_stopping"
+    CLIENTS_DISCONNECTING = "clients_disconnecting"
+    COMPLETE = "complete"
+    FAILED = "failed"
+
+
+@dataclass
+class ShutdownStatus:
+    """Status of a component during shutdown."""
+
+    component_name: str
+    component_type: str  # "channel", "agent", "client"
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    success: bool = False
+    error: str | None = None
+    pending_items: int = 0
+
+    @property
+    def duration_ms(self) -> float | None:
+        """Get duration in milliseconds."""
+        if self.started_at and self.completed_at:
+            return (self.completed_at - self.started_at).total_seconds() * 1000
+        return None
+
+
+@dataclass
+class ShutdownResult:
+    """Result of the shutdown process."""
+
+    success: bool
+    phase: ShutdownPhase
+    started_at: datetime
+    completed_at: datetime | None = None
+    component_statuses: list[ShutdownStatus] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def duration_ms(self) -> float | None:
+        """Get total duration in milliseconds."""
+        if self.completed_at:
+            return (self.completed_at - self.started_at).total_seconds() * 1000
+        return None
+
+    def summary(self) -> str:
+        """Get a summary of the shutdown result."""
+        status = "SUCCESS" if self.success else "FAILED"
+        duration = f" in {self.duration_ms:.0f}ms" if self.duration_ms else ""
+        failed = [s for s in self.component_statuses if not s.success]
+        if failed:
+            failures = ", ".join(s.component_name for s in failed)
+            return f"Shutdown {status}{duration}. Failed: {failures}"
+        return (
+            f"Shutdown {status}{duration}. All {len(self.component_statuses)} components stopped."
+        )
+
+
+class ShutdownManager:
+    """
+    Manages graceful shutdown of all system components.
+
+    Ensures orderly shutdown by:
+    1. Stopping channels first (stops accepting new requests)
+    2. Draining pending messages from agent queues
+    3. Stopping agents in reverse registration order
+    4. Disconnecting clients (Neo4j, Graphiti, etc.)
+
+    Usage:
+        manager = ShutdownManager(timeout_seconds=30)
+        manager.register_channel(cli_driver)
+        manager.register_agent(orchestrator)
+        manager.register_client("neo4j", neo4j.disconnect)
+
+        result = await manager.shutdown()
+    """
+
+    def __init__(
+        self,
+        timeout_seconds: float = 30.0,
+        drain_timeout_seconds: float = 10.0,
+    ) -> None:
+        """
+        Initialize shutdown manager.
+
+        Args:
+            timeout_seconds: Maximum time to wait for shutdown.
+            drain_timeout_seconds: Maximum time to wait for queue draining.
+        """
+        self.timeout_seconds = timeout_seconds
+        self.drain_timeout_seconds = drain_timeout_seconds
+
+        # Components in registration order
+        self._channels: list[tuple[str, BaseChannel]] = []
+        self._agents: list[tuple[str, BaseAgent]] = []
+        self._clients: list[tuple[str, Callable[[], Coroutine[Any, Any, None]]]] = []
+
+        # Shutdown state
+        self._shutdown_requested = False
+        self._current_phase = ShutdownPhase.INITIATED
+        self._shutdown_event = asyncio.Event()
+
+    @property
+    def shutdown_requested(self) -> bool:
+        """Check if shutdown has been requested."""
+        return self._shutdown_requested
+
+    @property
+    def current_phase(self) -> ShutdownPhase:
+        """Get current shutdown phase."""
+        return self._current_phase
+
+    def register_channel(self, name: str, channel: BaseChannel) -> None:
+        """
+        Register a channel for shutdown tracking.
+
+        Args:
+            name: Channel identifier.
+            channel: Channel instance.
+        """
+        self._channels.append((name, channel))
+        logger.debug(
+            f"[WHISPER] Registered channel for shutdown: {name}",
+            extra={"component": name, "type": "channel"},
+        )
+
+    def register_agent(self, name: str, agent: BaseAgent) -> None:
+        """
+        Register an agent for shutdown tracking.
+
+        Args:
+            name: Agent identifier.
+            agent: Agent instance.
+        """
+        self._agents.append((name, agent))
+        logger.debug(
+            f"[WHISPER] Registered agent for shutdown: {name}",
+            extra={"component": name, "type": "agent"},
+        )
+
+    def register_client(
+        self,
+        name: str,
+        disconnect_fn: Callable[[], Coroutine[Any, Any, None]],
+    ) -> None:
+        """
+        Register a client for shutdown.
+
+        Args:
+            name: Client identifier (e.g., "neo4j", "graphiti").
+            disconnect_fn: Async function to disconnect the client.
+        """
+        self._clients.append((name, disconnect_fn))
+        logger.debug(
+            f"[WHISPER] Registered client for shutdown: {name}",
+            extra={"component": name, "type": "client"},
+        )
+
+    def request_shutdown(self) -> None:
+        """Request graceful shutdown (non-blocking)."""
+        self._shutdown_requested = True
+        self._shutdown_event.set()
+        logger.info("[CHART] Shutdown requested")
+
+    async def wait_for_shutdown(self) -> None:
+        """Wait until shutdown is requested."""
+        await self._shutdown_event.wait()
+
+    async def shutdown(self) -> ShutdownResult:
+        """
+        Execute graceful shutdown of all components.
+
+        Returns:
+            ShutdownResult with status of each component.
+        """
+        result = ShutdownResult(
+            success=True,
+            phase=ShutdownPhase.INITIATED,
+            started_at=datetime.now(),
+        )
+
+        self._shutdown_requested = True
+        logger.info(
+            "[CHART] Beginning graceful shutdown...",
+            extra={"timeout_seconds": self.timeout_seconds},
+        )
+
+        try:
+            # Phase 1: Stop channels (stops accepting new requests)
+            await self._stop_channels(result)
+
+            # Phase 2: Drain agent queues
+            await self._drain_queues()
+
+            # Phase 3: Stop agents (reverse order)
+            await self._stop_agents(result)
+
+            # Phase 4: Disconnect clients
+            await self._disconnect_clients(result)
+
+            result.phase = ShutdownPhase.COMPLETE
+            result.success = all(s.success for s in result.component_statuses)
+
+        except TimeoutError:
+            result.phase = ShutdownPhase.FAILED
+            result.success = False
+            result.error = f"Shutdown timed out after {self.timeout_seconds}s"
+            logger.error(
+                f"[STORM] {result.error}",
+                extra={"phase": self._current_phase.value},
+            )
+
+        except Exception as e:
+            result.phase = ShutdownPhase.FAILED
+            result.success = False
+            result.error = str(e)
+            logger.error(
+                f"[STORM] Shutdown failed: {e}",
+                extra={"phase": self._current_phase.value},
+                exc_info=True,
+            )
+
+        result.completed_at = datetime.now()
+
+        # Log final summary
+        if result.success:
+            logger.info(
+                f"[BEACON] {result.summary()}",
+                extra={"duration_ms": result.duration_ms},
+            )
+        else:
+            logger.error(
+                f"[SHIPWRECK] {result.summary()}",
+                extra={"duration_ms": result.duration_ms},
+            )
+
+        return result
+
+    async def _stop_channels(self, result: ShutdownResult) -> None:
+        """Stop all channels."""
+        if not self._channels:
+            return
+
+        self._current_phase = ShutdownPhase.CHANNELS_STOPPING
+        logger.info(
+            f"[CHART] Stopping {len(self._channels)} channel(s)...",
+            extra={"phase": "channels_stopping"},
+        )
+
+        # Stop channels in reverse order
+        for name, channel in reversed(self._channels):
+            status = await self._stop_component(
+                name=name,
+                component_type="channel",
+                stop_fn=channel.stop,
+            )
+            result.component_statuses.append(status)
+
+    async def _drain_queues(self) -> None:
+        """Wait for agent queues to drain."""
+        if not self._agents:
+            return
+
+        self._current_phase = ShutdownPhase.DRAINING_QUEUES
+        logger.info(
+            f"[CHART] Draining {len(self._agents)} agent queue(s)...",
+            extra={"phase": "draining_queues", "timeout": self.drain_timeout_seconds},
+        )
+
+        try:
+            await asyncio.wait_for(
+                self._wait_for_queues_empty(),
+                timeout=self.drain_timeout_seconds,
+            )
+            logger.info("[CHART] All queues drained")
+        except TimeoutError:
+            # Log warning but continue - agents will be stopped anyway
+            pending_counts = self._get_pending_counts()
+            logger.warning(
+                f"[SWELL] Queue drain timed out. Remaining: {pending_counts}",
+                extra={"phase": "draining_queues"},
+            )
+
+    async def _wait_for_queues_empty(self) -> None:
+        """Wait until all agent queues are empty."""
+        while True:
+            all_empty = True
+            for _name, agent in self._agents:
+                if hasattr(agent, "inbox") and not agent.inbox.empty():
+                    all_empty = False
+                    break
+
+            if all_empty:
+                return
+
+            await asyncio.sleep(0.1)
+
+    def _get_pending_counts(self) -> dict[str, int]:
+        """Get pending message counts for each agent."""
+        counts = {}
+        for name, agent in self._agents:
+            if hasattr(agent, "inbox"):
+                counts[name] = agent.inbox.qsize()
+        return counts
+
+    async def _stop_agents(self, result: ShutdownResult) -> None:
+        """Stop all agents in reverse registration order."""
+        if not self._agents:
+            return
+
+        self._current_phase = ShutdownPhase.AGENTS_STOPPING
+        logger.info(
+            f"[CHART] Stopping {len(self._agents)} agent(s)...",
+            extra={"phase": "agents_stopping"},
+        )
+
+        # Stop agents in reverse order (last started = first stopped)
+        for name, agent in reversed(self._agents):
+            # Get pending count before stopping
+            pending = agent.inbox.qsize() if hasattr(agent, "inbox") else 0
+
+            status = await self._stop_component(
+                name=name,
+                component_type="agent",
+                stop_fn=agent.stop,
+            )
+            status.pending_items = pending
+            result.component_statuses.append(status)
+
+    async def _disconnect_clients(self, result: ShutdownResult) -> None:
+        """Disconnect all clients."""
+        if not self._clients:
+            return
+
+        self._current_phase = ShutdownPhase.CLIENTS_DISCONNECTING
+        logger.info(
+            f"[CHART] Disconnecting {len(self._clients)} client(s)...",
+            extra={"phase": "clients_disconnecting"},
+        )
+
+        # Disconnect in reverse order
+        for name, disconnect_fn in reversed(self._clients):
+            status = await self._stop_component(
+                name=name,
+                component_type="client",
+                stop_fn=disconnect_fn,
+            )
+            result.component_statuses.append(status)
+
+    async def _stop_component(
+        self,
+        name: str,
+        component_type: str,
+        stop_fn: Callable[[], Coroutine[Any, Any, None]],
+    ) -> ShutdownStatus:
+        """
+        Stop a single component with timeout and error handling.
+
+        Args:
+            name: Component identifier.
+            component_type: Type of component.
+            stop_fn: Async function to stop the component.
+
+        Returns:
+            ShutdownStatus for the component.
+        """
+        status = ShutdownStatus(
+            component_name=name,
+            component_type=component_type,
+            started_at=datetime.now(),
+        )
+
+        try:
+            # Per-component timeout (fraction of total)
+            component_timeout = self.timeout_seconds / max(
+                len(self._channels) + len(self._agents) + len(self._clients), 1
+            )
+
+            await asyncio.wait_for(stop_fn(), timeout=component_timeout)
+
+            status.success = True
+            status.completed_at = datetime.now()
+
+            logger.debug(
+                f"[WHISPER] Stopped {component_type}: {name}",
+                extra={
+                    "component": name,
+                    "type": component_type,
+                    "duration_ms": status.duration_ms,
+                },
+            )
+
+        except TimeoutError:
+            status.success = False
+            status.completed_at = datetime.now()
+            status.error = "Timeout"
+            logger.warning(
+                f"[SWELL] {component_type.title()} {name} stop timed out",
+                extra={"component": name, "type": component_type},
+            )
+
+        except Exception as e:
+            status.success = False
+            status.completed_at = datetime.now()
+            status.error = str(e)
+            logger.error(
+                f"[STORM] Error stopping {component_type} {name}: {e}",
+                extra={"component": name, "type": component_type},
+                exc_info=True,
+            )
+
+        return status
+
+
+# Module-level instance for application-wide shutdown coordination
+_shutdown_manager: ShutdownManager | None = None
+
+
+def get_shutdown_manager() -> ShutdownManager:
+    """Get or create the global shutdown manager."""
+    global _shutdown_manager
+    if _shutdown_manager is None:
+        _shutdown_manager = ShutdownManager()
+    return _shutdown_manager
+
+
+def reset_shutdown_manager() -> None:
+    """Reset the global shutdown manager (for testing)."""
+    global _shutdown_manager
+    _shutdown_manager = None
+
+
+__all__ = [
+    "ShutdownManager",
+    "ShutdownPhase",
+    "ShutdownResult",
+    "ShutdownStatus",
+    "get_shutdown_manager",
+    "reset_shutdown_manager",
+]

--- a/tests/unit/test_shutdown.py
+++ b/tests/unit/test_shutdown.py
@@ -1,0 +1,595 @@
+"""
+Unit tests for graceful shutdown management.
+
+Tests the ShutdownManager's ability to coordinate orderly shutdown
+of channels, agents, and clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+import pytest
+
+from klabautermann.core.shutdown import (
+    ShutdownManager,
+    ShutdownPhase,
+    ShutdownResult,
+    ShutdownStatus,
+    get_shutdown_manager,
+    reset_shutdown_manager,
+)
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def shutdown_manager() -> ShutdownManager:
+    """Create a fresh shutdown manager."""
+    return ShutdownManager(timeout_seconds=5.0, drain_timeout_seconds=2.0)
+
+
+@pytest.fixture
+def mock_channel() -> MagicMock:
+    """Create a mock channel."""
+    channel = MagicMock()
+    channel.stop = AsyncMock()
+    return channel
+
+
+@pytest.fixture
+def mock_agent() -> MagicMock:
+    """Create a mock agent with inbox."""
+    agent = MagicMock()
+    agent.stop = AsyncMock()
+    agent.inbox = asyncio.Queue()
+    return agent
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock client disconnect function."""
+    return AsyncMock()
+
+
+@pytest.fixture(autouse=True)
+def reset_global_manager() -> None:
+    """Reset global shutdown manager before each test."""
+    reset_shutdown_manager()
+
+
+# =============================================================================
+# Test ShutdownStatus
+# =============================================================================
+
+
+class TestShutdownStatus:
+    """Tests for ShutdownStatus dataclass."""
+
+    def test_duration_ms_calculation(self) -> None:
+        """Test duration calculation in milliseconds."""
+        started = datetime(2024, 1, 1, 12, 0, 0, 0)
+        completed = datetime(2024, 1, 1, 12, 0, 0, 500000)  # 500ms later
+
+        status = ShutdownStatus(
+            component_name="test",
+            component_type="agent",
+            started_at=started,
+            completed_at=completed,
+        )
+
+        assert status.duration_ms == 500.0
+
+    def test_duration_ms_none_when_incomplete(self) -> None:
+        """Test duration is None when not completed."""
+        status = ShutdownStatus(
+            component_name="test",
+            component_type="agent",
+            started_at=datetime.now(),
+        )
+
+        assert status.duration_ms is None
+
+
+# =============================================================================
+# Test ShutdownResult
+# =============================================================================
+
+
+class TestShutdownResult:
+    """Tests for ShutdownResult dataclass."""
+
+    def test_summary_success(self) -> None:
+        """Test summary for successful shutdown."""
+        result = ShutdownResult(
+            success=True,
+            phase=ShutdownPhase.COMPLETE,
+            started_at=datetime(2024, 1, 1, 12, 0, 0),
+            completed_at=datetime(2024, 1, 1, 12, 0, 1),
+            component_statuses=[
+                ShutdownStatus("channel", "channel", success=True),
+                ShutdownStatus("agent", "agent", success=True),
+            ],
+        )
+
+        summary = result.summary()
+        assert "SUCCESS" in summary
+        assert "2 components" in summary
+
+    def test_summary_failure(self) -> None:
+        """Test summary for failed shutdown."""
+        result = ShutdownResult(
+            success=False,
+            phase=ShutdownPhase.FAILED,
+            started_at=datetime(2024, 1, 1, 12, 0, 0),
+            completed_at=datetime(2024, 1, 1, 12, 0, 1),
+            component_statuses=[
+                ShutdownStatus("channel", "channel", success=True),
+                ShutdownStatus("agent", "agent", success=False),
+            ],
+        )
+
+        summary = result.summary()
+        assert "FAILED" in summary
+        assert "agent" in summary
+
+
+# =============================================================================
+# Test ShutdownManager - Registration
+# =============================================================================
+
+
+class TestShutdownRegistration:
+    """Tests for component registration."""
+
+    def test_register_channel(
+        self, shutdown_manager: ShutdownManager, mock_channel: MagicMock
+    ) -> None:
+        """Test registering a channel."""
+        shutdown_manager.register_channel("cli", mock_channel)
+
+        assert len(shutdown_manager._channels) == 1
+        assert shutdown_manager._channels[0][0] == "cli"
+
+    def test_register_agent(self, shutdown_manager: ShutdownManager, mock_agent: MagicMock) -> None:
+        """Test registering an agent."""
+        shutdown_manager.register_agent("orchestrator", mock_agent)
+
+        assert len(shutdown_manager._agents) == 1
+        assert shutdown_manager._agents[0][0] == "orchestrator"
+
+    def test_register_client(
+        self, shutdown_manager: ShutdownManager, mock_client: AsyncMock
+    ) -> None:
+        """Test registering a client."""
+        shutdown_manager.register_client("neo4j", mock_client)
+
+        assert len(shutdown_manager._clients) == 1
+        assert shutdown_manager._clients[0][0] == "neo4j"
+
+    def test_register_multiple_components(
+        self,
+        shutdown_manager: ShutdownManager,
+        mock_channel: MagicMock,
+        mock_agent: MagicMock,
+        mock_client: AsyncMock,
+    ) -> None:
+        """Test registering multiple components."""
+        shutdown_manager.register_channel("cli", mock_channel)
+        shutdown_manager.register_agent("orchestrator", mock_agent)
+        shutdown_manager.register_agent("ingestor", mock_agent)
+        shutdown_manager.register_client("neo4j", mock_client)
+
+        assert len(shutdown_manager._channels) == 1
+        assert len(shutdown_manager._agents) == 2
+        assert len(shutdown_manager._clients) == 1
+
+
+# =============================================================================
+# Test ShutdownManager - Shutdown Execution
+# =============================================================================
+
+
+class TestShutdownExecution:
+    """Tests for shutdown execution."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_empty_manager(self, shutdown_manager: ShutdownManager) -> None:
+        """Test shutdown with no registered components."""
+        result = await shutdown_manager.shutdown()
+
+        assert result.success is True
+        assert result.phase == ShutdownPhase.COMPLETE
+        assert len(result.component_statuses) == 0
+
+    @pytest.mark.asyncio
+    async def test_shutdown_single_channel(
+        self, shutdown_manager: ShutdownManager, mock_channel: MagicMock
+    ) -> None:
+        """Test shutdown with single channel."""
+        shutdown_manager.register_channel("cli", mock_channel)
+
+        result = await shutdown_manager.shutdown()
+
+        assert result.success is True
+        mock_channel.stop.assert_called_once()
+        assert len(result.component_statuses) == 1
+        assert result.component_statuses[0].component_name == "cli"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_single_agent(
+        self, shutdown_manager: ShutdownManager, mock_agent: MagicMock
+    ) -> None:
+        """Test shutdown with single agent."""
+        shutdown_manager.register_agent("orchestrator", mock_agent)
+
+        result = await shutdown_manager.shutdown()
+
+        assert result.success is True
+        mock_agent.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_single_client(
+        self, shutdown_manager: ShutdownManager, mock_client: AsyncMock
+    ) -> None:
+        """Test shutdown with single client."""
+        shutdown_manager.register_client("neo4j", mock_client)
+
+        result = await shutdown_manager.shutdown()
+
+        assert result.success is True
+        mock_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_order(self, shutdown_manager: ShutdownManager) -> None:
+        """Test that shutdown happens in correct order."""
+        call_order: list[str] = []
+
+        def make_stop_side_effect(name: str) -> Callable[[], Coroutine[Any, Any, None]]:
+            async def _stop() -> None:
+                call_order.append(name)
+
+            return _stop
+
+        channel = MagicMock()
+        channel.stop = AsyncMock(side_effect=make_stop_side_effect("channel"))
+
+        agent = MagicMock()
+        agent.stop = AsyncMock(side_effect=make_stop_side_effect("agent"))
+        agent.inbox = asyncio.Queue()
+
+        client = AsyncMock(side_effect=make_stop_side_effect("client"))
+
+        shutdown_manager.register_channel("cli", channel)
+        shutdown_manager.register_agent("orchestrator", agent)
+        shutdown_manager.register_client("neo4j", client)
+
+        await shutdown_manager.shutdown()
+
+        # Verify channels stop before agents, agents before clients
+        channel.stop.assert_called_once()
+        agent.stop.assert_called_once()
+        client.assert_called_once()
+
+        # Verify order: channel, then agent, then client
+        assert call_order == ["channel", "agent", "client"]
+
+    @pytest.mark.asyncio
+    async def test_reverse_order_within_category(self, shutdown_manager: ShutdownManager) -> None:
+        """Test that components stop in reverse registration order."""
+        stop_order: list[str] = []
+
+        def make_stop_side_effect(name: str) -> Callable[[], Coroutine[Any, Any, None]]:
+            async def _stop() -> None:
+                stop_order.append(name)
+
+            return _stop
+
+        agent1 = MagicMock()
+        agent1.stop = AsyncMock(side_effect=make_stop_side_effect("agent1"))
+        agent1.inbox = asyncio.Queue()
+
+        agent2 = MagicMock()
+        agent2.stop = AsyncMock(side_effect=make_stop_side_effect("agent2"))
+        agent2.inbox = asyncio.Queue()
+
+        agent3 = MagicMock()
+        agent3.stop = AsyncMock(side_effect=make_stop_side_effect("agent3"))
+        agent3.inbox = asyncio.Queue()
+
+        # Register in order: agent1, agent2, agent3
+        shutdown_manager.register_agent("agent1", agent1)
+        shutdown_manager.register_agent("agent2", agent2)
+        shutdown_manager.register_agent("agent3", agent3)
+
+        await shutdown_manager.shutdown()
+
+        # Should stop in reverse: agent3, agent2, agent1
+        assert stop_order == ["agent3", "agent2", "agent1"]
+
+
+# =============================================================================
+# Test ShutdownManager - Error Handling
+# =============================================================================
+
+
+class TestShutdownErrorHandling:
+    """Tests for error handling during shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_component_error_continues_shutdown(
+        self, shutdown_manager: ShutdownManager
+    ) -> None:
+        """Test that shutdown continues after component error."""
+        failing_agent = MagicMock()
+        failing_agent.stop = AsyncMock(side_effect=RuntimeError("Test error"))
+        failing_agent.inbox = asyncio.Queue()
+
+        successful_agent = MagicMock()
+        successful_agent.stop = AsyncMock()
+        successful_agent.inbox = asyncio.Queue()
+
+        shutdown_manager.register_agent("failing", failing_agent)
+        shutdown_manager.register_agent("successful", successful_agent)
+
+        result = await shutdown_manager.shutdown()
+
+        # Both agents should have stop() called
+        failing_agent.stop.assert_called_once()
+        successful_agent.stop.assert_called_once()
+
+        # Result should indicate partial failure
+        assert result.success is False
+        failed = [s for s in result.component_statuses if not s.success]
+        assert len(failed) == 1
+        assert failed[0].component_name == "failing"
+
+    @pytest.mark.asyncio
+    async def test_component_timeout(self, shutdown_manager: ShutdownManager) -> None:
+        """Test handling of component that times out."""
+        # Create manager with very short timeout
+        manager = ShutdownManager(timeout_seconds=0.1, drain_timeout_seconds=0.05)
+
+        async def slow_stop() -> None:
+            await asyncio.sleep(10.0)  # Much longer than timeout
+
+        slow_agent = MagicMock()
+        slow_agent.stop = AsyncMock(side_effect=slow_stop)
+        slow_agent.inbox = asyncio.Queue()
+
+        manager.register_agent("slow", slow_agent)
+
+        result = await manager.shutdown()
+
+        # Should have timed out
+        timed_out = [s for s in result.component_statuses if s.error and "Timeout" in s.error]
+        assert len(timed_out) == 1
+
+
+# =============================================================================
+# Test ShutdownManager - Queue Draining
+# =============================================================================
+
+
+class TestQueueDraining:
+    """Tests for queue draining during shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_tracks_pending_items(self, shutdown_manager: ShutdownManager) -> None:
+        """Test that pending queue items are tracked."""
+        agent = MagicMock()
+        agent.stop = AsyncMock()
+        agent.inbox = asyncio.Queue()
+
+        # Add some items to the queue
+        await agent.inbox.put("message1")
+        await agent.inbox.put("message2")
+
+        shutdown_manager.register_agent("agent", agent)
+
+        result = await shutdown_manager.shutdown()
+
+        # Should record pending items count
+        agent_status = result.component_statuses[0]
+        assert agent_status.pending_items == 2
+
+    @pytest.mark.asyncio
+    async def test_drain_timeout(self, shutdown_manager: ShutdownManager) -> None:
+        """Test that drain times out gracefully."""
+        # Create manager with very short drain timeout
+        manager = ShutdownManager(timeout_seconds=5.0, drain_timeout_seconds=0.1)
+
+        agent = MagicMock()
+        agent.stop = AsyncMock()
+        agent.inbox = asyncio.Queue()
+
+        # Add items that won't be consumed
+        await agent.inbox.put("message1")
+
+        manager.register_agent("agent", agent)
+
+        # Should complete without hanging
+        await manager.shutdown()
+
+        # Shutdown should still succeed (drain timeout is warning, not error)
+        assert agent.stop.called
+
+
+# =============================================================================
+# Test ShutdownManager - State Management
+# =============================================================================
+
+
+class TestShutdownState:
+    """Tests for shutdown state management."""
+
+    def test_initial_state(self, shutdown_manager: ShutdownManager) -> None:
+        """Test initial state of shutdown manager."""
+        assert shutdown_manager.shutdown_requested is False
+        assert shutdown_manager.current_phase == ShutdownPhase.INITIATED
+
+    def test_request_shutdown(self, shutdown_manager: ShutdownManager) -> None:
+        """Test requesting shutdown."""
+        shutdown_manager.request_shutdown()
+
+        assert shutdown_manager.shutdown_requested is True
+
+    @pytest.mark.asyncio
+    async def test_wait_for_shutdown(self, shutdown_manager: ShutdownManager) -> None:
+        """Test waiting for shutdown request."""
+
+        async def request_later() -> None:
+            await asyncio.sleep(0.1)
+            shutdown_manager.request_shutdown()
+
+        # Start background task to request shutdown
+        background_task = asyncio.create_task(request_later())
+
+        # This should complete once shutdown is requested
+        await asyncio.wait_for(shutdown_manager.wait_for_shutdown(), timeout=1.0)
+
+        # Cleanup background task
+        await background_task
+
+        assert shutdown_manager.shutdown_requested is True
+
+
+# =============================================================================
+# Test Module Functions
+# =============================================================================
+
+
+class TestModuleFunctions:
+    """Tests for module-level functions."""
+
+    def test_get_shutdown_manager_singleton(self) -> None:
+        """Test that get_shutdown_manager returns singleton."""
+        manager1 = get_shutdown_manager()
+        manager2 = get_shutdown_manager()
+
+        assert manager1 is manager2
+
+    def test_reset_shutdown_manager(self) -> None:
+        """Test resetting the global shutdown manager."""
+        manager1 = get_shutdown_manager()
+        reset_shutdown_manager()
+        manager2 = get_shutdown_manager()
+
+        assert manager1 is not manager2
+
+
+# =============================================================================
+# Test ShutdownPhase
+# =============================================================================
+
+
+class TestShutdownPhase:
+    """Tests for ShutdownPhase enum."""
+
+    def test_all_phases_have_values(self) -> None:
+        """Test that all phases have string values."""
+        for phase in ShutdownPhase:
+            assert isinstance(phase.value, str)
+            assert len(phase.value) > 0
+
+    def test_phase_progression(self) -> None:
+        """Test expected phase values."""
+        assert ShutdownPhase.INITIATED.value == "initiated"
+        assert ShutdownPhase.CHANNELS_STOPPING.value == "channels_stopping"
+        assert ShutdownPhase.DRAINING_QUEUES.value == "draining_queues"
+        assert ShutdownPhase.AGENTS_STOPPING.value == "agents_stopping"
+        assert ShutdownPhase.CLIENTS_DISCONNECTING.value == "clients_disconnecting"
+        assert ShutdownPhase.COMPLETE.value == "complete"
+        assert ShutdownPhase.FAILED.value == "failed"
+
+
+# =============================================================================
+# Test Integration Scenarios
+# =============================================================================
+
+
+class TestIntegrationScenarios:
+    """Integration tests for realistic shutdown scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_full_system_shutdown(self, shutdown_manager: ShutdownManager) -> None:
+        """Test shutdown of a complete system."""
+        # Create mock components
+        cli = MagicMock()
+        cli.stop = AsyncMock()
+
+        orchestrator = MagicMock()
+        orchestrator.stop = AsyncMock()
+        orchestrator.inbox = asyncio.Queue()
+
+        ingestor = MagicMock()
+        ingestor.stop = AsyncMock()
+        ingestor.inbox = asyncio.Queue()
+
+        researcher = MagicMock()
+        researcher.stop = AsyncMock()
+        researcher.inbox = asyncio.Queue()
+
+        neo4j = AsyncMock()
+        graphiti = AsyncMock()
+
+        # Register all components
+        shutdown_manager.register_channel("cli", cli)
+        shutdown_manager.register_agent("orchestrator", orchestrator)
+        shutdown_manager.register_agent("ingestor", ingestor)
+        shutdown_manager.register_agent("researcher", researcher)
+        shutdown_manager.register_client("graphiti", graphiti)
+        shutdown_manager.register_client("neo4j", neo4j)
+
+        # Execute shutdown
+        result = await shutdown_manager.shutdown()
+
+        # Verify success
+        assert result.success is True
+        assert result.phase == ShutdownPhase.COMPLETE
+        assert len(result.component_statuses) == 6
+
+        # Verify all components were stopped
+        cli.stop.assert_called_once()
+        orchestrator.stop.assert_called_once()
+        ingestor.stop.assert_called_once()
+        researcher.stop.assert_called_once()
+        graphiti.assert_called_once()
+        neo4j.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_with_pending_messages(self, shutdown_manager: ShutdownManager) -> None:
+        """Test shutdown when agents have pending messages."""
+        agent = MagicMock()
+        consumed_messages: list[Any] = []
+
+        async def stop_and_drain() -> None:
+            # Simulate draining messages during stop
+            while not agent.inbox.empty():
+                msg = await agent.inbox.get()
+                consumed_messages.append(msg)
+
+        agent.stop = AsyncMock(side_effect=stop_and_drain)
+        agent.inbox = asyncio.Queue()
+
+        # Add pending messages
+        await agent.inbox.put({"type": "ingest", "data": "test1"})
+        await agent.inbox.put({"type": "ingest", "data": "test2"})
+
+        shutdown_manager.register_agent("agent", agent)
+
+        result = await shutdown_manager.shutdown()
+
+        # Agent should have been stopped
+        assert agent.stop.called
+        assert result.success is True


### PR DESCRIPTION
## Summary
- Add ShutdownManager class to coordinate orderly shutdown of all system components
- Implement reverse-order component shutdown (last started = first stopped)
- Add pending message queue draining with configurable timeout
- Integrate with signal handlers (SIGINT/SIGTERM)
- Add 27 comprehensive unit tests

## Changes
- **New**: `src/klabautermann/core/shutdown.py` - ShutdownManager with:
  - Component registration (channels, agents, clients)
  - Reverse-order shutdown
  - Queue draining with timeout
  - Per-component timeout handling
  - Detailed phase logging
- **Updated**: `src/klabautermann/__main__.py`:
  - Integrate ShutdownManager
  - Register components during initialization
  - Use contextlib.suppress for cleaner error handling
  - Fix pre-existing bug: remove invalid llm_client arg from Ingestor
- **New**: `tests/unit/test_shutdown.py` - 27 tests covering all shutdown scenarios

## Test plan
- [x] All 27 shutdown tests pass
- [x] Full unit test suite passes
- [x] Pre-commit hooks pass
- [x] Mypy type checking passes

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)