### PR TITLE
feat(ontology): Add personal life entity types for Graphiti extraction

### DIFF
--- a/src/klabautermann/core/ontology.py
+++ b/src/klabautermann/core/ontology.py
@@ -85,8 +85,85 @@ class EmailType(BaseModel):
     is_unread: bool = Field(description="Whether email is unread", default=False)
 
 
+# ===========================================================================
+# Personal Life Entity Types
+# ===========================================================================
+
+
+class HobbyType(BaseModel):
+    """A leisure activity, interest, hobby, sport, or pastime."""
+
+    category: str | None = Field(
+        description="Category of hobby: sports, arts, music, gaming, outdoors, crafts, etc.",
+        default=None,
+    )
+    skill_level: str | None = Field(
+        description="Skill level: beginner, intermediate, advanced, expert", default=None
+    )
+    frequency: str | None = Field(
+        description="How often practiced: daily, weekly, monthly, occasionally", default=None
+    )
+
+
+class HealthMetricType(BaseModel):
+    """A health measurement, vital sign, fitness metric, or medical data point."""
+
+    metric_type: str | None = Field(
+        description="Type of metric: weight, blood_pressure, heart_rate, steps, sleep, glucose, etc.",
+        default=None,
+    )
+    value: float | None = Field(description="Numeric value of the measurement", default=None)
+    unit: str | None = Field(
+        description="Unit of measurement: kg, lbs, mmHg, bpm, steps, hours, mg/dL, etc.",
+        default=None,
+    )
+    recorded_at: str | None = Field(
+        description="When the measurement was taken (date/time)", default=None
+    )
+
+
+class PetType(BaseModel):
+    """An animal companion, pet, or domestic animal."""
+
+    species: str | None = Field(
+        description="Species of pet: dog, cat, bird, fish, rabbit, hamster, etc.", default=None
+    )
+    breed: str | None = Field(description="Breed or variety of the pet", default=None)
+    birth_date: str | None = Field(description="Pet's birth date or approximate age", default=None)
+    adoption_date: str | None = Field(description="When the pet was adopted", default=None)
+
+
+class MilestoneType(BaseModel):
+    """A personal achievement, life event, anniversary, or significant accomplishment."""
+
+    category: str | None = Field(
+        description="Category: career, education, personal, health, relationship, financial, etc.",
+        default=None,
+    )
+    significance: str | None = Field(
+        description="Level of significance: minor, moderate, major, life_changing", default=None
+    )
+    achieved_at: str | None = Field(
+        description="When the milestone was achieved (date)", default=None
+    )
+
+
+class RoutineType(BaseModel):
+    """A recurring activity, habit, schedule, or regular practice."""
+
+    frequency: str | None = Field(
+        description="How often: daily, weekly, monthly, weekdays, weekends", default=None
+    )
+    time_of_day: str | None = Field(
+        description="When during the day: morning, afternoon, evening, night", default=None
+    )
+    duration_minutes: int | None = Field(description="Typical duration in minutes", default=None)
+    is_active: bool = Field(description="Whether the routine is currently active", default=True)
+
+
 # Entity types dict for Graphiti's add_episode()
 ENTITY_TYPES: dict[str, type[BaseModel]] = {
+    # Core Entities
     "Person": PersonType,
     "Organization": OrganizationType,
     "Project": ProjectType,
@@ -94,6 +171,12 @@ ENTITY_TYPES: dict[str, type[BaseModel]] = {
     "Event": EventType,
     "Task": TaskType,
     "Email": EmailType,
+    # Personal Life Entities
+    "Hobby": HobbyType,
+    "HealthMetric": HealthMetricType,
+    "Pet": PetType,
+    "Milestone": MilestoneType,
+    "Routine": RoutineType,
 }
 
 
@@ -393,7 +476,7 @@ VECTOR_INDEXES: list[str] = [
 # ===========================================================================
 
 __all__ = [
-    # Entity type models for Graphiti
+    # Entity type models for Graphiti - Core
     "ENTITY_TYPES",
     "PersonType",
     "OrganizationType",
@@ -402,6 +485,12 @@ __all__ = [
     "EventType",
     "TaskType",
     "EmailType",
+    # Entity type models for Graphiti - Personal Life
+    "HobbyType",
+    "HealthMetricType",
+    "PetType",
+    "MilestoneType",
+    "RoutineType",
     # Enums
     "NodeLabel",
     "RelationType",

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,0 +1,392 @@
+"""
+Unit tests for ontology entity type models.
+
+Tests the Pydantic models used by Graphiti for entity extraction.
+"""
+
+from __future__ import annotations
+
+from klabautermann.core.ontology import (
+    ENTITY_TYPES,
+    HealthMetricType,
+    HobbyType,
+    MilestoneType,
+    NodeLabel,
+    OrganizationType,
+    PersonType,
+    PetType,
+    ProjectType,
+    RelationType,
+    RoutineType,
+    TaskType,
+)
+
+
+# =============================================================================
+# Test Core Entity Types
+# =============================================================================
+
+
+class TestPersonType:
+    """Tests for PersonType model."""
+
+    def test_default_values(self) -> None:
+        """Test PersonType with default values."""
+        person = PersonType()
+        assert person.email is None
+        assert person.title is None
+        assert person.phone is None
+
+    def test_with_all_fields(self) -> None:
+        """Test PersonType with all fields populated."""
+        person = PersonType(
+            email="john@example.com",
+            title="Software Engineer",
+            phone="+1-555-0123",
+        )
+        assert person.email == "john@example.com"
+        assert person.title == "Software Engineer"
+        assert person.phone == "+1-555-0123"
+
+
+class TestOrganizationType:
+    """Tests for OrganizationType model."""
+
+    def test_default_values(self) -> None:
+        """Test OrganizationType with default values."""
+        org = OrganizationType()
+        assert org.industry is None
+        assert org.domain is None
+
+    def test_with_all_fields(self) -> None:
+        """Test OrganizationType with all fields populated."""
+        org = OrganizationType(
+            industry="Technology",
+            domain="acme.com",
+        )
+        assert org.industry == "Technology"
+        assert org.domain == "acme.com"
+
+
+class TestProjectType:
+    """Tests for ProjectType model."""
+
+    def test_default_values(self) -> None:
+        """Test ProjectType with default values."""
+        project = ProjectType()
+        assert project.status is None
+        assert project.deadline is None
+
+    def test_with_all_fields(self) -> None:
+        """Test ProjectType with all fields populated."""
+        project = ProjectType(
+            status="active",
+            deadline="2024-12-31",
+        )
+        assert project.status == "active"
+        assert project.deadline == "2024-12-31"
+
+
+class TestTaskType:
+    """Tests for TaskType model."""
+
+    def test_default_values(self) -> None:
+        """Test TaskType with default values."""
+        task = TaskType()
+        assert task.status is None
+        assert task.priority is None
+        assert task.due_date is None
+
+    def test_with_all_fields(self) -> None:
+        """Test TaskType with all fields populated."""
+        task = TaskType(
+            status="in_progress",
+            priority="high",
+            due_date="2024-03-15",
+        )
+        assert task.status == "in_progress"
+        assert task.priority == "high"
+        assert task.due_date == "2024-03-15"
+
+
+# =============================================================================
+# Test Personal Life Entity Types
+# =============================================================================
+
+
+class TestHobbyType:
+    """Tests for HobbyType model."""
+
+    def test_default_values(self) -> None:
+        """Test HobbyType with default values."""
+        hobby = HobbyType()
+        assert hobby.category is None
+        assert hobby.skill_level is None
+        assert hobby.frequency is None
+
+    def test_with_all_fields(self) -> None:
+        """Test HobbyType with all fields populated."""
+        hobby = HobbyType(
+            category="sports",
+            skill_level="intermediate",
+            frequency="weekly",
+        )
+        assert hobby.category == "sports"
+        assert hobby.skill_level == "intermediate"
+        assert hobby.frequency == "weekly"
+
+    def test_various_categories(self) -> None:
+        """Test various hobby categories."""
+        categories = ["sports", "arts", "music", "gaming", "outdoors", "crafts"]
+        for cat in categories:
+            hobby = HobbyType(category=cat)
+            assert hobby.category == cat
+
+
+class TestHealthMetricType:
+    """Tests for HealthMetricType model."""
+
+    def test_default_values(self) -> None:
+        """Test HealthMetricType with default values."""
+        metric = HealthMetricType()
+        assert metric.metric_type is None
+        assert metric.value is None
+        assert metric.unit is None
+        assert metric.recorded_at is None
+
+    def test_with_all_fields(self) -> None:
+        """Test HealthMetricType with all fields populated."""
+        metric = HealthMetricType(
+            metric_type="weight",
+            value=75.5,
+            unit="kg",
+            recorded_at="2024-01-15T08:30:00",
+        )
+        assert metric.metric_type == "weight"
+        assert metric.value == 75.5
+        assert metric.unit == "kg"
+        assert metric.recorded_at == "2024-01-15T08:30:00"
+
+    def test_various_metric_types(self) -> None:
+        """Test various health metric types."""
+        metrics = [
+            ("weight", 75.0, "kg"),
+            ("blood_pressure", 120.0, "mmHg"),
+            ("heart_rate", 72.0, "bpm"),
+            ("steps", 10000.0, "steps"),
+            ("sleep", 7.5, "hours"),
+            ("glucose", 95.0, "mg/dL"),
+        ]
+        for metric_type, value, unit in metrics:
+            metric = HealthMetricType(metric_type=metric_type, value=value, unit=unit)
+            assert metric.metric_type == metric_type
+            assert metric.value == value
+            assert metric.unit == unit
+
+
+class TestPetType:
+    """Tests for PetType model."""
+
+    def test_default_values(self) -> None:
+        """Test PetType with default values."""
+        pet = PetType()
+        assert pet.species is None
+        assert pet.breed is None
+        assert pet.birth_date is None
+        assert pet.adoption_date is None
+
+    def test_with_all_fields(self) -> None:
+        """Test PetType with all fields populated."""
+        pet = PetType(
+            species="dog",
+            breed="Golden Retriever",
+            birth_date="2020-05-15",
+            adoption_date="2020-08-01",
+        )
+        assert pet.species == "dog"
+        assert pet.breed == "Golden Retriever"
+        assert pet.birth_date == "2020-05-15"
+        assert pet.adoption_date == "2020-08-01"
+
+    def test_various_species(self) -> None:
+        """Test various pet species."""
+        species_list = ["dog", "cat", "bird", "fish", "rabbit", "hamster"]
+        for species in species_list:
+            pet = PetType(species=species)
+            assert pet.species == species
+
+
+class TestMilestoneType:
+    """Tests for MilestoneType model."""
+
+    def test_default_values(self) -> None:
+        """Test MilestoneType with default values."""
+        milestone = MilestoneType()
+        assert milestone.category is None
+        assert milestone.significance is None
+        assert milestone.achieved_at is None
+
+    def test_with_all_fields(self) -> None:
+        """Test MilestoneType with all fields populated."""
+        milestone = MilestoneType(
+            category="career",
+            significance="major",
+            achieved_at="2024-01-01",
+        )
+        assert milestone.category == "career"
+        assert milestone.significance == "major"
+        assert milestone.achieved_at == "2024-01-01"
+
+    def test_various_categories(self) -> None:
+        """Test various milestone categories."""
+        categories = ["career", "education", "personal", "health", "relationship", "financial"]
+        for cat in categories:
+            milestone = MilestoneType(category=cat)
+            assert milestone.category == cat
+
+    def test_significance_levels(self) -> None:
+        """Test various significance levels."""
+        levels = ["minor", "moderate", "major", "life_changing"]
+        for level in levels:
+            milestone = MilestoneType(significance=level)
+            assert milestone.significance == level
+
+
+class TestRoutineType:
+    """Tests for RoutineType model."""
+
+    def test_default_values(self) -> None:
+        """Test RoutineType with default values."""
+        routine = RoutineType()
+        assert routine.frequency is None
+        assert routine.time_of_day is None
+        assert routine.duration_minutes is None
+        assert routine.is_active is True
+
+    def test_with_all_fields(self) -> None:
+        """Test RoutineType with all fields populated."""
+        routine = RoutineType(
+            frequency="daily",
+            time_of_day="morning",
+            duration_minutes=30,
+            is_active=True,
+        )
+        assert routine.frequency == "daily"
+        assert routine.time_of_day == "morning"
+        assert routine.duration_minutes == 30
+        assert routine.is_active is True
+
+    def test_inactive_routine(self) -> None:
+        """Test inactive routine."""
+        routine = RoutineType(
+            frequency="weekly",
+            is_active=False,
+        )
+        assert routine.frequency == "weekly"
+        assert routine.is_active is False
+
+    def test_various_frequencies(self) -> None:
+        """Test various routine frequencies."""
+        frequencies = ["daily", "weekly", "monthly", "weekdays", "weekends"]
+        for freq in frequencies:
+            routine = RoutineType(frequency=freq)
+            assert routine.frequency == freq
+
+
+# =============================================================================
+# Test ENTITY_TYPES Dict
+# =============================================================================
+
+
+class TestEntityTypes:
+    """Tests for ENTITY_TYPES dictionary."""
+
+    def test_contains_core_types(self) -> None:
+        """Test that ENTITY_TYPES contains core entity types."""
+        assert "Person" in ENTITY_TYPES
+        assert "Organization" in ENTITY_TYPES
+        assert "Project" in ENTITY_TYPES
+        assert "Location" in ENTITY_TYPES
+        assert "Event" in ENTITY_TYPES
+        assert "Task" in ENTITY_TYPES
+        assert "Email" in ENTITY_TYPES
+
+    def test_contains_personal_life_types(self) -> None:
+        """Test that ENTITY_TYPES contains personal life entity types."""
+        assert "Hobby" in ENTITY_TYPES
+        assert "HealthMetric" in ENTITY_TYPES
+        assert "Pet" in ENTITY_TYPES
+        assert "Milestone" in ENTITY_TYPES
+        assert "Routine" in ENTITY_TYPES
+
+    def test_types_are_pydantic_models(self) -> None:
+        """Test that all entity types are Pydantic BaseModel subclasses."""
+        from pydantic import BaseModel
+
+        for name, model in ENTITY_TYPES.items():
+            assert issubclass(model, BaseModel), f"{name} is not a BaseModel subclass"
+
+    def test_total_entity_count(self) -> None:
+        """Test total number of entity types."""
+        # 7 core + 5 personal life = 12
+        assert len(ENTITY_TYPES) == 12
+
+
+# =============================================================================
+# Test NodeLabel Enum
+# =============================================================================
+
+
+class TestNodeLabel:
+    """Tests for NodeLabel enum."""
+
+    def test_core_labels_exist(self) -> None:
+        """Test that core labels exist."""
+        assert NodeLabel.PERSON.value == "Person"
+        assert NodeLabel.ORGANIZATION.value == "Organization"
+        assert NodeLabel.PROJECT.value == "Project"
+        assert NodeLabel.TASK.value == "Task"
+
+    def test_personal_life_labels_exist(self) -> None:
+        """Test that personal life labels exist."""
+        assert NodeLabel.HOBBY.value == "Hobby"
+        assert NodeLabel.HEALTH_METRIC.value == "HealthMetric"
+        assert NodeLabel.PET.value == "Pet"
+        assert NodeLabel.MILESTONE.value == "Milestone"
+        assert NodeLabel.ROUTINE.value == "Routine"
+
+    def test_system_labels_exist(self) -> None:
+        """Test that system labels exist."""
+        assert NodeLabel.THREAD.value == "Thread"
+        assert NodeLabel.MESSAGE.value == "Message"
+        assert NodeLabel.DAY.value == "Day"
+
+
+# =============================================================================
+# Test RelationType Enum
+# =============================================================================
+
+
+class TestRelationType:
+    """Tests for RelationType enum."""
+
+    def test_professional_relations_exist(self) -> None:
+        """Test that professional relationship types exist."""
+        assert RelationType.WORKS_AT.value == "WORKS_AT"
+        assert RelationType.REPORTS_TO.value == "REPORTS_TO"
+        assert RelationType.ASSIGNED_TO.value == "ASSIGNED_TO"
+
+    def test_personal_life_relations_exist(self) -> None:
+        """Test that personal life relationship types exist."""
+        assert RelationType.PRACTICES.value == "PRACTICES"
+        assert RelationType.OWNS.value == "OWNS"
+        assert RelationType.CARES_FOR.value == "CARES_FOR"
+        assert RelationType.FOLLOWS_ROUTINE.value == "FOLLOWS_ROUTINE"
+        assert RelationType.ACHIEVES.value == "ACHIEVES"
+
+    def test_family_relations_exist(self) -> None:
+        """Test that family relationship types exist."""
+        assert RelationType.FAMILY_OF.value == "FAMILY_OF"
+        assert RelationType.SPOUSE_OF.value == "SPOUSE_OF"
+        assert RelationType.PARENT_OF.value == "PARENT_OF"
+        assert RelationType.CHILD_OF.value == "CHILD_OF"


### PR DESCRIPTION
## Summary

- Add 5 new Pydantic entity type models for personal life knowledge extraction
- HobbyType: leisure activities, interests, sports, pastimes with category/skill_level/frequency
- HealthMetricType: health measurements, vitals, fitness metrics with type/value/unit/timestamp
- PetType: animal companions with species/breed/birth_date/adoption_date
- MilestoneType: achievements, life events, anniversaries with category/significance/achieved_at
- RoutineType: recurring activities, habits, schedules with frequency/time_of_day/duration/is_active
- Update ENTITY_TYPES dict from 7 to 12 entity types
- Add 35 unit tests covering all entity types

## Test plan

- [x] Run `uv run pytest tests/unit/test_ontology.py` - 35 tests passing
- [x] Verify ENTITY_TYPES contains all 12 types
- [x] Verify all models are Pydantic BaseModel subclasses
- [x] Pre-commit hooks passing (ruff, mypy, smoke tests)

Closes #162, #163, #164, #165, #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)