### PR TITLE
refactor(orchestrator): Remove keyword-based intent classification (#2)

### DIFF
--- a/audit/GAPS.md
+++ b/audit/GAPS.md
@@ -24,7 +24,7 @@ This document catalogs gaps between the specifications in `specs/` and the curre
 
 | Component | Spec Section | Status | Gap Description | Priority | Issue ID |
 |-----------|--------------|--------|-----------------|----------|----------|
-| Orchestrator | MAINAGENT.md 2.1 | AI-First | Intent classification uses keyword matching (search_keywords, action_keywords in config) instead of pure LLM | P0 | AGT-P-001 |
+| ~~Orchestrator~~ | ~~MAINAGENT.md 2.1~~ | ~~AI-First~~ | ~~Intent classification uses keyword matching~~ **FIXED** (PR #xxx) - Removed keyword fallback, pure LLM only | ~~P0~~ | ~~AGT-P-001~~ |
 | Orchestrator | MAINAGENT.md 5.1 | Missing | True multi-model orchestration not implemented - uses single Sonnet model | P1 | AGT-P-002 |
 | Orchestrator | PRD 8.4 | Missing | Storm Mode detection and response adaptation | P2 | AGT-P-004 |
 | Ingestor | AGENTS.md 2.1 | Missing | LLM-based pre-extraction using Haiku - relies entirely on Graphiti | P1 | AGT-P-009 |

--- a/specs/architecture/AGENTS.md
+++ b/specs/architecture/AGENTS.md
@@ -607,26 +607,23 @@ Each agent has a YAML configuration file:
 
 ```yaml
 # config/agents/orchestrator.yaml
-model: claude-3-5-sonnet-20241022
-fallback_model: claude-3-haiku-20240307
-max_context_tokens: 8000
-personality: klabautermann
-temperature: 0.7
+use_v2_workflow: true  # Think-Dispatch-Synthesize pattern
 
+model:
+  primary: claude-sonnet-4-20250514
+  fallback: claude-3-haiku-20240307
+  temperature: 0.7
+  max_context_tokens: 8000
+
+personality:
+  name: klabautermann
+  wit_level: 0.3
+
+# Intent classification uses LLM for semantic understanding
+# No keyword lists - pure AI-first approach (Issue #2 / AGT-P-001)
 intent_classification:
-  search_keywords:
-    - "who"
-    - "what"
-    - "when"
-    - "where"
-    - "find"
-    - "tell me about"
-  action_keywords:
-    - "send"
-    - "email"
-    - "schedule"
-    - "create"
-    - "draft"
+  model: claude-3-5-haiku-20241022  # Fast model for classification
+  timeout: 5.0  # Seconds before graceful degradation
 
 delegation:
   search: researcher

--- a/src/klabautermann/agents/orchestrator/_orchestrator.py
+++ b/src/klabautermann/agents/orchestrator/_orchestrator.py
@@ -990,67 +990,17 @@ class Orchestrator(BaseAgent):
             )
 
         except Exception as e:
-            # Fallback to simple heuristics if LLM fails
+            # AI-First: No keyword fallback - return CONVERSATION with low confidence
+            # This ensures the system degrades gracefully while maintaining semantic purity
+            # Issue #2 (AGT-P-001): Remove keyword-based intent classification
             logger.warning(
-                f"[SWELL] LLM classification failed, using fallback: {e}",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return self._classify_intent_fallback(text, trace_id)
-
-    def _classify_intent_fallback(self, text: str, trace_id: str) -> IntentClassification:
-        """
-        Simple fallback classification when LLM is unavailable.
-
-        Uses basic heuristics - much less accurate than LLM but works offline.
-        """
-        text_lower = text.lower().strip()
-
-        # Question mark -> SEARCH
-        if "?" in text:
-            logger.debug(
-                "[WHISPER] Fallback: question mark -> SEARCH",
+                f"[SWELL] LLM classification failed, defaulting to CONVERSATION: {e}",
                 extra={"trace_id": trace_id, "agent_name": self.name},
             )
             return IntentClassification(
-                type=IntentType.SEARCH,
-                confidence=0.6,
-                query=text,
+                type=IntentType.CONVERSATION,
+                confidence=0.3,  # Low confidence signals classification uncertainty
             )
-
-        # Action keywords
-        action_starts = ("send", "email", "schedule", "create", "draft", "book")
-        if any(text_lower.startswith(kw) for kw in action_starts):
-            logger.debug(
-                "[WHISPER] Fallback: action keyword -> ACTION",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return IntentClassification(
-                type=IntentType.ACTION,
-                confidence=0.6,
-                action=text,
-            )
-
-        # Ingestion keywords
-        ingest_starts = ("i met", "i talked", "i spoke", "i learned", "i just")
-        if any(text_lower.startswith(kw) for kw in ingest_starts):
-            logger.debug(
-                "[WHISPER] Fallback: ingestion keyword -> INGESTION",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return IntentClassification(
-                type=IntentType.INGESTION,
-                confidence=0.6,
-            )
-
-        # Default to conversation
-        logger.debug(
-            "[WHISPER] Fallback: default -> CONVERSATION",
-            extra={"trace_id": trace_id, "agent_name": self.name},
-        )
-        return IntentClassification(
-            type=IntentType.CONVERSATION,
-            confidence=0.5,
-        )
 
     # =========================================================================
     # Intent Handlers (T021 - Full Delegation)

--- a/tests/integration/test_sprint2_agents.py
+++ b/tests/integration/test_sprint2_agents.py
@@ -264,6 +264,25 @@ class TestIntentClassification:
             assert intent.type == IntentType.CONVERSATION
             assert intent.confidence == 0.7
 
+    @pytest.mark.asyncio
+    async def test_llm_failure_returns_conversation(self, orchestrator: Orchestrator) -> None:
+        """When LLM classification fails, return CONVERSATION with low confidence.
+
+        AI-First principle: No keyword fallback. Graceful degradation to
+        CONVERSATION intent preserves semantic purity (Issue #2 / AGT-P-001).
+        """
+        with patch.object(
+            orchestrator, "_call_classification_model", new_callable=AsyncMock
+        ) as mock_llm:
+            # Simulate LLM failure
+            mock_llm.side_effect = Exception("API timeout")
+            intent = await orchestrator._classify_intent(
+                "Send an email to John", None, "test-trace"
+            )
+            # Should fall back to CONVERSATION, NOT use keyword matching
+            assert intent.type == IntentType.CONVERSATION
+            assert intent.confidence == 0.3  # Low confidence signals uncertainty
+
 
 # ====================
 # AGENT DELEGATION TESTS


### PR DESCRIPTION
## Summary
- Remove keyword-based fallback classification (AI-First principle)
- When LLM fails, gracefully degrade to CONVERSATION intent with low confidence
- Update AGENTS.md spec to reflect current LLM-only approach
- Add test for LLM failure graceful degradation

## Issue
Closes #2 ([AGT-P-001] Remove keyword-based intent classification - use pure LLM)

## Changes
- `src/klabautermann/agents/orchestrator/_orchestrator.py`: Remove `_classify_intent_fallback` method with hardcoded keywords; replace with graceful CONVERSATION degradation
- `specs/architecture/AGENTS.md`: Update config example to match actual implementation (no keywords)
- `audit/GAPS.md`: Mark AGT-P-001 as fixed
- `tests/integration/test_sprint2_agents.py`: Add test `test_llm_failure_returns_conversation`

## AI-First Principle
The system now uses pure LLM semantic understanding:
- No keyword matching
- No regex patterns
- Graceful degradation returns CONVERSATION with 0.3 confidence (signals uncertainty)

## Test plan
- [x] All intent classification tests pass
- [x] New test verifies LLM failure returns CONVERSATION (not keyword-matched intent)
- [x] Pre-commit hooks pass (linting, type checking, smoke tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)