### PR TITLE
feat(calendar): Add recurring events support

### DIFF
--- a/src/klabautermann/mcp/google_workspace.py
+++ b/src/klabautermann/mcp/google_workspace.py
@@ -69,6 +69,92 @@ class CalendarEvent(BaseModel):
     calendar_name: str | None = None  # Human-readable calendar name
     event_type: str | None = None  # "default", "outOfOffice", "focusTime", "workingLocation"
     transparency: str | None = None  # "opaque" (busy) or "transparent" (free)
+    recurrence_rule: str | None = None  # RFC 5545 RRULE string (e.g., "RRULE:FREQ=DAILY")
+    recurring_event_id: str | None = None  # ID of parent recurring event (for instances)
+
+
+class RecurrenceBuilder:
+    """
+    Build RFC 5545 RRULE strings for common recurrence patterns.
+
+    Examples:
+        RecurrenceBuilder.daily()  # "RRULE:FREQ=DAILY"
+        RecurrenceBuilder.weekly(["MO", "WE", "FR"])  # "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
+        RecurrenceBuilder.monthly(15)  # "RRULE:FREQ=MONTHLY;BYMONTHDAY=15"
+        RecurrenceBuilder.yearly()  # "RRULE:FREQ=YEARLY"
+    """
+
+    @staticmethod
+    def daily(count: int | None = None, until: datetime | None = None) -> str:
+        """Create a daily recurrence rule."""
+        rule = "RRULE:FREQ=DAILY"
+        if count:
+            rule += f";COUNT={count}"
+        elif until:
+            rule += f";UNTIL={until.strftime('%Y%m%dT%H%M%SZ')}"
+        return rule
+
+    @staticmethod
+    def weekly(
+        days: list[str] | None = None,
+        count: int | None = None,
+        until: datetime | None = None,
+    ) -> str:
+        """
+        Create a weekly recurrence rule.
+
+        Args:
+            days: List of day abbreviations (MO, TU, WE, TH, FR, SA, SU).
+                  If None, recurs on the same day as the event.
+            count: Number of occurrences (mutually exclusive with until)
+            until: End date for recurrence (mutually exclusive with count)
+        """
+        rule = "RRULE:FREQ=WEEKLY"
+        if days:
+            rule += f";BYDAY={','.join(days)}"
+        if count:
+            rule += f";COUNT={count}"
+        elif until:
+            rule += f";UNTIL={until.strftime('%Y%m%dT%H%M%SZ')}"
+        return rule
+
+    @staticmethod
+    def monthly(
+        day_of_month: int | None = None,
+        count: int | None = None,
+        until: datetime | None = None,
+    ) -> str:
+        """
+        Create a monthly recurrence rule.
+
+        Args:
+            day_of_month: Day of month (1-31). If None, uses event's day.
+            count: Number of occurrences
+            until: End date for recurrence
+        """
+        rule = "RRULE:FREQ=MONTHLY"
+        if day_of_month:
+            rule += f";BYMONTHDAY={day_of_month}"
+        if count:
+            rule += f";COUNT={count}"
+        elif until:
+            rule += f";UNTIL={until.strftime('%Y%m%dT%H%M%SZ')}"
+        return rule
+
+    @staticmethod
+    def yearly(count: int | None = None, until: datetime | None = None) -> str:
+        """Create a yearly recurrence rule."""
+        rule = "RRULE:FREQ=YEARLY"
+        if count:
+            rule += f";COUNT={count}"
+        elif until:
+            rule += f";UNTIL={until.strftime('%Y%m%dT%H%M%SZ')}"
+        return rule
+
+    @staticmethod
+    def weekdays(count: int | None = None, until: datetime | None = None) -> str:
+        """Create a weekday (Mon-Fri) recurrence rule."""
+        return RecurrenceBuilder.weekly(["MO", "TU", "WE", "TH", "FR"], count, until)
 
 
 class SendEmailResult(BaseModel):
@@ -1272,6 +1358,7 @@ class GoogleWorkspaceBridge:
         description: str | None = None,
         location: str | None = None,
         attendees: list[str] | None = None,
+        recurrence_rule: str | None = None,
         context: Any = None,  # noqa: ARG002
     ) -> CreateEventResult:
         """
@@ -1284,6 +1371,12 @@ class GoogleWorkspaceBridge:
             description: Optional event description
             location: Optional event location
             attendees: Optional list of attendee email addresses
+            recurrence_rule: Optional RFC 5545 RRULE string for recurring events.
+                Use RecurrenceBuilder for common patterns:
+                - RecurrenceBuilder.daily() -> "RRULE:FREQ=DAILY"
+                - RecurrenceBuilder.weekly(["MO", "WE", "FR"])
+                - RecurrenceBuilder.monthly(15)
+                - RecurrenceBuilder.yearly()
             context: Ignored (kept for interface compatibility)
 
         Returns:
@@ -1304,6 +1397,8 @@ class GoogleWorkspaceBridge:
                 event_body["location"] = location
             if attendees:
                 event_body["attendees"] = [{"email": email} for email in attendees]
+            if recurrence_rule:
+                event_body["recurrence"] = [recurrence_rule]
 
             event: dict[str, Any] = (
                 self._calendar_service.events()
@@ -1335,6 +1430,7 @@ class GoogleWorkspaceBridge:
         description: str | None = None,
         location: str | None = None,
         attendees: list[str] | None = None,
+        recurrence_rule: str | None = None,
         context: Any = None,  # noqa: ARG002
     ) -> UpdateEventResult:
         """
@@ -1350,6 +1446,8 @@ class GoogleWorkspaceBridge:
             description: New event description (optional)
             location: New event location (optional)
             attendees: New list of attendee email addresses (optional)
+            recurrence_rule: New RFC 5545 RRULE string (optional).
+                Use RecurrenceBuilder for common patterns.
             context: Ignored (kept for interface compatibility)
 
         Returns:
@@ -1372,6 +1470,8 @@ class GoogleWorkspaceBridge:
                 event_body["location"] = location
             if attendees is not None:
                 event_body["attendees"] = [{"email": email} for email in attendees]
+            if recurrence_rule is not None:
+                event_body["recurrence"] = [recurrence_rule]
 
             event: dict[str, Any] = (
                 self._calendar_service.events()
@@ -1542,6 +1642,10 @@ class GoogleWorkspaceBridge:
                 start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
                 end = datetime.fromisoformat(end_str.replace("Z", "+00:00"))
 
+                # Extract recurrence info
+                recurrence = evt.get("recurrence", [])
+                recurrence_rule = recurrence[0] if recurrence else None
+
                 event = CalendarEvent(
                     id=evt.get("id", ""),
                     title=evt.get("summary", "(no title)"),
@@ -1554,6 +1658,8 @@ class GoogleWorkspaceBridge:
                     calendar_name=calendar_name,
                     event_type=evt.get("eventType"),  # "default", "outOfOffice", "focusTime", etc.
                     transparency=evt.get("transparency"),  # "opaque" (busy) or "transparent" (free)
+                    recurrence_rule=recurrence_rule,
+                    recurring_event_id=evt.get("recurringEventId"),
                 )
                 parsed.append(event)
 
@@ -1576,5 +1682,6 @@ __all__ = [
     "CreateEventResult",
     "EmailMessage",
     "GoogleWorkspaceBridge",
+    "RecurrenceBuilder",
     "SendEmailResult",
 ]

--- a/tests/unit/test_google_workspace.py
+++ b/tests/unit/test_google_workspace.py
@@ -1224,3 +1224,195 @@ class TestRateLimiting:
 
         # Bridge was started, semaphore should be created
         assert bridge._semaphore._value == 2
+
+
+# ===========================================================================
+# Recurring Events Tests
+# ===========================================================================
+
+
+class TestRecurrenceBuilder:
+    """Test RecurrenceBuilder for generating RFC 5545 RRULE strings."""
+
+    def test_daily_basic(self):
+        """Test daily recurrence rule."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.daily()
+        assert rule == "RRULE:FREQ=DAILY"
+
+    def test_daily_with_count(self):
+        """Test daily recurrence with occurrence count."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.daily(count=10)
+        assert rule == "RRULE:FREQ=DAILY;COUNT=10"
+
+    def test_daily_with_until(self):
+        """Test daily recurrence with end date."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        until = datetime(2026, 12, 31, 23, 59, 59)
+        rule = RecurrenceBuilder.daily(until=until)
+        assert rule == "RRULE:FREQ=DAILY;UNTIL=20261231T235959Z"
+
+    def test_weekly_basic(self):
+        """Test weekly recurrence rule."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.weekly()
+        assert rule == "RRULE:FREQ=WEEKLY"
+
+    def test_weekly_with_days(self):
+        """Test weekly recurrence on specific days."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.weekly(days=["MO", "WE", "FR"])
+        assert rule == "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
+
+    def test_weekly_with_days_and_count(self):
+        """Test weekly recurrence on specific days with count."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.weekly(days=["TU", "TH"], count=8)
+        assert rule == "RRULE:FREQ=WEEKLY;BYDAY=TU,TH;COUNT=8"
+
+    def test_monthly_basic(self):
+        """Test monthly recurrence rule."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.monthly()
+        assert rule == "RRULE:FREQ=MONTHLY"
+
+    def test_monthly_with_day(self):
+        """Test monthly recurrence on specific day of month."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.monthly(day_of_month=15)
+        assert rule == "RRULE:FREQ=MONTHLY;BYMONTHDAY=15"
+
+    def test_yearly_basic(self):
+        """Test yearly recurrence rule."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.yearly()
+        assert rule == "RRULE:FREQ=YEARLY"
+
+    def test_yearly_with_count(self):
+        """Test yearly recurrence with count."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.yearly(count=5)
+        assert rule == "RRULE:FREQ=YEARLY;COUNT=5"
+
+    def test_weekdays(self):
+        """Test weekdays (Mon-Fri) recurrence."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        rule = RecurrenceBuilder.weekdays()
+        assert rule == "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+
+
+class TestRecurringCalendarEvents:
+    """Test calendar operations with recurrence."""
+
+    @pytest.mark.asyncio
+    async def test_create_recurring_event(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test creating a recurring event."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        mock_calendar_service.events.return_value.insert.return_value.execute.return_value = {
+            "id": "recurring-event-123",
+            "htmlLink": "https://calendar.google.com/event/123",
+            "recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        result = await bridge.create_event(
+            title="Weekly Standup",
+            start=datetime(2026, 1, 20, 9, 0),
+            end=datetime(2026, 1, 20, 9, 30),
+            recurrence_rule=RecurrenceBuilder.weekly(["MO", "WE", "FR"]),
+        )
+
+        assert result.success is True
+        assert result.event_id == "recurring-event-123"
+
+        # Verify the API was called with recurrence
+        call_args = mock_calendar_service.events.return_value.insert.call_args
+        body = call_args[1]["body"]
+        assert "recurrence" in body
+        assert body["recurrence"] == ["RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"]
+
+    @pytest.mark.asyncio
+    async def test_parse_recurring_event(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test parsing a recurring event from API response."""
+        mock_calendar_service.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "id": "recurring-event-456",
+                    "summary": "Daily Standup",
+                    "start": {"dateTime": "2026-01-20T09:00:00Z"},
+                    "end": {"dateTime": "2026-01-20T09:30:00Z"},
+                    "recurrence": ["RRULE:FREQ=DAILY"],
+                },
+                {
+                    "id": "instance-789",
+                    "summary": "Daily Standup",
+                    "start": {"dateTime": "2026-01-21T09:00:00Z"},
+                    "end": {"dateTime": "2026-01-21T09:30:00Z"},
+                    "recurringEventId": "recurring-event-456",
+                },
+            ]
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        events = await bridge.list_events(
+            start=datetime(2026, 1, 20),
+            end=datetime(2026, 1, 22),
+        )
+
+        assert len(events) == 2
+        # First event is the recurring event definition
+        assert events[0].recurrence_rule == "RRULE:FREQ=DAILY"
+        assert events[0].recurring_event_id is None
+        # Second event is an instance of the recurring event
+        assert events[1].recurrence_rule is None
+        assert events[1].recurring_event_id == "recurring-event-456"
+
+    @pytest.mark.asyncio
+    async def test_update_recurring_event(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test updating a recurring event's recurrence pattern."""
+        from klabautermann.mcp.google_workspace import RecurrenceBuilder
+
+        mock_calendar_service.events.return_value.patch.return_value.execute.return_value = {
+            "id": "recurring-event-123",
+            "htmlLink": "https://calendar.google.com/event/123",
+            "recurrence": ["RRULE:FREQ=DAILY"],
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        result = await bridge.update_event(
+            event_id="recurring-event-123",
+            recurrence_rule=RecurrenceBuilder.daily(),
+        )
+
+        assert result.success is True
+
+        # Verify the API was called with recurrence
+        call_args = mock_calendar_service.events.return_value.patch.call_args
+        body = call_args[1]["body"]
+        assert "recurrence" in body
+        assert body["recurrence"] == ["RRULE:FREQ=DAILY"]


### PR DESCRIPTION
## Summary

Implements recurring calendar events support for create, update, and query operations.

### Changes

**New RecurrenceBuilder Helper Class:**
- `daily(count, until)` - Daily recurrence
- `weekly(days, count, until)` - Weekly recurrence on specific days
- `monthly(day_of_month, count, until)` - Monthly recurrence
- `yearly(count, until)` - Yearly recurrence
- `weekdays(count, until)` - Mon-Fri workday recurrence

**Enhanced CalendarEvent Model:**
- `recurrence_rule: str | None` - RFC 5545 RRULE string
- `recurring_event_id: str | None` - Parent event ID for instances

**Updated Methods:**
- `create_event()` now accepts `recurrence_rule` parameter
- `update_event()` now accepts `recurrence_rule` parameter
- Event parsing extracts recurrence info from API responses

## Example Usage

```python
from klabautermann.mcp.google_workspace import RecurrenceBuilder

# Daily standup
result = await bridge.create_event(
    title="Daily Standup",
    start=datetime(2026, 1, 20, 9, 0),
    end=datetime(2026, 1, 20, 9, 30),
    recurrence_rule=RecurrenceBuilder.weekdays(),  # Mon-Fri
)

# Weekly team meeting
result = await bridge.create_event(
    title="Team Meeting",
    start=datetime(2026, 1, 20, 14, 0),
    end=datetime(2026, 1, 20, 15, 0),
    recurrence_rule=RecurrenceBuilder.weekly(["TU", "TH"]),
)
```

## Test plan

- [x] All 1519 unit tests pass (14 new tests for recurrence)
- [x] RecurrenceBuilder generates valid RFC 5545 RRULE strings
- [x] Linting passes (ruff check)
- [x] Type checking passes (mypy)
- [x] Pre-commit hooks pass

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)