### PR TITLE
fix(memory): Link Graphiti-extracted entities to messages and fix schedule query limits

### DIFF
--- a/src/klabautermann/agents/ingestor.py
+++ b/src/klabautermann/agents/ingestor.py
@@ -7,6 +7,9 @@ only preprocesses input to remove role prefixes, roleplay, and system mentions.
 
 Runs asynchronously (fire-and-forget) to avoid blocking user responses.
 
+After ingestion, links extracted entities to the source Message node via
+MENTIONED_IN relationships (Bug #350 fix).
+
 Reference: specs/architecture/AGENTS.md Section 1.2
 Task: T023 - Ingestor Agent
 """
@@ -23,6 +26,7 @@ from klabautermann.core.logger import logger
 if TYPE_CHECKING:
     from klabautermann.core.models import AgentMessage
     from klabautermann.memory.graphiti_client import GraphitiClient
+    from klabautermann.memory.neo4j_client import Neo4jClient
 
 
 class Ingestor(BaseAgent):
@@ -57,6 +61,7 @@ class Ingestor(BaseAgent):
         name: str = "ingestor",
         config: dict[str, Any] | None = None,
         graphiti_client: GraphitiClient | None = None,
+        neo4j_client: Neo4jClient | None = None,
     ) -> None:
         """
         Initialize the Ingestor agent.
@@ -65,9 +70,11 @@ class Ingestor(BaseAgent):
             name: Agent name (default "ingestor").
             config: Agent configuration dict.
             graphiti_client: GraphitiClient instance for graph storage.
+            neo4j_client: Neo4jClient for entity linking (Bug #350).
         """
         super().__init__(name, config)
         self.graphiti = graphiti_client
+        self.neo4j = neo4j_client
 
     async def process_message(self, msg: AgentMessage) -> AgentMessage | None:
         """
@@ -76,16 +83,21 @@ class Ingestor(BaseAgent):
         This is a fire-and-forget agent - it never returns a response.
         Ingestion failures are logged but don't crash the agent.
 
+        After ingestion, links extracted entities to the source message
+        via MENTIONED_IN relationships (Bug #350 fix).
+
         Args:
             msg: AgentMessage with payload containing:
                 - text: Text to ingest
                 - captain_uuid: User UUID (optional, used for group_id)
+                - message_uuid: UUID of source Message for entity linking (Bug #350)
 
         Returns:
             None (fire-and-forget pattern)
         """
         text = msg.payload.get("text", "")
         captain_uuid = msg.payload.get("captain_uuid")
+        message_uuid = msg.payload.get("message_uuid")
 
         if not text:
             logger.warning(
@@ -118,11 +130,19 @@ class Ingestor(BaseAgent):
         try:
             # Pass cleaned text directly to Graphiti
             # Graphiti's internal LLM handles entity/relationship extraction
-            await self._ingest_to_graphiti(
+            episode_name = await self._ingest_to_graphiti(
                 content=cleaned,
                 captain_uuid=captain_uuid,
                 trace_id=msg.trace_id,
             )
+
+            # Link extracted entities to source message (Bug #350 fix)
+            if episode_name and message_uuid and self.neo4j and self.graphiti:
+                await self._link_entities_to_message(
+                    episode_name=episode_name,
+                    message_uuid=message_uuid,
+                    trace_id=msg.trace_id,
+                )
 
         except Exception as e:
             # Log but don't crash - ingestion is best-effort
@@ -183,7 +203,7 @@ class Ingestor(BaseAgent):
         content: str,
         captain_uuid: str | None,
         trace_id: str,
-    ) -> None:
+    ) -> str | None:
         """
         Send cleaned content to Graphiti for extraction.
 
@@ -198,6 +218,9 @@ class Ingestor(BaseAgent):
             captain_uuid: User UUID for grouping related episodes.
             trace_id: Trace ID for logging.
 
+        Returns:
+            Episode name for entity linking, or None if ingestion skipped.
+
         Raises:
             Exception: If Graphiti ingestion fails.
         """
@@ -206,27 +229,117 @@ class Ingestor(BaseAgent):
                 "[SWELL] No Graphiti client configured - skipping ingestion",
                 extra={"trace_id": trace_id, "agent_name": self.name},
             )
-            return
+            return None
 
         if not self.graphiti.is_connected:
             logger.warning(
                 "[SWELL] Graphiti not connected - skipping ingestion",
                 extra={"trace_id": trace_id, "agent_name": self.name},
             )
-            return
+            return None
 
         logger.debug(
             f"[WHISPER] Sending to Graphiti: {len(content)} chars",
             extra={"trace_id": trace_id, "agent_name": self.name},
         )
 
-        await self.graphiti.add_episode(
+        episode_name = await self.graphiti.add_episode(
             content=content,
             source="conversation",
             reference_time=None,  # Use current time
             group_id=captain_uuid or "default",
             trace_id=trace_id,
         )
+
+        return episode_name
+
+    async def _link_entities_to_message(
+        self,
+        episode_name: str,
+        message_uuid: str,
+        trace_id: str,
+    ) -> None:
+        """
+        Link entities extracted by Graphiti to the source message.
+
+        After Graphiti ingestion, queries for entities created by that episode
+        and creates MENTIONED_IN relationships to the Message node.
+
+        Bug #350 fix: Enables queries like "What did I talk about with John?"
+        to find the specific message where John was mentioned.
+
+        Args:
+            episode_name: Name of the Graphiti episode (from add_episode).
+            message_uuid: UUID of the Message node to link entities to.
+            trace_id: Trace ID for logging.
+        """
+        if not self.graphiti or not self.neo4j:
+            return
+
+        try:
+            # Import here to avoid circular imports
+            from klabautermann.agents.researcher_models import EntityReference
+            from klabautermann.memory.message_linking import link_entities_to_message
+
+            # Get entities extracted by this episode
+            entities = await self.graphiti.get_entities_from_episode(
+                episode_name=episode_name,
+                trace_id=trace_id,
+            )
+
+            if not entities:
+                logger.debug(
+                    "[WHISPER] No entities found from episode to link",
+                    extra={
+                        "trace_id": trace_id,
+                        "agent_name": self.name,
+                        "episode_name": episode_name,
+                    },
+                )
+                return
+
+            # Convert to EntityReference objects
+            entity_refs = [
+                EntityReference(
+                    uuid=e["uuid"],
+                    name=e.get("name", "Unknown"),
+                    entity_type=e.get("labels", ["Entity"])[0] if e.get("labels") else "Entity",
+                    confidence=1.0,  # High confidence since Graphiti extracted them
+                    source_technique="graphiti_ingestion",
+                )
+                for e in entities
+            ]
+
+            # Create MENTIONED_IN relationships
+            link_count = await link_entities_to_message(
+                neo4j=self.neo4j,
+                message_uuid=message_uuid,
+                entity_refs=entity_refs,
+                trace_id=trace_id,
+            )
+
+            logger.info(
+                f"[BEACON] Linked {link_count} ingested entities to message",
+                extra={
+                    "trace_id": trace_id,
+                    "agent_name": self.name,
+                    "episode_name": episode_name,
+                    "message_uuid": message_uuid[:8],
+                    "entity_count": len(entities),
+                    "link_count": link_count,
+                },
+            )
+
+        except Exception as e:
+            # Non-blocking: log but don't fail
+            logger.warning(
+                f"[SWELL] Entity linking failed (non-blocking): {e}",
+                extra={
+                    "trace_id": trace_id,
+                    "agent_name": self.name,
+                    "episode_name": episode_name,
+                },
+            )
 
 
 # ===========================================================================

--- a/src/klabautermann/agents/orchestrator/_orchestrator.py
+++ b/src/klabautermann/agents/orchestrator/_orchestrator.py
@@ -145,10 +145,12 @@ class Orchestrator(BaseAgent):
         self._agent_registry["researcher"] = researcher
 
         # Create and register Ingestor agent for entity extraction
+        # Pass neo4j_client for entity linking (Bug #350)
         ingestor = Ingestor(
             name="ingestor",
             config=config,
             graphiti_client=graphiti,
+            neo4j_client=neo4j_client,
         )
         self._agent_registry["ingestor"] = ingestor
 
@@ -337,14 +339,17 @@ class Orchestrator(BaseAgent):
                     context = None
 
             # Store user message in thread (if thread_manager available)
+            # Capture message UUID for entity linking (Bug #350)
+            user_message_uuid: str | None = None
             if self.thread_manager:
                 try:
-                    await self.thread_manager.add_message(
+                    user_message = await self.thread_manager.add_message(
                         thread_uuid=thread_uuid,
                         role="user",
                         content=text,
                         trace_id=trace_id,
                     )
+                    user_message_uuid = user_message.uuid
                 except Exception as e:
                     logger.warning(
                         f"[SWELL] Could not store user message: {e}",
@@ -398,7 +403,9 @@ class Orchestrator(BaseAgent):
             # Fire-and-forget ingestion only for INGESTION intent (don't pollute graph with queries)
             if self.graphiti and intent.type == IntentType.INGESTION:
                 self._track_background_task(
-                    self._ingest_conversation(text, response_text, trace_id),
+                    self._ingest_conversation(
+                        text, response_text, trace_id, message_uuid=user_message_uuid
+                    ),
                     trace_id=trace_id,
                     task_name=f"ingest-v1-{trace_id}",
                 )
@@ -539,6 +546,7 @@ class Orchestrator(BaseAgent):
         user_text: str,
         _assistant_text: str,  # Reserved - not ingested to avoid meta-garbage
         trace_id: str,
+        message_uuid: str | None = None,
     ) -> None:
         """
         Fire-and-forget: ingest user message into knowledge graph.
@@ -555,10 +563,14 @@ class Orchestrator(BaseAgent):
         - Roleplay markers (*actions*, **Researcher**: etc.)
         - System mentions (The Locker, etc.)
 
+        After ingestion, creates MENTIONED_IN relationships between extracted
+        entities and the source Message node (Bug #350 fix).
+
         Args:
             user_text: User's message to ingest.
             _assistant_text: Reserved for future use (currently ignored).
             trace_id: Request trace ID.
+            message_uuid: UUID of the Message node to link entities to.
         """
         if not self.graphiti:
             return
@@ -580,7 +592,7 @@ class Orchestrator(BaseAgent):
             )
 
             # Ingest cleaned user message - Graphiti handles entity extraction
-            await self.graphiti.add_episode(
+            episode_name = await self.graphiti.add_episode(
                 content=cleaned_text,
                 source="conversation",
                 trace_id=trace_id,
@@ -588,14 +600,109 @@ class Orchestrator(BaseAgent):
 
             logger.debug(
                 "[WHISPER] Conversation ingested to Graphiti",
-                extra={"trace_id": trace_id, "agent_name": self.name},
+                extra={"trace_id": trace_id, "agent_name": self.name, "episode_name": episode_name},
             )
+
+            # Link extracted entities to the message (Bug #350 fix)
+            if message_uuid and self.neo4j_client:
+                await self._link_ingested_entities_to_message(
+                    episode_name=episode_name,
+                    message_uuid=message_uuid,
+                    trace_id=trace_id,
+                )
 
         except Exception as e:
             # Don't fail the response if ingestion fails
             logger.warning(
                 f"[SWELL] Ingestion failed (non-blocking): {e}",
                 extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+
+    async def _link_ingested_entities_to_message(
+        self,
+        episode_name: str,
+        message_uuid: str,
+        trace_id: str,
+    ) -> None:
+        """
+        Link entities extracted by Graphiti to the source message.
+
+        After Graphiti ingestion, queries for entities created by that episode
+        and creates MENTIONED_IN relationships to the Message node.
+
+        This enables queries like "What did I talk about with John?" to find
+        the specific message where John was mentioned.
+
+        Bug #350 fix: Closes the gap between Graphiti extraction and message linking.
+
+        Args:
+            episode_name: Name of the Graphiti episode (from add_episode).
+            message_uuid: UUID of the Message node to link entities to.
+            trace_id: Request trace ID for logging.
+        """
+        if not self.graphiti or not self.neo4j_client:
+            return
+
+        try:
+            # Get entities extracted by this episode
+            entities = await self.graphiti.get_entities_from_episode(
+                episode_name=episode_name,
+                trace_id=trace_id,
+            )
+
+            if not entities:
+                logger.debug(
+                    "[WHISPER] No entities found from episode to link",
+                    extra={
+                        "trace_id": trace_id,
+                        "episode_name": episode_name,
+                        "message_uuid": message_uuid[:8],
+                    },
+                )
+                return
+
+            # Convert to EntityReference objects for link_entities_to_message
+            from klabautermann.agents.researcher_models import EntityReference
+
+            entity_refs = [
+                EntityReference(
+                    uuid=e["uuid"],
+                    name=e.get("name", "Unknown"),
+                    entity_type=e.get("labels", ["Entity"])[0] if e.get("labels") else "Entity",
+                    confidence=1.0,  # High confidence since Graphiti extracted them
+                    source_technique="graphiti_ingestion",
+                )
+                for e in entities
+            ]
+
+            # Create MENTIONED_IN relationships
+            link_count = await link_entities_to_message(
+                neo4j=self.neo4j_client,
+                message_uuid=message_uuid,
+                entity_refs=entity_refs,
+                trace_id=trace_id,
+            )
+
+            logger.info(
+                f"[BEACON] Linked {link_count} ingested entities to message",
+                extra={
+                    "trace_id": trace_id,
+                    "episode_name": episode_name,
+                    "message_uuid": message_uuid[:8],
+                    "entity_count": len(entities),
+                    "link_count": link_count,
+                },
+            )
+
+        except Exception as e:
+            # Non-blocking: log but don't fail
+            logger.warning(
+                f"[SWELL] Entity linking failed (non-blocking): {e}",
+                extra={
+                    "trace_id": trace_id,
+                    "episode_name": episode_name,
+                    "message_uuid": message_uuid[:8],
+                },
             )
 
     # =========================================================================
@@ -1780,6 +1887,7 @@ Analyze this message and return a JSON task plan.
         task_plan: TaskPlan,
         trace_id: str,
         original_text: str = "",
+        message_uuid: str | None = None,
     ) -> dict[str, Any]:
         """
         Execute all planned tasks in parallel.
@@ -1794,18 +1902,23 @@ Analyze this message and return a JSON task plan.
             task_plan: TaskPlan from _plan_tasks()
             trace_id: For logging
             original_text: Original user message (fallback for ingest payloads)
+            message_uuid: UUID of user message for entity linking (Bug #350)
 
         Returns:
             Dictionary mapping task descriptions to results
         """
         # Validate and fix ingest task payloads before dispatch
         for task in task_plan.tasks:
-            if task.task_type == "ingest" and not task.payload.get("text"):
-                logger.warning(
-                    "[SWELL] Ingest task missing 'text' in payload, using original message",
-                    extra={"trace_id": trace_id, "description": task.description[:50]},
-                )
-                task.payload["text"] = original_text
+            if task.task_type == "ingest":
+                if not task.payload.get("text"):
+                    logger.warning(
+                        "[SWELL] Ingest task missing 'text' in payload, using original message",
+                        extra={"trace_id": trace_id, "description": task.description[:50]},
+                    )
+                    task.payload["text"] = original_text
+                # Add message_uuid for entity linking (Bug #350)
+                if message_uuid:
+                    task.payload["message_uuid"] = message_uuid
 
         blocking_count = sum(1 for t in task_plan.tasks if t.blocking)
         non_blocking_count = len(task_plan.tasks) - blocking_count
@@ -2163,14 +2276,17 @@ Analyze this message and return a JSON task plan.
             )
 
             # Store user message in thread
+            # Capture message UUID for entity linking (Bug #350)
+            user_message_uuid_v2: str | None = None
             if self.thread_manager:
                 try:
-                    await self.thread_manager.add_message(
+                    user_message = await self.thread_manager.add_message(
                         thread_uuid=thread_uuid,
                         role="user",
                         content=text,
                         trace_id=trace_id,
                     )
+                    user_message_uuid_v2 = user_message.uuid
                 except Exception as e:
                     logger.warning(
                         f"[SWELL] Failed to store user message: {e}",
@@ -2226,7 +2342,9 @@ Analyze this message and return a JSON task plan.
 
             # 4. Dispatch: Execute tasks in parallel (individual failures captured)
             exec_start = time.time()
-            results = await self._execute_parallel_safe(task_plan, trace_id, original_text=text)
+            results = await self._execute_parallel_safe(
+                task_plan, trace_id, original_text=text, message_uuid=user_message_uuid_v2
+            )
             logger.info(
                 "[BEACON] Parallel execution complete",
                 extra={
@@ -2580,6 +2698,7 @@ Analyze this message and return a JSON task plan.
         task_plan: TaskPlan,
         trace_id: str,
         original_text: str = "",
+        message_uuid: str | None = None,
     ) -> dict[str, Any]:
         """
         Execute all planned tasks in parallel with individual failure capture.
@@ -2593,13 +2712,14 @@ Analyze this message and return a JSON task plan.
             task_plan: TaskPlan from _plan_tasks()
             trace_id: For logging
             original_text: Original user message (fallback for ingest payloads)
+            message_uuid: UUID of user message for entity linking (Bug #350)
 
         Returns:
             Dictionary mapping task descriptions to results (includes errors)
         """
         try:
             # Use the existing _execute_parallel which already has return_exceptions=True
-            results = await self._execute_parallel(task_plan, trace_id, original_text)
+            results = await self._execute_parallel(task_plan, trace_id, original_text, message_uuid)
 
             # Count successes and failures
             success_count = sum(

--- a/src/klabautermann/agents/researcher.py
+++ b/src/klabautermann/agents/researcher.py
@@ -712,6 +712,12 @@ class Researcher(BaseAgent):
 
             if is_schedule_query:
                 # Query CalendarEvent nodes by event start_time from all calendars
+                # Use higher limit (100) for schedule queries to avoid cutting off
+                # multi-calendar events. Users expect to see ALL events in their
+                # requested time range, not just the first few.
+                # Reference: Bug #349
+                schedule_limit = 100
+
                 calendar_cypher = """
                 MATCH (c:CalendarEvent)
                 WHERE c.start_time >= $start AND c.start_time <= $end
@@ -723,7 +729,7 @@ class Researcher(BaseAgent):
                 params = {
                     "start": time_range.start or 0,
                     "end": time_range.end or datetime.now(UTC).timestamp(),
-                    "limit": limit,
+                    "limit": schedule_limit,
                 }
 
                 records = await self.neo4j.execute_query(calendar_cypher, params, trace_id=trace_id)

--- a/src/klabautermann/memory/graphiti_client.py
+++ b/src/klabautermann/memory/graphiti_client.py
@@ -129,7 +129,7 @@ class GraphitiClient:
         reference_time: datetime | None = None,
         group_id: str | None = None,
         trace_id: str | None = None,
-    ) -> None:
+    ) -> str:
         """
         Ingest new information into the knowledge graph.
 
@@ -145,6 +145,9 @@ class GraphitiClient:
             reference_time: When the events in content occurred
             group_id: Optional group identifier for related episodes
             trace_id: Trace ID for logging
+
+        Returns:
+            Episode name (can be used to query entities later)
         """
         self._ensure_connected()
         assert self._client is not None  # Guaranteed by _ensure_connected
@@ -169,8 +172,10 @@ class GraphitiClient:
             # Use current time if no reference time provided
             ref_time = reference_time or datetime.now(tz=UTC)
 
+            episode_name = f"episode_{trace_id or 'unknown'}_{ref_time.timestamp():.0f}"
+
             await self._client.add_episode(
-                name=f"episode_{trace_id or 'unknown'}_{ref_time.timestamp():.0f}",
+                name=episode_name,
                 episode_body=content,
                 source=episode_type,
                 source_description=f"Klabautermann {source} channel",
@@ -181,8 +186,14 @@ class GraphitiClient:
 
             logger.info(
                 "[BEACON] Episode ingested successfully",
-                extra={"trace_id": trace_id, "agent_name": "graphiti"},
+                extra={
+                    "trace_id": trace_id,
+                    "agent_name": "graphiti",
+                    "episode_name": episode_name,
+                },
             )
+
+            return episode_name
 
         except Exception as e:
             logger.error(
@@ -383,6 +394,91 @@ class GraphitiClient:
                 extra={"trace_id": trace_id, "agent_name": "graphiti"},
             )
             return None
+
+    async def get_entities_from_episode(
+        self,
+        episode_name: str,
+        trace_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Retrieve entities that were extracted from a specific episode.
+
+        Queries the graph for EntityNode instances that are connected to
+        the episode via Graphiti's internal EXTRACTED_FROM or similar relationships.
+
+        Args:
+            episode_name: The name of the episode (returned from add_episode)
+            trace_id: Trace ID for logging
+
+        Returns:
+            List of entity dicts with uuid, name, and labels
+        """
+        self._ensure_connected()
+        assert self._client is not None  # Guaranteed by _ensure_connected
+
+        logger.debug(
+            f"[WHISPER] Querying entities from episode: {episode_name}",
+            extra={"trace_id": trace_id, "agent_name": "graphiti"},
+        )
+
+        try:
+            # Access the Neo4j driver from Graphiti client
+            driver = self._client.driver
+
+            # Query entities connected to this episode
+            # Graphiti stores Episode nodes and links entities via edges
+            # We need to find entities created/updated by this episode
+            cypher = """
+                MATCH (ep:EpisodicNode {name: $episode_name})
+                MATCH (e:EntityNode)-[r:MENTIONED_IN]->(ep)
+                RETURN DISTINCT e.uuid as uuid, e.name as name, labels(e) as labels
+                UNION
+                MATCH (ep:EpisodicNode {name: $episode_name})
+                MATCH (e:EntityNode)<-[:RELATES_TO]-(edge)-[:RELATES_TO]->(ep)
+                RETURN DISTINCT e.uuid as uuid, e.name as name, labels(e) as labels
+            """
+
+            async with driver.session() as session:
+                result = await session.run(cypher, parameters={"episode_name": episode_name})
+                records = await result.data()
+
+            entities: list[dict[str, Any]] = []
+            seen_uuids: set[str] = set()
+
+            for record in records:
+                uuid = record.get("uuid")
+                if uuid and uuid not in seen_uuids:
+                    seen_uuids.add(uuid)
+                    entities.append(
+                        {
+                            "uuid": uuid,
+                            "name": record.get("name", "Unknown"),
+                            "labels": record.get("labels", ["Entity"]),
+                        }
+                    )
+
+            logger.info(
+                f"[BEACON] Found {len(entities)} entities from episode",
+                extra={
+                    "trace_id": trace_id,
+                    "agent_name": "graphiti",
+                    "episode_name": episode_name,
+                    "entity_count": len(entities),
+                },
+            )
+
+            return entities
+
+        except Exception as e:
+            logger.warning(
+                f"[SWELL] Failed to get entities from episode: {e}",
+                extra={
+                    "trace_id": trace_id,
+                    "agent_name": "graphiti",
+                    "episode_name": episode_name,
+                },
+            )
+            return []
 
 
 # ===========================================================================

--- a/tests/unit/test_orchestrator_v2_error_handling.py
+++ b/tests/unit/test_orchestrator_v2_error_handling.py
@@ -297,8 +297,8 @@ class TestExecuteParallelSafe:
         ) as mock_execute:
             results = await orchestrator._execute_parallel_safe(task_plan, "trace-456")
 
-            # _execute_parallel now takes original_text parameter (defaults to "")
-            mock_execute.assert_called_once_with(task_plan, "trace-456", "")
+            # _execute_parallel now takes original_text and message_uuid parameters
+            mock_execute.assert_called_once_with(task_plan, "trace-456", "", None)
             assert "Find Sarah" in results
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Bug #350**: Messages are now linked to entities extracted during Graphiti ingestion via MENTIONED_IN relationships
- **Bug #349**: Schedule queries now return all events (up to 100) instead of truncating to 10

## Test plan

- [x] All unit tests pass (1492 passed)
- [x] Lint passes (`make lint`)
- [x] Type check passes (`make type-check`)
- [ ] Manual test: "I met John (john@example.com), PM at Acme" should create Person and Organization linked to Message
- [ ] Manual test: "What's my schedule this week?" should return all events, not just first 10

## Technical Changes

### Bug #350 - Entity Linking Fix
- `GraphitiClient.add_episode()` now returns episode name
- Added `GraphitiClient.get_entities_from_episode()` to query extracted entities
- Added `Orchestrator._link_ingested_entities_to_message()` for v1 workflow
- Updated `Ingestor` agent to accept `neo4j_client` and link entities for v2 workflow
- Pass `message_uuid` through task payloads for entity linking

### Bug #349 - Schedule Query Fix
- Changed `_execute_temporal_search()` calendar query LIMIT from 10 to 100
- Prevents truncation of multi-calendar events in time range queries

Closes #349, Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)