### PR TITLE
feat(docker): Add development docker-compose configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,138 @@
+# Klabautermann Development Docker Compose Configuration
+#
+# Optimized for local development with:
+# - Source code mounting (hot reload)
+# - Debug ports exposed
+# - Verbose logging
+# - Lower resource limits for dev machines
+# - Faster health check intervals
+#
+# Usage:
+#   docker-compose -f docker-compose.dev.yml up -d
+#   docker-compose -f docker-compose.dev.yml logs -f
+#   docker-compose -f docker-compose.dev.yml exec klabautermann-app bash
+#
+# Debug with debugpy:
+#   1. Set DEBUGPY_ENABLE=true in .env
+#   2. Connect VS Code to localhost:5678
+
+services:
+  # ===========================================================================
+  # Neo4j Graph Database (Development)
+  # ===========================================================================
+  neo4j:
+    image: neo4j:5.26-community
+    container_name: klabautermann-neo4j-dev
+    restart: unless-stopped
+    ports:
+      - "7474:7474"  # Browser UI
+      - "7687:7687"  # Bolt protocol
+    environment:
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-devpassword}
+      # Lower memory settings for development
+      - NEO4J_server_memory_pagecache_size=256M
+      - NEO4J_server_memory_heap_initial__size=256M
+      - NEO4J_server_memory_heap_max__size=512M
+      # Enable APOC plugin
+      - NEO4J_PLUGINS=["apoc"]
+      - NEO4J_dbms_security_procedures_unrestricted=apoc.*
+      - NEO4J_dbms_security_procedures_allowlist=apoc.*
+    volumes:
+      - neo4j_data_dev:/data
+      - neo4j_logs_dev:/logs
+      - neo4j_plugins_dev:/plugins
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:7474 || exit 1"]
+      interval: 5s   # Faster for development
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.25"
+          memory: 512M
+    networks:
+      - klabautermann-net-dev
+
+  # ===========================================================================
+  # Klabautermann Application (Development)
+  # ===========================================================================
+  klabautermann-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    container_name: klabautermann-app-dev
+    restart: unless-stopped
+    stdin_open: true   # Keep stdin open for CLI interaction
+    tty: true          # Allocate pseudo-TTY
+    env_file:
+      - .env
+    environment:
+      - NEO4J_URI=bolt://neo4j:7687
+      - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
+      # Enable debug mode
+      - PYTHONDONTWRITEBYTECODE=1
+      - PYTHONUNBUFFERED=1
+      # Debugpy settings (set DEBUGPY_ENABLE=true to activate)
+      - DEBUGPY_ENABLE=${DEBUGPY_ENABLE:-false}
+      - DEBUGPY_PORT=5678
+      - DEBUGPY_WAIT_FOR_CLIENT=${DEBUGPY_WAIT_FOR_CLIENT:-false}
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    volumes:
+      # Mount source code for hot reload (read-write for development)
+      - ./src:/app/src
+      - ./scripts:/app/scripts
+      - ./config:/app/config
+      - ./tests:/app/tests
+      - ./main.py:/app/main.py
+      # Persist data and logs locally
+      - ./data:/app/data
+      - ./logs:/app/logs
+      # Mount requirements for easy updates
+      - ./requirements.txt:/app/requirements.txt:ro
+      - ./requirements-dev.txt:/app/requirements-dev.txt:ro
+    ports:
+      - "5678:5678"  # debugpy
+      - "8000:8000"  # potential API/debug server
+    healthcheck:
+      test: ["CMD", "python", "-c", "import sys; sys.exit(0)"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.25"
+          memory: 256M
+    networks:
+      - klabautermann-net-dev
+
+# ===========================================================================
+# Networks
+# ===========================================================================
+networks:
+  klabautermann-net-dev:
+    name: klabautermann-network-dev
+    driver: bridge
+
+# ===========================================================================
+# Volumes
+# ===========================================================================
+volumes:
+  neo4j_data_dev:
+    name: klabautermann-neo4j-data-dev
+  neo4j_logs_dev:
+    name: klabautermann-neo4j-logs-dev
+  neo4j_plugins_dev:
+    name: klabautermann-neo4j-plugins-dev

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,3 +20,6 @@ types-pyyaml>=6.0  # Type stubs for PyYAML (used by mypy)
 
 # === Git Hooks ===
 pre-commit>=3.0
+
+# === Debugging ===
+debugpy>=1.8  # Remote debugging support


### PR DESCRIPTION
## Summary
- Add `docker-compose.dev.yml` optimized for local development
- Add debugpy to `requirements-dev.txt` for remote debugging support
- Provides lower resource limits suitable for development machines

## Features
- **Development Stage**: Uses the `development` target from Dockerfile
- **Hot Reload**: Source code volume mounts (src, scripts, config, tests)
- **Debug Support**: Port 5678 exposed for debugpy remote debugging
- **Low Memory**: Neo4j 256-512MB, App 256MB-1GB limits
- **Fast Iteration**: Faster health check intervals (5s vs 30s)
- **Verbose Logging**: DEBUG level by default

## Usage
```bash
# Start development environment
docker-compose -f docker-compose.dev.yml up -d

# Enable debugging (add to .env)
DEBUGPY_ENABLE=true
DEBUGPY_WAIT_FOR_CLIENT=true  # Optional: wait for debugger
```

## Test plan
- [x] YAML syntax validated by pre-commit hooks
- [x] Follows existing docker-compose patterns
- [x] Resource limits appropriate for dev machines

Closes #270

:robot: Generated with [Claude Code](https://claude.com/claude-code)