### PR TITLE
refactor(memory): Remove keyword-based zoom level detection (AI-first)

### DIFF
--- a/audit/GAPS.md
+++ b/audit/GAPS.md
@@ -32,7 +32,7 @@ This document catalogs gaps between the specifications in `specs/` and the curre
 | Researcher | RESEARCHER.md 2.4 | Missing | Structural traversal queries (REPORTS_TO chains, etc.) | P1 | AGT-P-013 |
 | Researcher | RESEARCHER.md 2.5 | Missing | Time-filtered temporal queries ("Who did X work for last year?") | P1 | AGT-P-014 |
 | Researcher | RESEARCHER.md 2.6 | Missing | Island search (Knowledge Island exploration) | P2 | AGT-P-015 |
-| Researcher | AGENTS_EXTENDED.md 4.4 | AI-First | Zoom level detection uses keyword matching | P0 | AGT-P-018 |
+| ~~Researcher~~ | ~~AGENTS_EXTENDED.md 4.4~~ | ~~AI-First~~ | ~~Zoom level detection uses keyword matching~~ **FIXED** - Removed keyword fallback, pure LLM only | ~~P0~~ | ~~AGT-P-018~~ |
 | Executor | MCP.md | Missing | Email reply-to-thread functionality | P1 | AGT-P-020 |
 | Executor | MCP.md | Missing | Calendar event update/delete | P1 | AGT-P-021 |
 | Executor | MCP.md | Missing | Recurring events support | P2 | AGT-P-022 |
@@ -213,7 +213,7 @@ Per `specs/architecture/AGENTS_EXTENDED.md`, all 6 secondary agents are unimplem
 | Feature | Spec Section | Status | Gap Description | Issue ID |
 |---------|--------------|--------|-----------------|----------|
 | Multi-level retrieval | MEMORY.md | Partial | Zoom levels not implemented | MEM-001 |
-| Zoom level detection | MEMORY.md | AI-First | Uses keyword matching | MEM-002 |
+| ~~Zoom level detection~~ | ~~MEMORY.md~~ | ~~AI-First~~ | ~~Uses keyword matching~~ **FIXED** - Pure LLM semantic understanding | ~~MEM-002~~ |
 | Deduplication wiring | MEMORY.md | Unwired | Module exists, not integrated | MEM-003 |
 | Orphan message detection | MEMORY.md | Missing | No cleanup routine | MEM-004 |
 | Entity merge utility | MEMORY.md | Missing | No merge function | MEM-005 |
@@ -354,9 +354,9 @@ These issues MUST use pure LLM intelligence, no keywords or regex:
 
 | Issue ID | Description | Current Approach | Required Approach |
 |----------|-------------|------------------|-------------------|
-| AGT-P-001 | Intent classification | Keyword lists in config | LLM tool_use classification |
-| AGT-P-018 | Query zoom level detection | Keyword matching | LLM semantic understanding |
-| MEM-002 | Retrieval zoom detection | Keyword matching | LLM context analysis |
+| ~~AGT-P-001~~ | ~~Intent classification~~ | ~~Keyword lists in config~~ | **FIXED** - LLM tool_use classification |
+| ~~AGT-P-018~~ | ~~Query zoom level detection~~ | ~~Keyword matching~~ | **FIXED** - LLM semantic understanding |
+| ~~MEM-002~~ | ~~Retrieval zoom detection~~ | ~~Keyword matching~~ | **FIXED** - LLM context analysis |
 | SKILL-006 | Skill discovery | Pattern matching | Natural language understanding |
 
 ---

--- a/specs/architecture/AGENTS_EXTENDED.md
+++ b/specs/architecture/AGENTS_EXTENDED.md
@@ -683,35 +683,42 @@ class Cartographer(BaseAgent):
 
 ### 4.4 Multi-Level Retrieval Support
 
+Uses AI-first semantic understanding for zoom level detection (no keyword matching).
+See `memory/zoom_search.py` for implementation.
+
 ```python
-# In researcher.py
+# In memory/zoom_search.py
 
-async def search(self, query: str, zoom_level: str = "auto") -> List[SearchResult]:
-    """Hybrid search with zoom level support."""
-    if zoom_level == "auto":
-        zoom_level = self._detect_zoom_level(query)
+class AIZoomLevelSelector:
+    """AI-first zoom level detection using Claude Haiku."""
 
-    if zoom_level == "macro":
-        # Query Community nodes
-        return await self._search_communities(query)
-    elif zoom_level == "meso":
-        # Query Project/Note nodes
-        return await self._search_projects_notes(query)
-    else:  # micro
-        # Query Entity nodes
-        return await self._search_entities(query)
+    async def classify_query(self, query: str, trace_id: str | None = None) -> ZoomClassification:
+        """
+        Classify query zoom level using LLM semantic understanding.
 
-def _detect_zoom_level(self, query: str) -> str:
-    """Detect appropriate zoom level from query."""
-    macro_keywords = ["overview", "summary", "big picture", "all my", "everything about"]
-    meso_keywords = ["project", "thread", "topic", "conversation"]
+        AI-First principle: Uses semantic analysis, not keyword matching.
+        Falls back to MICRO with low confidence if LLM unavailable.
+        """
+        # Uses tool_use to extract structured classification
+        response = await anthropic.messages.create(
+            model=ZOOM_CLASSIFICATION_MODEL,
+            system=ZOOM_CLASSIFIER_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": query}],
+            tools=[zoom_classification_tool],
+        )
+        # Parse and return ZoomClassification
 
-    query_lower = query.lower()
-    if any(kw in query_lower for kw in macro_keywords):
-        return "macro"
-    elif any(kw in query_lower for kw in meso_keywords):
-        return "meso"
-    return "micro"
+async def ai_zoom_search(neo4j, query: str, ...) -> ZoomSearchResponse:
+    """Execute search using AI-based zoom level selection."""
+    selector = AIZoomLevelSelector()
+    classification = await selector.classify_query(query)
+
+    if classification.level == ZoomLevel.MACRO:
+        return await macro_search(neo4j, ...)  # Community nodes
+    elif classification.level == ZoomLevel.MESO:
+        return await meso_search(neo4j, query, ...)  # Project/Note nodes
+    else:  # MICRO
+        return await micro_search(neo4j, query, ...)  # Entity facts
 ```
 
 ---

--- a/src/klabautermann/memory/zoom_search.py
+++ b/src/klabautermann/memory/zoom_search.py
@@ -659,20 +659,19 @@ class AIZoomLevelSelector:
             )
             return self._fallback_classification(query)
 
-    def _fallback_classification(self, query: str) -> ZoomClassification:
+    def _fallback_classification(self, query: str) -> ZoomClassification:  # noqa: ARG002
         """
-        Fallback to keyword-based classification when AI is unavailable.
+        Fallback classification when AI is unavailable.
 
-        This provides graceful degradation when the LLM call fails.
+        AI-First principle: No keyword matching. Default to MICRO (most
+        common query type) with low confidence to signal uncertainty.
+
+        Issue AGT-P-018: Remove keyword-based zoom level detection.
         """
-        # Use the keyword-based selector as fallback
-        keyword_selector = ZoomLevelSelector()
-        level_str = keyword_selector.select_zoom_level(query)
-
         return ZoomClassification(
-            level=ZoomLevel(level_str),
-            confidence=0.5,  # Lower confidence for keyword fallback
-            reasoning="Fallback to keyword-based classification",
+            level=ZoomLevel.MICRO,
+            confidence=0.3,  # Low confidence signals classification uncertainty
+            reasoning="LLM unavailable - defaulting to MICRO (AI-first, no keyword fallback)",
         )
 
 

--- a/tests/unit/test_zoom_search.py
+++ b/tests/unit/test_zoom_search.py
@@ -551,15 +551,20 @@ class TestAIZoomLevelSelector:
 
     @pytest.mark.asyncio
     async def test_fallback_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test fallback to keyword selector when API key missing."""
+        """Test fallback when API key missing - AI-first, no keyword matching.
+
+        AI-First principle (AGT-P-018): When LLM unavailable, default to MICRO
+        with low confidence instead of using keyword matching.
+        """
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
         selector = AIZoomLevelSelector()
         classification = await selector.classify_query("Give me an overview")
 
-        # Should fall back to keyword-based classification
-        assert classification.confidence == 0.5  # Fallback confidence
-        assert classification.reasoning == "Fallback to keyword-based classification"
+        # Should NOT use keyword matching - always defaults to MICRO
+        assert classification.level == ZoomLevel.MICRO
+        assert classification.confidence == 0.3  # Low confidence signals uncertainty
+        assert "AI-first" in classification.reasoning
 
     @pytest.mark.asyncio
     async def test_classify_macro_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -654,7 +659,10 @@ class TestAIZoomLevelSelector:
 
     @pytest.mark.asyncio
     async def test_fallback_on_no_tool_use_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test fallback when LLM doesn't return tool_use block."""
+        """Test fallback when LLM doesn't return tool_use block.
+
+        AI-First principle: Default to MICRO, no keyword matching.
+        """
         mock_response = MagicMock()
         mock_response.content = [MagicMock(type="text", text="Unable to classify")]
 
@@ -670,12 +678,17 @@ class TestAIZoomLevelSelector:
         selector = AIZoomLevelSelector()
         classification = await selector.classify_query("Some query")
 
-        # Should fall back to keyword-based
-        assert classification.confidence == 0.5
+        # AI-first: Default to MICRO with low confidence (no keyword matching)
+        assert classification.level == ZoomLevel.MICRO
+        assert classification.confidence == 0.3
 
     @pytest.mark.asyncio
     async def test_fallback_on_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test fallback when API call fails."""
+        """Test fallback when API call fails.
+
+        AI-First principle (AGT-P-018): Graceful degradation to MICRO,
+        no keyword matching.
+        """
         import anthropic
 
         mock_client = MagicMock()
@@ -692,9 +705,10 @@ class TestAIZoomLevelSelector:
         selector = AIZoomLevelSelector()
         classification = await selector.classify_query("Some query")
 
-        # Should fall back gracefully
-        assert classification.confidence == 0.5
-        assert classification.reasoning == "Fallback to keyword-based classification"
+        # AI-first: Default to MICRO with low confidence (no keyword matching)
+        assert classification.level == ZoomLevel.MICRO
+        assert classification.confidence == 0.3
+        assert "AI-first" in classification.reasoning
 
 
 class TestAIZoomSearch:


### PR DESCRIPTION
## Summary
- Remove keyword-based fallback in zoom level classification (AI-First principle)
- When LLM classification fails, default to MICRO with low confidence
- Update AGENTS_EXTENDED.md spec to reflect current LLM-only approach
- Update tests to verify AI-first fallback behavior

## Issues
Related to: AGT-P-018 (Zoom level detection uses keyword matching), MEM-002 (Retrieval zoom detection)

## Changes
- `src/klabautermann/memory/zoom_search.py`: Replace keyword fallback with MICRO default + 0.3 confidence
- `specs/architecture/AGENTS_EXTENDED.md`: Update Section 4.4 to show AI-first implementation
- `audit/GAPS.md`: Mark AGT-P-018 and MEM-002 as fixed
- `tests/unit/test_zoom_search.py`: Update 3 fallback tests to expect MICRO + 0.3 confidence

## AI-First Principle
The system now uses pure LLM semantic understanding for zoom level detection:
- No keyword matching in primary path (already AI-based via Claude Haiku)
- No keyword matching in fallback path (now defaults to MICRO with low confidence)
- Low confidence (0.3) signals uncertainty when LLM is unavailable

## Test plan
- [x] All 37 zoom search tests pass
- [x] 3 fallback tests updated to verify MICRO default behavior
- [x] Pre-commit hooks pass (linting, type checking, smoke tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)