### PR TITLE
feat(ontology,memory): Add entity types and statistics modules

### DIFF
--- a/src/klabautermann/core/ontology.py
+++ b/src/klabautermann/core/ontology.py
@@ -161,6 +161,55 @@ class RoutineType(BaseModel):
     is_active: bool = Field(description="Whether the routine is currently active", default=True)
 
 
+class PreferenceType(BaseModel):
+    """A personal like, dislike, taste, or opinion about something."""
+
+    category: str | None = Field(
+        description="Category of preference: food, music, travel, technology, style, etc.",
+        default=None,
+    )
+    sentiment: str | None = Field(
+        description="Sentiment: like, dislike, love, hate, neutral, indifferent", default=None
+    )
+    strength: float | None = Field(
+        description="Strength of preference from 0.0 (weak) to 1.0 (strong)", default=None
+    )
+    context: str | None = Field(description="Context or reason for the preference", default=None)
+
+
+class CommunityType(BaseModel):
+    """A knowledge island - a cluster of related concepts, topics, or entities."""
+
+    theme: str | None = Field(description="Primary theme or topic of the community", default=None)
+    summary: str | None = Field(
+        description="Brief summary of what this knowledge island represents", default=None
+    )
+    node_count: int | None = Field(
+        description="Number of nodes in this community/island", default=None
+    )
+    coherence_score: float | None = Field(
+        description="How tightly related the nodes are (0.0-1.0)", default=None
+    )
+
+
+class LoreEpisodeType(BaseModel):
+    """A story chapter or episode in the progressive disclosure lore system."""
+
+    saga_id: str | None = Field(
+        description="Identifier of the saga/story this episode belongs to", default=None
+    )
+    chapter: int | None = Field(description="Chapter number within the saga", default=None)
+    told_at: str | None = Field(
+        description="When this episode was told/revealed to the user", default=None
+    )
+    topic: str | None = Field(
+        description="Main topic or subject of this lore episode", default=None
+    )
+    is_revealed: bool = Field(
+        description="Whether this episode has been revealed to the user", default=False
+    )
+
+
 # Entity types dict for Graphiti's add_episode()
 ENTITY_TYPES: dict[str, type[BaseModel]] = {
     # Core Entities
@@ -177,6 +226,9 @@ ENTITY_TYPES: dict[str, type[BaseModel]] = {
     "Pet": PetType,
     "Milestone": MilestoneType,
     "Routine": RoutineType,
+    "Preference": PreferenceType,
+    "Community": CommunityType,
+    "LoreEpisode": LoreEpisodeType,
 }
 
 
@@ -491,6 +543,9 @@ __all__ = [
     "PetType",
     "MilestoneType",
     "RoutineType",
+    "PreferenceType",
+    "CommunityType",
+    "LoreEpisodeType",
     # Enums
     "NodeLabel",
     "RelationType",

--- a/src/klabautermann/memory/__init__.py
+++ b/src/klabautermann/memory/__init__.py
@@ -6,8 +6,22 @@ Contains:
 - neo4j_client: Direct Neo4j driver access
 - thread_manager: Conversation thread persistence
 - queries: Parametrized Cypher query library
+- graph_statistics: Graph node/relationship counts
+- context_statistics: Context window token/overflow tracking
 """
 
+from klabautermann.memory.context_statistics import (
+    ContextWindowMetrics,
+    GlobalContextMetrics,
+    get_global_context_metrics,
+    get_thread_context_metrics,
+)
+from klabautermann.memory.graph_statistics import (
+    GraphStatistics,
+    get_graph_statistics,
+    get_node_counts_by_type,
+    get_relationship_counts_by_type,
+)
 from klabautermann.memory.graphiti_client import GraphitiClient
 from klabautermann.memory.neo4j_client import Neo4jClient
 from klabautermann.memory.queries import CypherQueries, QueryBuilder, QueryResult
@@ -15,10 +29,21 @@ from klabautermann.memory.thread_manager import ThreadManager
 
 
 __all__ = [
+    # Clients
     "CypherQueries",
     "GraphitiClient",
     "Neo4jClient",
     "QueryBuilder",
     "QueryResult",
     "ThreadManager",
+    # Graph Statistics
+    "GraphStatistics",
+    "get_graph_statistics",
+    "get_node_counts_by_type",
+    "get_relationship_counts_by_type",
+    # Context Statistics
+    "ContextWindowMetrics",
+    "GlobalContextMetrics",
+    "get_global_context_metrics",
+    "get_thread_context_metrics",
 ]

--- a/src/klabautermann/memory/context_statistics.py
+++ b/src/klabautermann/memory/context_statistics.py
@@ -1,0 +1,390 @@
+"""
+Context window statistics for Klabautermann.
+
+Tracks context usage including token counts, compression ratios,
+and overflow events for conversation threads.
+
+Reference: specs/architecture/MEMORY.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from klabautermann.core.logger import logger
+
+
+if TYPE_CHECKING:
+    from klabautermann.memory.neo4j_client import Neo4jClient
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# Approximate characters per token for rough estimation
+# More accurate counting would require tiktoken or similar
+CHARS_PER_TOKEN_ESTIMATE = 4
+
+# Default max messages in context window
+DEFAULT_MAX_MESSAGES = 20
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class ContextWindowMetrics:
+    """Metrics for a single thread's context window."""
+
+    thread_uuid: str
+    message_count: int
+    max_messages: int
+
+    # Token estimates
+    estimated_tokens: int
+    estimated_token_limit: int | None = None
+
+    # Compression tracking
+    compression_ratio: float = 1.0  # 1.0 = no compression
+    original_content_size: int = 0
+    compressed_content_size: int = 0
+
+    # Overflow tracking
+    overflow_events: int = 0
+    messages_dropped: int = 0
+
+    # Timestamps
+    last_message_at: datetime | None = None
+    computed_at: datetime = field(default_factory=datetime.now)
+
+    @property
+    def is_at_capacity(self) -> bool:
+        """Check if context window is at maximum capacity."""
+        return self.message_count >= self.max_messages
+
+    @property
+    def utilization_percent(self) -> float:
+        """Calculate context window utilization percentage."""
+        if self.max_messages <= 0:
+            return 0.0
+        return (self.message_count / self.max_messages) * 100.0
+
+
+@dataclass
+class GlobalContextMetrics:
+    """Aggregated context metrics across all threads."""
+
+    total_threads: int
+    active_threads: int
+
+    # Token statistics
+    total_estimated_tokens: int
+    avg_tokens_per_thread: float
+
+    # Overflow statistics
+    total_overflow_events: int
+    total_messages_dropped: int
+    threads_at_capacity: int
+
+    # Compression statistics
+    avg_compression_ratio: float
+
+    # Metadata
+    computed_at: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class OverflowEvent:
+    """Record of a context window overflow event."""
+
+    thread_uuid: str
+    timestamp: datetime
+    messages_before: int
+    messages_after: int
+    messages_dropped: int
+    reason: str = "capacity_exceeded"
+
+
+# =============================================================================
+# Token Estimation
+# =============================================================================
+
+
+def estimate_tokens(text: str | None) -> int:
+    """
+    Estimate token count from text using character-based approximation.
+
+    For more accurate counting, integrate tiktoken or similar library.
+
+    Args:
+        text: Text content to estimate tokens for
+
+    Returns:
+        Estimated token count
+    """
+    if not text:
+        return 0
+    return max(1, len(text) // CHARS_PER_TOKEN_ESTIMATE)
+
+
+def estimate_message_tokens(role: str, content: str) -> int:
+    """
+    Estimate tokens for a message including role overhead.
+
+    Args:
+        role: Message role (user, assistant, system)
+        content: Message content
+
+    Returns:
+        Estimated token count including overhead
+    """
+    # Role tokens (approximately 4 tokens for role formatting)
+    role_overhead = 4
+    content_tokens = estimate_tokens(content)
+    return role_overhead + content_tokens
+
+
+# =============================================================================
+# Context Statistics Functions
+# =============================================================================
+
+
+async def get_thread_context_metrics(
+    neo4j: Neo4jClient,
+    thread_uuid: str,
+    max_messages: int = DEFAULT_MAX_MESSAGES,
+    trace_id: str | None = None,
+) -> ContextWindowMetrics:
+    """
+    Get context window metrics for a specific thread.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        thread_uuid: UUID of the thread
+        max_messages: Maximum messages allowed in context window
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        ContextWindowMetrics for the thread
+    """
+    logger.debug(
+        f"[WHISPER] Computing context metrics for thread {thread_uuid[:8]}...",
+        extra={"trace_id": trace_id, "agent_name": "context_stats"},
+    )
+
+    # Query thread messages
+    query = """
+    MATCH (t:Thread {uuid: $thread_uuid})-[:CONTAINS]->(m:Message)
+    RETURN m.content AS content, m.role AS role, m.timestamp AS timestamp
+    ORDER BY m.timestamp DESC
+    LIMIT $max_messages
+    """
+
+    result = await neo4j.execute_query(
+        query,
+        {
+            "thread_uuid": thread_uuid,
+            "max_messages": max_messages * 2,
+        },  # Get extra for overflow calc
+        trace_id=trace_id,
+    )
+
+    # Calculate metrics
+    total_messages = len(result)
+    messages_in_window = min(total_messages, max_messages)
+    overflow_events = 1 if total_messages > max_messages else 0
+    messages_dropped = max(0, total_messages - max_messages)
+
+    # Estimate tokens for messages in window
+    total_tokens = 0
+    original_size = 0
+
+    for i, row in enumerate(result):
+        content = row.get("content") or ""
+        role = row.get("role") or "user"
+        original_size += len(content)
+
+        if i < max_messages:
+            total_tokens += estimate_message_tokens(role, content)
+
+    # Calculate compression ratio (1.0 if no summarization applied)
+    compressed_size = original_size  # Would be different if summarization was applied
+    compression_ratio = original_size / compressed_size if compressed_size > 0 else 1.0
+
+    # Get last message timestamp
+    last_message_at = None
+    if result:
+        timestamp = result[0].get("timestamp")
+        if timestamp:
+            last_message_at = datetime.fromtimestamp(timestamp)
+
+    return ContextWindowMetrics(
+        thread_uuid=thread_uuid,
+        message_count=messages_in_window,
+        max_messages=max_messages,
+        estimated_tokens=total_tokens,
+        compression_ratio=compression_ratio,
+        original_content_size=original_size,
+        compressed_content_size=compressed_size,
+        overflow_events=overflow_events,
+        messages_dropped=messages_dropped,
+        last_message_at=last_message_at,
+    )
+
+
+async def get_global_context_metrics(
+    neo4j: Neo4jClient,
+    max_messages: int = DEFAULT_MAX_MESSAGES,
+    trace_id: str | None = None,
+) -> GlobalContextMetrics:
+    """
+    Get aggregated context metrics across all threads.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        max_messages: Maximum messages allowed per context window
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        GlobalContextMetrics with aggregated statistics
+    """
+    logger.info(
+        "[CHART] Computing global context metrics",
+        extra={"trace_id": trace_id, "agent_name": "context_stats"},
+    )
+
+    # Query all threads with message counts
+    query = """
+    MATCH (t:Thread)
+    OPTIONAL MATCH (t)-[:CONTAINS]->(m:Message)
+    WITH t, count(m) AS message_count,
+         collect(m.content) AS contents,
+         max(m.timestamp) AS last_msg
+    RETURN t.uuid AS thread_uuid,
+           t.status AS status,
+           message_count,
+           contents,
+           last_msg
+    """
+
+    result = await neo4j.execute_query(query, {}, trace_id=trace_id)
+
+    total_threads = len(result)
+    active_threads = 0
+    total_tokens = 0
+    total_overflow_events = 0
+    total_messages_dropped = 0
+    threads_at_capacity = 0
+    compression_ratios: list[float] = []
+
+    for row in result:
+        status = row.get("status")
+        message_count = int(row.get("message_count", 0))
+        contents = row.get("contents") or []
+
+        if status == "active":
+            active_threads += 1
+
+        # Count tokens for messages in window
+        for content in contents[:max_messages]:
+            if content:
+                total_tokens += estimate_tokens(content)
+
+        # Track overflow
+        if message_count > max_messages:
+            total_overflow_events += 1
+            total_messages_dropped += message_count - max_messages
+
+        # Track capacity
+        if message_count >= max_messages:
+            threads_at_capacity += 1
+
+        # Compression ratio (1.0 for now, would track actual if summarization applied)
+        compression_ratios.append(1.0)
+
+    avg_tokens = total_tokens / total_threads if total_threads > 0 else 0.0
+    avg_compression = (
+        sum(compression_ratios) / len(compression_ratios) if compression_ratios else 1.0
+    )
+
+    metrics = GlobalContextMetrics(
+        total_threads=total_threads,
+        active_threads=active_threads,
+        total_estimated_tokens=total_tokens,
+        avg_tokens_per_thread=avg_tokens,
+        total_overflow_events=total_overflow_events,
+        total_messages_dropped=total_messages_dropped,
+        threads_at_capacity=threads_at_capacity,
+        avg_compression_ratio=avg_compression,
+    )
+
+    logger.info(
+        f"[CHART] Global context: {total_threads} threads, {total_tokens} tokens, "
+        f"{threads_at_capacity} at capacity",
+        extra={"trace_id": trace_id, "agent_name": "context_stats"},
+    )
+
+    return metrics
+
+
+def metrics_to_dict(metrics: ContextWindowMetrics | GlobalContextMetrics) -> dict:
+    """
+    Convert metrics to a serializable dictionary.
+
+    Args:
+        metrics: ContextWindowMetrics or GlobalContextMetrics instance
+
+    Returns:
+        Dictionary representation of metrics
+    """
+    if isinstance(metrics, ContextWindowMetrics):
+        return {
+            "thread_uuid": metrics.thread_uuid,
+            "message_count": metrics.message_count,
+            "max_messages": metrics.max_messages,
+            "estimated_tokens": metrics.estimated_tokens,
+            "compression_ratio": metrics.compression_ratio,
+            "overflow_events": metrics.overflow_events,
+            "messages_dropped": metrics.messages_dropped,
+            "is_at_capacity": metrics.is_at_capacity,
+            "utilization_percent": metrics.utilization_percent,
+            "last_message_at": metrics.last_message_at.isoformat()
+            if metrics.last_message_at
+            else None,
+            "computed_at": metrics.computed_at.isoformat(),
+        }
+    else:
+        return {
+            "total_threads": metrics.total_threads,
+            "active_threads": metrics.active_threads,
+            "total_estimated_tokens": metrics.total_estimated_tokens,
+            "avg_tokens_per_thread": metrics.avg_tokens_per_thread,
+            "total_overflow_events": metrics.total_overflow_events,
+            "total_messages_dropped": metrics.total_messages_dropped,
+            "threads_at_capacity": metrics.threads_at_capacity,
+            "avg_compression_ratio": metrics.avg_compression_ratio,
+            "computed_at": metrics.computed_at.isoformat(),
+        }
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+__all__ = [
+    "CHARS_PER_TOKEN_ESTIMATE",
+    "ContextWindowMetrics",
+    "DEFAULT_MAX_MESSAGES",
+    "GlobalContextMetrics",
+    "OverflowEvent",
+    "estimate_message_tokens",
+    "estimate_tokens",
+    "get_global_context_metrics",
+    "get_thread_context_metrics",
+    "metrics_to_dict",
+]

--- a/src/klabautermann/memory/graph_statistics.py
+++ b/src/klabautermann/memory/graph_statistics.py
@@ -1,0 +1,273 @@
+"""
+Graph statistics collection for Klabautermann.
+
+Provides comprehensive statistics about the knowledge graph including
+node counts by type, relationship counts, and total graph size.
+
+Reference: specs/architecture/MEMORY.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from klabautermann.core.logger import logger
+
+
+if TYPE_CHECKING:
+    from klabautermann.memory.neo4j_client import Neo4jClient
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class NodeCountByType:
+    """Node count for a specific node type."""
+
+    label: str
+    count: int
+
+
+@dataclass
+class RelationshipCountByType:
+    """Relationship count for a specific relationship type."""
+
+    relationship_type: str
+    count: int
+
+
+@dataclass
+class GraphStatistics:
+    """Complete graph statistics."""
+
+    # Node statistics
+    total_nodes: int
+    nodes_by_type: list[NodeCountByType]
+
+    # Relationship statistics
+    total_relationships: int
+    relationships_by_type: list[RelationshipCountByType]
+
+    # Metadata
+    timestamp: datetime
+    database_name: str | None = None
+
+
+# =============================================================================
+# Statistics Functions
+# =============================================================================
+
+
+async def get_node_counts_by_type(
+    neo4j: Neo4jClient,
+    trace_id: str | None = None,
+) -> list[NodeCountByType]:
+    """
+    Get count of nodes grouped by label.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        List of NodeCountByType for each label
+    """
+    logger.debug(
+        "[WHISPER] Counting nodes by type",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    query = """
+    CALL db.labels() YIELD label
+    CALL {
+        WITH label
+        MATCH (n)
+        WHERE label IN labels(n)
+        RETURN count(n) AS count
+    }
+    RETURN label, count
+    ORDER BY count DESC
+    """
+
+    result = await neo4j.execute_query(query, {}, trace_id=trace_id)
+
+    counts = [NodeCountByType(label=row["label"], count=int(row["count"])) for row in result]
+
+    logger.debug(
+        f"[WHISPER] Found {len(counts)} node types",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    return counts
+
+
+async def get_relationship_counts_by_type(
+    neo4j: Neo4jClient,
+    trace_id: str | None = None,
+) -> list[RelationshipCountByType]:
+    """
+    Get count of relationships grouped by type.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        List of RelationshipCountByType for each relationship type
+    """
+    logger.debug(
+        "[WHISPER] Counting relationships by type",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    query = """
+    CALL db.relationshipTypes() YIELD relationshipType
+    CALL {
+        WITH relationshipType
+        MATCH ()-[r]->()
+        WHERE type(r) = relationshipType
+        RETURN count(r) AS count
+    }
+    RETURN relationshipType, count
+    ORDER BY count DESC
+    """
+
+    result = await neo4j.execute_query(query, {}, trace_id=trace_id)
+
+    counts = [
+        RelationshipCountByType(relationship_type=row["relationshipType"], count=int(row["count"]))
+        for row in result
+    ]
+
+    logger.debug(
+        f"[WHISPER] Found {len(counts)} relationship types",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    return counts
+
+
+async def get_total_node_count(
+    neo4j: Neo4jClient,
+    trace_id: str | None = None,
+) -> int:
+    """
+    Get total number of nodes in the graph.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        Total node count
+    """
+    query = "MATCH (n) RETURN count(n) AS total"
+    result = await neo4j.execute_query(query, {}, trace_id=trace_id)
+    return int(result[0]["total"]) if result else 0
+
+
+async def get_total_relationship_count(
+    neo4j: Neo4jClient,
+    trace_id: str | None = None,
+) -> int:
+    """
+    Get total number of relationships in the graph.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        Total relationship count
+    """
+    query = "MATCH ()-[r]->() RETURN count(r) AS total"
+    result = await neo4j.execute_query(query, {}, trace_id=trace_id)
+    return int(result[0]["total"]) if result else 0
+
+
+async def get_graph_statistics(
+    neo4j: Neo4jClient,
+    trace_id: str | None = None,
+) -> GraphStatistics:
+    """
+    Get complete graph statistics.
+
+    Aggregates node counts, relationship counts, and totals into
+    a comprehensive statistics report.
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        GraphStatistics with all metrics
+    """
+    logger.info(
+        "[CHART] Computing graph statistics",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    # Gather all statistics
+    nodes_by_type = await get_node_counts_by_type(neo4j, trace_id)
+    relationships_by_type = await get_relationship_counts_by_type(neo4j, trace_id)
+    total_nodes = await get_total_node_count(neo4j, trace_id)
+    total_relationships = await get_total_relationship_count(neo4j, trace_id)
+
+    stats = GraphStatistics(
+        total_nodes=total_nodes,
+        nodes_by_type=nodes_by_type,
+        total_relationships=total_relationships,
+        relationships_by_type=relationships_by_type,
+        timestamp=datetime.now(),
+    )
+
+    logger.info(
+        f"[CHART] Graph statistics: {total_nodes} nodes, {total_relationships} relationships",
+        extra={"trace_id": trace_id, "agent_name": "graph_stats"},
+    )
+
+    return stats
+
+
+def statistics_to_dict(stats: GraphStatistics) -> dict:
+    """
+    Convert GraphStatistics to a serializable dictionary.
+
+    Args:
+        stats: GraphStatistics instance
+
+    Returns:
+        Dictionary representation of statistics
+    """
+    return {
+        "total_nodes": stats.total_nodes,
+        "total_relationships": stats.total_relationships,
+        "nodes_by_type": {node.label: node.count for node in stats.nodes_by_type},
+        "relationships_by_type": {
+            rel.relationship_type: rel.count for rel in stats.relationships_by_type
+        },
+        "timestamp": stats.timestamp.isoformat(),
+        "database_name": stats.database_name,
+    }
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+__all__ = [
+    "GraphStatistics",
+    "NodeCountByType",
+    "RelationshipCountByType",
+    "get_graph_statistics",
+    "get_node_counts_by_type",
+    "get_relationship_counts_by_type",
+    "get_total_node_count",
+    "get_total_relationship_count",
+    "statistics_to_dict",
+]

--- a/tests/unit/test_context_statistics.py
+++ b/tests/unit/test_context_statistics.py
@@ -1,0 +1,348 @@
+"""
+Unit tests for context window statistics module.
+
+Tests token estimation, context metrics, and overflow tracking.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from klabautermann.memory.context_statistics import (
+    CHARS_PER_TOKEN_ESTIMATE,
+    DEFAULT_MAX_MESSAGES,
+    ContextWindowMetrics,
+    GlobalContextMetrics,
+    estimate_message_tokens,
+    estimate_tokens,
+    get_global_context_metrics,
+    get_thread_context_metrics,
+    metrics_to_dict,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    """Create a mock Neo4jClient."""
+    client = MagicMock()
+    client.execute_query = AsyncMock()
+    return client
+
+
+# =============================================================================
+# Test Token Estimation
+# =============================================================================
+
+
+class TestEstimateTokens:
+    """Tests for estimate_tokens function."""
+
+    def test_empty_string(self) -> None:
+        """Test estimating tokens for empty string."""
+        assert estimate_tokens("") == 0
+        assert estimate_tokens(None) == 0
+
+    def test_short_text(self) -> None:
+        """Test estimating tokens for short text."""
+        # 8 characters / 4 = 2 tokens
+        result = estimate_tokens("Hello!!!")  # 8 characters
+        assert result == 2
+
+    def test_longer_text(self) -> None:
+        """Test estimating tokens for longer text."""
+        text = "This is a longer piece of text that should have more tokens"
+        expected = len(text) // CHARS_PER_TOKEN_ESTIMATE
+        assert estimate_tokens(text) == expected
+
+    def test_minimum_one_token(self) -> None:
+        """Test that minimum is 1 token for non-empty text."""
+        # Single character
+        result = estimate_tokens("a")
+        assert result == 1
+
+
+class TestEstimateMessageTokens:
+    """Tests for estimate_message_tokens function."""
+
+    def test_user_message(self) -> None:
+        """Test estimating tokens for user message."""
+        result = estimate_message_tokens("user", "Hello, how are you?")
+        # 4 (role overhead) + content tokens
+        content_tokens = estimate_tokens("Hello, how are you?")
+        assert result == 4 + content_tokens
+
+    def test_assistant_message(self) -> None:
+        """Test estimating tokens for assistant message."""
+        result = estimate_message_tokens("assistant", "I'm doing well!")
+        content_tokens = estimate_tokens("I'm doing well!")
+        assert result == 4 + content_tokens
+
+    def test_empty_content(self) -> None:
+        """Test estimating tokens with empty content."""
+        result = estimate_message_tokens("user", "")
+        assert result == 4  # Just role overhead
+
+
+# =============================================================================
+# Test ContextWindowMetrics
+# =============================================================================
+
+
+class TestContextWindowMetrics:
+    """Tests for ContextWindowMetrics dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating ContextWindowMetrics."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test-uuid",
+            message_count=15,
+            max_messages=20,
+            estimated_tokens=500,
+        )
+        assert metrics.thread_uuid == "test-uuid"
+        assert metrics.message_count == 15
+        assert metrics.max_messages == 20
+        assert metrics.estimated_tokens == 500
+
+    def test_is_at_capacity_false(self) -> None:
+        """Test is_at_capacity when under limit."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test",
+            message_count=10,
+            max_messages=20,
+            estimated_tokens=100,
+        )
+        assert metrics.is_at_capacity is False
+
+    def test_is_at_capacity_true(self) -> None:
+        """Test is_at_capacity when at limit."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test",
+            message_count=20,
+            max_messages=20,
+            estimated_tokens=100,
+        )
+        assert metrics.is_at_capacity is True
+
+    def test_utilization_percent(self) -> None:
+        """Test utilization percentage calculation."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test",
+            message_count=10,
+            max_messages=20,
+            estimated_tokens=100,
+        )
+        assert metrics.utilization_percent == 50.0
+
+    def test_utilization_percent_full(self) -> None:
+        """Test utilization at 100%."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test",
+            message_count=20,
+            max_messages=20,
+            estimated_tokens=100,
+        )
+        assert metrics.utilization_percent == 100.0
+
+    def test_utilization_percent_zero_max(self) -> None:
+        """Test utilization with zero max messages."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test",
+            message_count=0,
+            max_messages=0,
+            estimated_tokens=0,
+        )
+        assert metrics.utilization_percent == 0.0
+
+
+# =============================================================================
+# Test GlobalContextMetrics
+# =============================================================================
+
+
+class TestGlobalContextMetrics:
+    """Tests for GlobalContextMetrics dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating GlobalContextMetrics."""
+        metrics = GlobalContextMetrics(
+            total_threads=10,
+            active_threads=5,
+            total_estimated_tokens=5000,
+            avg_tokens_per_thread=500.0,
+            total_overflow_events=2,
+            total_messages_dropped=10,
+            threads_at_capacity=3,
+            avg_compression_ratio=1.0,
+        )
+        assert metrics.total_threads == 10
+        assert metrics.active_threads == 5
+        assert metrics.total_estimated_tokens == 5000
+        assert metrics.avg_tokens_per_thread == 500.0
+
+
+# =============================================================================
+# Test Thread Context Metrics
+# =============================================================================
+
+
+class TestGetThreadContextMetrics:
+    """Tests for get_thread_context_metrics function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_metrics(self, mock_neo4j: MagicMock) -> None:
+        """Test that thread metrics are returned."""
+        mock_neo4j.execute_query.return_value = [
+            {"content": "Hello", "role": "user", "timestamp": 1705320000.0},
+            {"content": "Hi there", "role": "assistant", "timestamp": 1705319900.0},
+        ]
+
+        result = await get_thread_context_metrics(mock_neo4j, "test-uuid")
+
+        assert result.thread_uuid == "test-uuid"
+        assert result.message_count == 2
+        assert result.max_messages == DEFAULT_MAX_MESSAGES
+        assert result.estimated_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_empty_thread(self, mock_neo4j: MagicMock) -> None:
+        """Test metrics for empty thread."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_thread_context_metrics(mock_neo4j, "empty-uuid")
+
+        assert result.message_count == 0
+        assert result.estimated_tokens == 0
+        assert result.overflow_events == 0
+
+    @pytest.mark.asyncio
+    async def test_overflow_detection(self, mock_neo4j: MagicMock) -> None:
+        """Test overflow detection when messages exceed max."""
+        # Return more messages than max_messages
+        messages = [
+            {"content": f"Message {i}", "role": "user", "timestamp": 1705320000.0 - i}
+            for i in range(25)
+        ]
+        mock_neo4j.execute_query.return_value = messages
+
+        result = await get_thread_context_metrics(mock_neo4j, "test-uuid", max_messages=20)
+
+        assert result.overflow_events == 1
+        assert result.messages_dropped == 5
+
+    @pytest.mark.asyncio
+    async def test_custom_max_messages(self, mock_neo4j: MagicMock) -> None:
+        """Test with custom max_messages limit."""
+        mock_neo4j.execute_query.return_value = [
+            {"content": "Test", "role": "user", "timestamp": 1705320000.0},
+        ]
+
+        result = await get_thread_context_metrics(mock_neo4j, "test-uuid", max_messages=10)
+
+        assert result.max_messages == 10
+
+
+# =============================================================================
+# Test Global Context Metrics
+# =============================================================================
+
+
+class TestGetGlobalContextMetrics:
+    """Tests for get_global_context_metrics function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_aggregated_metrics(self, mock_neo4j: MagicMock) -> None:
+        """Test that global metrics are aggregated."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "thread_uuid": "thread-1",
+                "status": "active",
+                "message_count": 10,
+                "contents": ["Hello", "Hi"],
+                "last_msg": 1705320000.0,
+            },
+            {
+                "thread_uuid": "thread-2",
+                "status": "archived",
+                "message_count": 25,
+                "contents": ["Test"] * 25,
+                "last_msg": 1705310000.0,
+            },
+        ]
+
+        result = await get_global_context_metrics(mock_neo4j)
+
+        assert result.total_threads == 2
+        assert result.active_threads == 1
+        assert result.total_estimated_tokens > 0
+        assert result.total_overflow_events == 1  # thread-2 has 25 > 20
+        assert result.threads_at_capacity == 1  # thread-2 is at/over capacity
+
+    @pytest.mark.asyncio
+    async def test_empty_database(self, mock_neo4j: MagicMock) -> None:
+        """Test metrics for empty database."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_global_context_metrics(mock_neo4j)
+
+        assert result.total_threads == 0
+        assert result.active_threads == 0
+        assert result.total_estimated_tokens == 0
+        assert result.avg_tokens_per_thread == 0.0
+
+
+# =============================================================================
+# Test Serialization
+# =============================================================================
+
+
+class TestMetricsToDict:
+    """Tests for metrics_to_dict function."""
+
+    def test_context_window_metrics(self) -> None:
+        """Test converting ContextWindowMetrics to dict."""
+        metrics = ContextWindowMetrics(
+            thread_uuid="test-uuid",
+            message_count=15,
+            max_messages=20,
+            estimated_tokens=500,
+            overflow_events=0,
+            messages_dropped=0,
+        )
+
+        result = metrics_to_dict(metrics)
+
+        assert result["thread_uuid"] == "test-uuid"
+        assert result["message_count"] == 15
+        assert result["max_messages"] == 20
+        assert result["estimated_tokens"] == 500
+        assert result["is_at_capacity"] is False
+        assert result["utilization_percent"] == 75.0
+
+    def test_global_context_metrics(self) -> None:
+        """Test converting GlobalContextMetrics to dict."""
+        metrics = GlobalContextMetrics(
+            total_threads=10,
+            active_threads=5,
+            total_estimated_tokens=5000,
+            avg_tokens_per_thread=500.0,
+            total_overflow_events=2,
+            total_messages_dropped=10,
+            threads_at_capacity=3,
+            avg_compression_ratio=1.0,
+        )
+
+        result = metrics_to_dict(metrics)
+
+        assert result["total_threads"] == 10
+        assert result["active_threads"] == 5
+        assert result["total_estimated_tokens"] == 5000
+        assert result["avg_tokens_per_thread"] == 500.0
+        assert "computed_at" in result

--- a/tests/unit/test_graph_statistics.py
+++ b/tests/unit/test_graph_statistics.py
@@ -1,0 +1,264 @@
+"""
+Unit tests for graph statistics module.
+
+Tests node counting, relationship counting, and statistics aggregation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from klabautermann.memory.graph_statistics import (
+    GraphStatistics,
+    NodeCountByType,
+    RelationshipCountByType,
+    get_graph_statistics,
+    get_node_counts_by_type,
+    get_relationship_counts_by_type,
+    get_total_node_count,
+    get_total_relationship_count,
+    statistics_to_dict,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    """Create a mock Neo4jClient."""
+    client = MagicMock()
+    client.execute_query = AsyncMock()
+    return client
+
+
+# =============================================================================
+# Test Data Classes
+# =============================================================================
+
+
+class TestNodeCountByType:
+    """Tests for NodeCountByType dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating NodeCountByType."""
+        node_count = NodeCountByType(label="Person", count=42)
+        assert node_count.label == "Person"
+        assert node_count.count == 42
+
+
+class TestRelationshipCountByType:
+    """Tests for RelationshipCountByType dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating RelationshipCountByType."""
+        rel_count = RelationshipCountByType(relationship_type="KNOWS", count=100)
+        assert rel_count.relationship_type == "KNOWS"
+        assert rel_count.count == 100
+
+
+class TestGraphStatistics:
+    """Tests for GraphStatistics dataclass."""
+
+    def test_creation(self) -> None:
+        """Test creating GraphStatistics."""
+        stats = GraphStatistics(
+            total_nodes=100,
+            nodes_by_type=[NodeCountByType("Person", 50), NodeCountByType("Task", 50)],
+            total_relationships=75,
+            relationships_by_type=[RelationshipCountByType("KNOWS", 75)],
+            timestamp=datetime(2024, 1, 15, 10, 0, 0),
+            database_name="test",
+        )
+        assert stats.total_nodes == 100
+        assert len(stats.nodes_by_type) == 2
+        assert stats.total_relationships == 75
+        assert len(stats.relationships_by_type) == 1
+        assert stats.database_name == "test"
+
+
+# =============================================================================
+# Test Node Counting
+# =============================================================================
+
+
+class TestGetNodeCountsByType:
+    """Tests for get_node_counts_by_type function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_counts(self, mock_neo4j: MagicMock) -> None:
+        """Test that node counts are returned correctly."""
+        mock_neo4j.execute_query.return_value = [
+            {"label": "Person", "count": 50},
+            {"label": "Task", "count": 30},
+            {"label": "Project", "count": 20},
+        ]
+
+        result = await get_node_counts_by_type(mock_neo4j)
+
+        assert len(result) == 3
+        assert result[0].label == "Person"
+        assert result[0].count == 50
+        assert result[1].label == "Task"
+        assert result[1].count == 30
+
+    @pytest.mark.asyncio
+    async def test_empty_graph(self, mock_neo4j: MagicMock) -> None:
+        """Test counting nodes in empty graph."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_node_counts_by_type(mock_neo4j)
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_passes_trace_id(self, mock_neo4j: MagicMock) -> None:
+        """Test that trace_id is passed to query."""
+        mock_neo4j.execute_query.return_value = []
+
+        await get_node_counts_by_type(mock_neo4j, trace_id="test-trace")
+
+        mock_neo4j.execute_query.assert_called_once()
+        call_kwargs = mock_neo4j.execute_query.call_args.kwargs
+        assert call_kwargs.get("trace_id") == "test-trace"
+
+
+class TestGetTotalNodeCount:
+    """Tests for get_total_node_count function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count(self, mock_neo4j: MagicMock) -> None:
+        """Test that total node count is returned."""
+        mock_neo4j.execute_query.return_value = [{"total": 150}]
+
+        result = await get_total_node_count(mock_neo4j)
+
+        assert result == 150
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self, mock_neo4j: MagicMock) -> None:
+        """Test handling empty result."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_total_node_count(mock_neo4j)
+
+        assert result == 0
+
+
+# =============================================================================
+# Test Relationship Counting
+# =============================================================================
+
+
+class TestGetRelationshipCountsByType:
+    """Tests for get_relationship_counts_by_type function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_counts(self, mock_neo4j: MagicMock) -> None:
+        """Test that relationship counts are returned correctly."""
+        mock_neo4j.execute_query.return_value = [
+            {"relationshipType": "KNOWS", "count": 100},
+            {"relationshipType": "WORKS_AT", "count": 50},
+        ]
+
+        result = await get_relationship_counts_by_type(mock_neo4j)
+
+        assert len(result) == 2
+        assert result[0].relationship_type == "KNOWS"
+        assert result[0].count == 100
+
+    @pytest.mark.asyncio
+    async def test_empty_graph(self, mock_neo4j: MagicMock) -> None:
+        """Test counting relationships in empty graph."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_relationship_counts_by_type(mock_neo4j)
+
+        assert len(result) == 0
+
+
+class TestGetTotalRelationshipCount:
+    """Tests for get_total_relationship_count function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count(self, mock_neo4j: MagicMock) -> None:
+        """Test that total relationship count is returned."""
+        mock_neo4j.execute_query.return_value = [{"total": 200}]
+
+        result = await get_total_relationship_count(mock_neo4j)
+
+        assert result == 200
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self, mock_neo4j: MagicMock) -> None:
+        """Test handling empty result."""
+        mock_neo4j.execute_query.return_value = []
+
+        result = await get_total_relationship_count(mock_neo4j)
+
+        assert result == 0
+
+
+# =============================================================================
+# Test Complete Statistics
+# =============================================================================
+
+
+class TestGetGraphStatistics:
+    """Tests for get_graph_statistics function."""
+
+    @pytest.mark.asyncio
+    async def test_aggregates_all_stats(self, mock_neo4j: MagicMock) -> None:
+        """Test that all statistics are aggregated."""
+        # Mock responses for each query
+        mock_neo4j.execute_query.side_effect = [
+            # Node counts by type
+            [{"label": "Person", "count": 50}, {"label": "Task", "count": 30}],
+            # Relationship counts by type
+            [{"relationshipType": "KNOWS", "count": 75}],
+            # Total nodes
+            [{"total": 80}],
+            # Total relationships
+            [{"total": 75}],
+        ]
+
+        result = await get_graph_statistics(mock_neo4j)
+
+        assert result.total_nodes == 80
+        assert result.total_relationships == 75
+        assert len(result.nodes_by_type) == 2
+        assert len(result.relationships_by_type) == 1
+        assert isinstance(result.timestamp, datetime)
+
+
+# =============================================================================
+# Test Serialization
+# =============================================================================
+
+
+class TestStatisticsToDict:
+    """Tests for statistics_to_dict function."""
+
+    def test_converts_to_dict(self) -> None:
+        """Test converting statistics to dictionary."""
+        stats = GraphStatistics(
+            total_nodes=100,
+            nodes_by_type=[NodeCountByType("Person", 60), NodeCountByType("Task", 40)],
+            total_relationships=50,
+            relationships_by_type=[RelationshipCountByType("KNOWS", 50)],
+            timestamp=datetime(2024, 1, 15, 10, 0, 0),
+        )
+
+        result = statistics_to_dict(stats)
+
+        assert result["total_nodes"] == 100
+        assert result["total_relationships"] == 50
+        assert result["nodes_by_type"]["Person"] == 60
+        assert result["nodes_by_type"]["Task"] == 40
+        assert result["relationships_by_type"]["KNOWS"] == 50
+        assert "timestamp" in result

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -8,13 +8,16 @@ from __future__ import annotations
 
 from klabautermann.core.ontology import (
     ENTITY_TYPES,
+    CommunityType,
     HealthMetricType,
     HobbyType,
+    LoreEpisodeType,
     MilestoneType,
     NodeLabel,
     OrganizationType,
     PersonType,
     PetType,
+    PreferenceType,
     ProjectType,
     RelationType,
     RoutineType,
@@ -293,6 +296,122 @@ class TestRoutineType:
             assert routine.frequency == freq
 
 
+class TestPreferenceType:
+    """Tests for PreferenceType model."""
+
+    def test_default_values(self) -> None:
+        """Test PreferenceType with default values."""
+        pref = PreferenceType()
+        assert pref.category is None
+        assert pref.sentiment is None
+        assert pref.strength is None
+        assert pref.context is None
+
+    def test_with_all_fields(self) -> None:
+        """Test PreferenceType with all fields populated."""
+        pref = PreferenceType(
+            category="food",
+            sentiment="love",
+            strength=0.9,
+            context="Grew up in Italy",
+        )
+        assert pref.category == "food"
+        assert pref.sentiment == "love"
+        assert pref.strength == 0.9
+        assert pref.context == "Grew up in Italy"
+
+    def test_various_sentiments(self) -> None:
+        """Test various sentiment values."""
+        sentiments = ["like", "dislike", "love", "hate", "neutral", "indifferent"]
+        for sent in sentiments:
+            pref = PreferenceType(sentiment=sent)
+            assert pref.sentiment == sent
+
+    def test_strength_bounds(self) -> None:
+        """Test strength values at boundaries."""
+        pref_weak = PreferenceType(strength=0.0)
+        assert pref_weak.strength == 0.0
+
+        pref_strong = PreferenceType(strength=1.0)
+        assert pref_strong.strength == 1.0
+
+
+class TestCommunityType:
+    """Tests for CommunityType model."""
+
+    def test_default_values(self) -> None:
+        """Test CommunityType with default values."""
+        community = CommunityType()
+        assert community.theme is None
+        assert community.summary is None
+        assert community.node_count is None
+        assert community.coherence_score is None
+
+    def test_with_all_fields(self) -> None:
+        """Test CommunityType with all fields populated."""
+        community = CommunityType(
+            theme="work_projects",
+            summary="All nodes related to ongoing work projects",
+            node_count=25,
+            coherence_score=0.85,
+        )
+        assert community.theme == "work_projects"
+        assert community.summary == "All nodes related to ongoing work projects"
+        assert community.node_count == 25
+        assert community.coherence_score == 0.85
+
+    def test_various_themes(self) -> None:
+        """Test various community themes."""
+        themes = ["family", "work", "hobbies", "health", "finance", "travel"]
+        for theme in themes:
+            community = CommunityType(theme=theme)
+            assert community.theme == theme
+
+
+class TestLoreEpisodeType:
+    """Tests for LoreEpisodeType model."""
+
+    def test_default_values(self) -> None:
+        """Test LoreEpisodeType with default values."""
+        episode = LoreEpisodeType()
+        assert episode.saga_id is None
+        assert episode.chapter is None
+        assert episode.told_at is None
+        assert episode.topic is None
+        assert episode.is_revealed is False
+
+    def test_with_all_fields(self) -> None:
+        """Test LoreEpisodeType with all fields populated."""
+        episode = LoreEpisodeType(
+            saga_id="career_journey",
+            chapter=3,
+            told_at="2024-01-15T10:00:00",
+            topic="First promotion",
+            is_revealed=True,
+        )
+        assert episode.saga_id == "career_journey"
+        assert episode.chapter == 3
+        assert episode.told_at == "2024-01-15T10:00:00"
+        assert episode.topic == "First promotion"
+        assert episode.is_revealed is True
+
+    def test_unrevealed_episode(self) -> None:
+        """Test unrevealed lore episode."""
+        episode = LoreEpisodeType(
+            saga_id="family_history",
+            chapter=1,
+            is_revealed=False,
+        )
+        assert episode.saga_id == "family_history"
+        assert episode.is_revealed is False
+
+    def test_chapter_sequence(self) -> None:
+        """Test various chapter numbers."""
+        for chapter in [1, 5, 10, 50, 100]:
+            episode = LoreEpisodeType(chapter=chapter)
+            assert episode.chapter == chapter
+
+
 # =============================================================================
 # Test ENTITY_TYPES Dict
 # =============================================================================
@@ -318,6 +437,9 @@ class TestEntityTypes:
         assert "Pet" in ENTITY_TYPES
         assert "Milestone" in ENTITY_TYPES
         assert "Routine" in ENTITY_TYPES
+        assert "Preference" in ENTITY_TYPES
+        assert "Community" in ENTITY_TYPES
+        assert "LoreEpisode" in ENTITY_TYPES
 
     def test_types_are_pydantic_models(self) -> None:
         """Test that all entity types are Pydantic BaseModel subclasses."""
@@ -328,8 +450,8 @@ class TestEntityTypes:
 
     def test_total_entity_count(self) -> None:
         """Test total number of entity types."""
-        # 7 core + 5 personal life = 12
-        assert len(ENTITY_TYPES) == 12
+        # 7 core + 8 personal life = 15
+        assert len(ENTITY_TYPES) == 15
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add 3 new Pydantic entity type models completing personal life ontology:
  - PreferenceType: likes/dislikes with sentiment and strength scoring
  - CommunityType: knowledge islands with theme/summary/node_count
  - LoreEpisodeType: progressive disclosure with saga_id/chapter/told_at
- Update ENTITY_TYPES dict to 15 types (7 core + 8 personal life)
- Add graph_statistics.py: node/relationship counts by type, totals
- Add context_statistics.py: token estimation, overflow tracking, compression ratios
- Export new statistics functions from memory module

## Test plan

- [x] Run `uv run pytest tests/unit/test_ontology.py` - 46 tests passing
- [x] Run `uv run pytest tests/unit/test_graph_statistics.py` - 14 tests passing
- [x] Run `uv run pytest tests/unit/test_context_statistics.py` - 22 tests passing
- [x] All 82 tests passing
- [x] Pre-commit hooks passing (ruff, mypy, smoke tests)

Closes #167, #168, #169, #196, #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)