### PR TITLE
feat(mcp): Add email attachments and filesystem MCP server (#208, #213)

### DIFF
--- a/src/klabautermann/mcp/__init__.py
+++ b/src/klabautermann/mcp/__init__.py
@@ -3,17 +3,21 @@ MCP module - Model Context Protocol integration.
 
 Contains:
 - client: MCP client wrapper for external tool execution
-- google_workspace: Gmail and Calendar integration via MCP
+- google_workspace: Gmail and Calendar integration via direct API
+- filesystem: Filesystem operations via MCP server
 
-Supported MCP servers (Sprint 2+):
-- Gmail: Email reading and sending
-- Google Calendar: Event management
-- Filesystem: Local file operations
+Supported MCP servers:
+- Filesystem: Local file operations with sandboxed access
 """
 
+from klabautermann.mcp.filesystem import (
+    FilesystemBridge,
+    FilesystemConfig,
+)
 from klabautermann.mcp.google_workspace import (
     CalendarEvent,
     CreateEventResult,
+    EmailAttachment,
     EmailMessage,
     GoogleWorkspaceBridge,
     SendEmailResult,
@@ -23,7 +27,10 @@ from klabautermann.mcp.google_workspace import (
 __all__ = [
     "CalendarEvent",
     "CreateEventResult",
+    "EmailAttachment",
     "EmailMessage",
+    "FilesystemBridge",
+    "FilesystemConfig",
     "GoogleWorkspaceBridge",
     "SendEmailResult",
 ]

--- a/src/klabautermann/mcp/filesystem.py
+++ b/src/klabautermann/mcp/filesystem.py
@@ -1,0 +1,453 @@
+"""
+Filesystem Bridge - MCP server integration for local file operations.
+
+Wraps the @modelcontextprotocol/server-filesystem MCP server to provide
+secure, sandboxed file operations within configured allowed paths.
+
+Reference: specs/architecture/MCP.md Section 3
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from klabautermann.core.exceptions import MCPError
+from klabautermann.core.logger import logger
+from klabautermann.mcp.client import MCPClient, MCPServerConfig, ToolInvocationContext
+
+
+# ===========================================================================
+# Configuration
+# ===========================================================================
+
+
+@dataclass
+class FilesystemConfig:
+    """
+    Configuration for filesystem MCP server.
+
+    Attributes:
+        allowed_paths: List of directories the server can access.
+                      Files outside these paths will be rejected.
+        timeout: Timeout for filesystem operations in seconds.
+    """
+
+    allowed_paths: list[str] = field(default_factory=list)
+    timeout: float = 30.0
+
+    def __post_init__(self) -> None:
+        """Validate and resolve allowed paths."""
+        if not self.allowed_paths:
+            # Default to current working directory
+            self.allowed_paths = [str(Path.cwd())]
+
+        # Resolve all paths to absolute
+        self.allowed_paths = [str(Path(p).resolve()) for p in self.allowed_paths]
+
+
+# ===========================================================================
+# Filesystem Bridge
+# ===========================================================================
+
+
+class FilesystemBridge:
+    """
+    Bridge to filesystem operations via MCP server.
+
+    Provides sandboxed file read/write operations through the
+    @modelcontextprotocol/server-filesystem MCP server.
+
+    Example:
+        config = FilesystemConfig(allowed_paths=["/app/data", "/app/attachments"])
+        bridge = FilesystemBridge(config)
+        await bridge.start()
+
+        # Read a file
+        content = await bridge.read_file("/app/data/notes.txt", context)
+
+        # Write a file
+        await bridge.write_file("/app/attachments/report.pdf", data, context)
+
+        await bridge.stop()
+
+    Security:
+        - Only paths within allowed_paths can be accessed
+        - Attempts to escape via symlinks or .. are blocked by the MCP server
+    """
+
+    SERVER_NAME = "filesystem"
+
+    def __init__(self, config: FilesystemConfig | None = None) -> None:
+        """
+        Initialize the filesystem bridge.
+
+        Args:
+            config: Filesystem configuration. If None, uses defaults.
+        """
+        self.config = config or FilesystemConfig()
+        self._client = MCPClient()
+        self._started = False
+
+    async def start(self) -> None:
+        """
+        Start the filesystem MCP server.
+
+        Raises:
+            MCPError: If server fails to start.
+        """
+        if self._started:
+            return
+
+        # Build MCP server config
+        # The filesystem server expects allowed directories as arguments
+        command = [
+            "npx",
+            "-y",
+            "@modelcontextprotocol/server-filesystem",
+            *self.config.allowed_paths,
+        ]
+
+        server_config = MCPServerConfig(
+            name=self.SERVER_NAME,
+            command=command,
+            timeout=self.config.timeout,
+        )
+
+        await self._client.start_server(server_config)
+        self._started = True
+
+        logger.info(
+            "[CHART] Filesystem MCP server started",
+            extra={"allowed_paths": self.config.allowed_paths},
+        )
+
+    async def stop(self) -> None:
+        """Stop the filesystem MCP server."""
+        if self._started:
+            await self._client.stop_all()
+            self._started = False
+            logger.info("[CHART] Filesystem MCP server stopped")
+
+    async def read_file(
+        self,
+        path: str,
+        context: ToolInvocationContext,
+    ) -> str:
+        """
+        Read a text file's contents.
+
+        Args:
+            path: Absolute path to the file (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Returns:
+            File contents as string
+
+        Raises:
+            MCPError: If read fails or path is not allowed
+        """
+        await self.start()
+
+        result = await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "read_file",
+            {"path": path},
+            context,
+        )
+
+        # MCP server returns content in result
+        content: str = result.get("content", [{}])[0].get("text", "")
+
+        logger.debug(
+            f"[WHISPER] File read: {path}",
+            extra={"trace_id": context.trace_id, "size": len(content)},
+        )
+
+        return content
+
+    async def read_file_bytes(
+        self,
+        path: str,
+        context: ToolInvocationContext,
+    ) -> bytes:
+        """
+        Read a binary file's contents.
+
+        Args:
+            path: Absolute path to the file (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Returns:
+            File contents as bytes
+
+        Raises:
+            MCPError: If read fails or path is not allowed
+        """
+        # For binary files, we read directly since MCP server may not handle binary well
+        await self.start()
+
+        # Validate path is within allowed paths
+        resolved_path = str(Path(path).resolve())
+        if not any(resolved_path.startswith(ap) for ap in self.config.allowed_paths):
+            raise MCPError(
+                f"Path not allowed: {path}",
+                trace_id=context.trace_id,
+            )
+
+        try:
+            data = Path(path).read_bytes()
+
+            logger.debug(
+                f"[WHISPER] Binary file read: {path}",
+                extra={"trace_id": context.trace_id, "size": len(data)},
+            )
+
+            return data
+        except OSError as e:
+            raise MCPError(
+                f"Failed to read file: {e}",
+                trace_id=context.trace_id,
+            ) from e
+
+    async def write_file(
+        self,
+        path: str,
+        content: str,
+        context: ToolInvocationContext,
+    ) -> None:
+        """
+        Write text content to a file.
+
+        Args:
+            path: Absolute path to the file (must be within allowed_paths)
+            content: Text content to write
+            context: Invocation context with trace_id
+
+        Raises:
+            MCPError: If write fails or path is not allowed
+        """
+        await self.start()
+
+        await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "write_file",
+            {"path": path, "content": content},
+            context,
+        )
+
+        logger.info(
+            f"[BEACON] File written: {path}",
+            extra={"trace_id": context.trace_id, "size": len(content)},
+        )
+
+    async def write_file_bytes(
+        self,
+        path: str,
+        data: bytes,
+        context: ToolInvocationContext,
+    ) -> None:
+        """
+        Write binary data to a file.
+
+        Args:
+            path: Absolute path to the file (must be within allowed_paths)
+            data: Binary data to write
+            context: Invocation context with trace_id
+
+        Raises:
+            MCPError: If write fails or path is not allowed
+        """
+        await self.start()
+
+        # Validate path is within allowed paths
+        resolved_path = str(Path(path).resolve())
+        if not any(resolved_path.startswith(ap) for ap in self.config.allowed_paths):
+            raise MCPError(
+                f"Path not allowed: {path}",
+                trace_id=context.trace_id,
+            )
+
+        try:
+            # Ensure directory exists
+            file_path = Path(path)
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+
+            file_path.write_bytes(data)
+
+            logger.info(
+                f"[BEACON] Binary file written: {path}",
+                extra={"trace_id": context.trace_id, "size": len(data)},
+            )
+        except OSError as e:
+            raise MCPError(
+                f"Failed to write file: {e}",
+                trace_id=context.trace_id,
+            ) from e
+
+    async def list_directory(
+        self,
+        path: str,
+        context: ToolInvocationContext,
+    ) -> list[dict[str, Any]]:
+        """
+        List contents of a directory.
+
+        Args:
+            path: Absolute path to the directory (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Returns:
+            List of entries with name, type (file/directory), and size
+
+        Raises:
+            MCPError: If listing fails or path is not allowed
+        """
+        await self.start()
+
+        result = await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "list_directory",
+            {"path": path},
+            context,
+        )
+
+        # Parse result - MCP server returns entries in content
+        entries: list[dict[str, Any]] = []
+        content = result.get("content", [])
+        if content and isinstance(content[0].get("text"), str):
+            # Parse text listing into structured data
+            for line in content[0]["text"].strip().split("\n"):
+                if line:
+                    # Format: [DIR] name or [FILE] name (size)
+                    if line.startswith("[DIR]"):
+                        name = line[6:].strip()
+                        entries.append({"name": name, "type": "directory", "size": 0})
+                    elif line.startswith("[FILE]"):
+                        # Extract name and optional size
+                        parts = line[7:].strip()
+                        name = parts.split(" (")[0] if " (" in parts else parts
+                        entries.append({"name": name, "type": "file", "size": 0})
+
+        logger.debug(
+            f"[WHISPER] Directory listed: {path}",
+            extra={"trace_id": context.trace_id, "entries": len(entries)},
+        )
+
+        return entries
+
+    async def create_directory(
+        self,
+        path: str,
+        context: ToolInvocationContext,
+    ) -> None:
+        """
+        Create a directory (including parent directories).
+
+        Args:
+            path: Absolute path for the new directory (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Raises:
+            MCPError: If creation fails or path is not allowed
+        """
+        await self.start()
+
+        await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "create_directory",
+            {"path": path},
+            context,
+        )
+
+        logger.info(
+            f"[BEACON] Directory created: {path}",
+            extra={"trace_id": context.trace_id},
+        )
+
+    async def move_file(
+        self,
+        source: str,
+        destination: str,
+        context: ToolInvocationContext,
+    ) -> None:
+        """
+        Move or rename a file.
+
+        Args:
+            source: Source file path (must be within allowed_paths)
+            destination: Destination path (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Raises:
+            MCPError: If move fails or paths are not allowed
+        """
+        await self.start()
+
+        await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "move_file",
+            {"source": source, "destination": destination},
+            context,
+        )
+
+        logger.info(
+            f"[BEACON] File moved: {source} -> {destination}",
+            extra={"trace_id": context.trace_id},
+        )
+
+    async def get_file_info(
+        self,
+        path: str,
+        context: ToolInvocationContext,
+    ) -> dict[str, Any]:
+        """
+        Get file metadata (size, modified time, etc.).
+
+        Args:
+            path: Absolute path to the file (must be within allowed_paths)
+            context: Invocation context with trace_id
+
+        Returns:
+            Dict with file metadata (size, modified, created, is_file, is_directory)
+
+        Raises:
+            MCPError: If path is not allowed or doesn't exist
+        """
+        await self.start()
+
+        result = await self._client.invoke_tool(
+            self.SERVER_NAME,
+            "get_file_info",
+            {"path": path},
+            context,
+        )
+
+        # Parse result
+        info: dict[str, Any] = {}
+        content = result.get("content", [])
+        if content and isinstance(content[0].get("text"), str):
+            # Parse the text response into structured data
+            text = content[0]["text"]
+            for line in text.strip().split("\n"):
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    info[key.strip().lower().replace(" ", "_")] = value.strip()
+
+        logger.debug(
+            f"[WHISPER] File info: {path}",
+            extra={"trace_id": context.trace_id},
+        )
+
+        return info
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "FilesystemBridge",
+    "FilesystemConfig",
+]

--- a/src/klabautermann/mcp/google_workspace.py
+++ b/src/klabautermann/mcp/google_workspace.py
@@ -41,6 +41,25 @@ T = TypeVar("T")
 # ===========================================================================
 
 
+class EmailAttachment(BaseModel):
+    """Email attachment metadata from Gmail."""
+
+    attachment_id: str  # Gmail's internal attachment ID for downloading
+    filename: str
+    mime_type: str
+    size: int  # Size in bytes
+
+    @property
+    def size_human(self) -> str:
+        """Human-readable file size."""
+        if self.size < 1024:
+            return f"{self.size} B"
+        elif self.size < 1024 * 1024:
+            return f"{self.size / 1024:.1f} KB"
+        else:
+            return f"{self.size / (1024 * 1024):.1f} MB"
+
+
 class EmailMessage(BaseModel):
     """Parsed email message from Gmail."""
 
@@ -53,6 +72,12 @@ class EmailMessage(BaseModel):
     snippet: str
     body: str | None = None
     is_unread: bool = False
+    attachments: list[EmailAttachment] = Field(default_factory=list)
+
+    @property
+    def has_attachments(self) -> bool:
+        """Check if email has attachments."""
+        return len(self.attachments) > 0
 
 
 class CalendarEvent(BaseModel):
@@ -912,6 +937,111 @@ class GoogleWorkspaceBridge:
         query = f"newer_than:{hours}h"
         return await self.search_emails(query, max_results=50)
 
+    async def download_attachment(
+        self,
+        message_id: str,
+        attachment_id: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> bytes:
+        """
+        Download an email attachment's raw bytes.
+
+        Args:
+            message_id: Gmail message ID containing the attachment
+            attachment_id: Attachment ID from EmailAttachment.attachment_id
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            Raw attachment bytes
+
+        Raises:
+            ExternalServiceError: If download fails
+        """
+        await self.start()
+
+        def do_download() -> bytes:
+            attachment = (
+                self._gmail_service.users()
+                .messages()
+                .attachments()
+                .get(userId="me", messageId=message_id, id=attachment_id)
+                .execute()
+            )
+            data = attachment.get("data", "")
+            return base64.urlsafe_b64decode(data)
+
+        try:
+            return await self._rate_limited_call("gmail", do_download)
+        except HttpError as e:
+            logger.error(
+                f"[STORM] Attachment download failed: {e}",
+                extra={"message_id": message_id, "attachment_id": attachment_id},
+            )
+            raise ExternalServiceError("gmail", f"Attachment download failed: {e}") from e
+
+    async def save_attachment(
+        self,
+        message_id: str,
+        attachment: EmailAttachment,
+        save_path: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> str:
+        """
+        Download and save an attachment to the local filesystem.
+
+        Args:
+            message_id: Gmail message ID containing the attachment
+            attachment: EmailAttachment object with attachment metadata
+            save_path: Directory path where the attachment should be saved
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            Full path to the saved file
+
+        Raises:
+            ExternalServiceError: If download or save fails
+        """
+        from pathlib import Path as FilePath
+
+        # Download attachment bytes
+        data = await self.download_attachment(message_id, attachment.attachment_id)
+
+        # Ensure save directory exists
+        save_dir = FilePath(save_path)
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build full file path
+        file_path = save_dir / attachment.filename
+
+        # Handle duplicate filenames
+        if file_path.exists():
+            base = FilePath(attachment.filename).stem
+            ext = FilePath(attachment.filename).suffix
+            counter = 1
+            while file_path.exists():
+                file_path = save_dir / f"{base}_{counter}{ext}"
+                counter += 1
+
+        # Save to filesystem
+        try:
+            file_path.write_bytes(data)
+
+            logger.info(
+                f"[BEACON] Attachment saved: {file_path}",
+                extra={
+                    "message_id": message_id,
+                    "attachment_filename": attachment.filename,
+                    "attachment_size": len(data),
+                },
+            )
+            return str(file_path)
+        except OSError as e:
+            logger.error(
+                f"[STORM] Failed to save attachment: {e}",
+                extra={"file_path": str(file_path)},
+            )
+            raise ExternalServiceError("filesystem", f"Failed to save attachment: {e}") from e
+
     # ===========================================================================
     # Email Management Operations
     # ===========================================================================
@@ -1574,18 +1704,15 @@ class GoogleWorkspaceBridge:
                 except Exception:
                     date = datetime.now()
 
-                # Extract body
+                # Extract body and attachments
                 body = None
+                attachments: list[EmailAttachment] = []
                 payload = msg.get("payload", {})
+
                 if "body" in payload and payload["body"].get("data"):
                     body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8")
                 elif "parts" in payload:
-                    for part in payload["parts"]:
-                        if part.get("mimeType") == "text/plain" and part.get("body", {}).get(
-                            "data"
-                        ):
-                            body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8")
-                            break
+                    body, attachments = self._extract_parts(payload["parts"])
 
                 email = EmailMessage(
                     id=msg.get("id", ""),
@@ -1597,6 +1724,7 @@ class GoogleWorkspaceBridge:
                     snippet=msg.get("snippet", ""),
                     body=body,
                     is_unread="UNREAD" in msg.get("labelIds", []),
+                    attachments=attachments,
                 )
                 parsed.append(email)
 
@@ -1608,6 +1736,50 @@ class GoogleWorkspaceBridge:
                 continue
 
         return parsed
+
+    def _extract_parts(
+        self, parts: list[dict[str, Any]]
+    ) -> tuple[str | None, list[EmailAttachment]]:
+        """
+        Recursively extract body text and attachments from email parts.
+
+        Args:
+            parts: List of MIME parts from Gmail API
+
+        Returns:
+            Tuple of (body_text, attachments_list)
+        """
+        body = None
+        attachments: list[EmailAttachment] = []
+
+        for part in parts:
+            mime_type = part.get("mimeType", "")
+            filename = part.get("filename", "")
+            part_body = part.get("body", {})
+
+            # Check for nested multipart
+            if "parts" in part:
+                nested_body, nested_attachments = self._extract_parts(part["parts"])
+                if nested_body and not body:
+                    body = nested_body
+                attachments.extend(nested_attachments)
+
+            # Check for text body
+            elif mime_type == "text/plain" and part_body.get("data") and not filename:
+                if not body:  # Only take first text/plain
+                    body = base64.urlsafe_b64decode(part_body["data"]).decode("utf-8")
+
+            # Check for attachments (has filename and attachmentId)
+            elif filename and part_body.get("attachmentId"):
+                attachment = EmailAttachment(
+                    attachment_id=part_body["attachmentId"],
+                    filename=filename,
+                    mime_type=mime_type,
+                    size=part_body.get("size", 0),
+                )
+                attachments.append(attachment)
+
+        return body, attachments
 
     def _parse_calendar_events(
         self,
@@ -1680,6 +1852,7 @@ class GoogleWorkspaceBridge:
 __all__ = [
     "CalendarEvent",
     "CreateEventResult",
+    "EmailAttachment",
     "EmailMessage",
     "GoogleWorkspaceBridge",
     "RecurrenceBuilder",

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -1,0 +1,346 @@
+"""
+Unit tests for Filesystem Bridge.
+
+Tests the MCP-based filesystem operations using mocking.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klabautermann.core.exceptions import MCPError
+from klabautermann.mcp.client import ToolInvocationContext
+from klabautermann.mcp.filesystem import FilesystemBridge, FilesystemConfig
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def context():
+    """Create a test invocation context."""
+    return ToolInvocationContext(
+        trace_id="test-trace-123",
+        agent_name="test-agent",
+        thread_id="thread-456",
+    )
+
+
+@pytest.fixture
+def mock_mcp_client():
+    """Create a mock MCP client."""
+    with patch("klabautermann.mcp.filesystem.MCPClient") as mock_class:
+        mock_client = MagicMock()
+        mock_client.start_server = AsyncMock()
+        mock_client.stop_all = AsyncMock()
+        mock_client.invoke_tool = AsyncMock()
+        mock_class.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def bridge(mock_mcp_client):
+    """Create a FilesystemBridge with mock client."""
+    config = FilesystemConfig(allowed_paths=["/app/data", "/app/attachments"])
+    return FilesystemBridge(config)
+
+
+# ===========================================================================
+# Configuration Tests
+# ===========================================================================
+
+
+class TestFilesystemConfig:
+    """Test FilesystemConfig initialization."""
+
+    def test_default_config(self):
+        """Test default configuration uses current directory."""
+        config = FilesystemConfig()
+        assert len(config.allowed_paths) == 1
+        assert config.allowed_paths[0] == str(Path.cwd().resolve())
+
+    def test_custom_allowed_paths(self):
+        """Test custom allowed paths are resolved to absolute."""
+        config = FilesystemConfig(allowed_paths=["/tmp", "/home/user"])
+        assert "/tmp" in config.allowed_paths
+        assert "/home/user" in config.allowed_paths
+
+    def test_relative_paths_resolved(self, tmp_path):
+        """Test relative paths are converted to absolute."""
+        config = FilesystemConfig(allowed_paths=["./data"])
+        # All paths should be absolute
+        for path in config.allowed_paths:
+            assert Path(path).is_absolute()
+
+    def test_timeout_default(self):
+        """Test default timeout value."""
+        config = FilesystemConfig()
+        assert config.timeout == 30.0
+
+    def test_custom_timeout(self):
+        """Test custom timeout configuration."""
+        config = FilesystemConfig(timeout=60.0)
+        assert config.timeout == 60.0
+
+
+# ===========================================================================
+# Lifecycle Tests
+# ===========================================================================
+
+
+class TestFilesystemBridgeLifecycle:
+    """Test bridge initialization and lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_start_creates_server(self, bridge, mock_mcp_client):
+        """Test starting creates MCP server with correct config."""
+        await bridge.start()
+
+        mock_mcp_client.start_server.assert_called_once()
+        config = mock_mcp_client.start_server.call_args[0][0]
+        assert config.name == "filesystem"
+        assert "npx" in config.command
+        assert "@modelcontextprotocol/server-filesystem" in config.command
+        assert "/app/data" in config.command
+        assert "/app/attachments" in config.command
+
+    @pytest.mark.asyncio
+    async def test_start_idempotent(self, bridge, mock_mcp_client):
+        """Test starting multiple times is safe."""
+        await bridge.start()
+        await bridge.start()
+
+        assert mock_mcp_client.start_server.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_stops_server(self, bridge, mock_mcp_client):
+        """Test stopping stops the MCP server."""
+        await bridge.start()
+        await bridge.stop()
+
+        mock_mcp_client.stop_all.assert_called_once()
+        assert bridge._started is False
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start(self, bridge, mock_mcp_client):
+        """Test stopping without starting is safe."""
+        await bridge.stop()
+
+        mock_mcp_client.stop_all.assert_not_called()
+
+
+# ===========================================================================
+# Read Operations Tests
+# ===========================================================================
+
+
+class TestReadOperations:
+    """Test file read operations."""
+
+    @pytest.mark.asyncio
+    async def test_read_file_success(self, bridge, mock_mcp_client, context):
+        """Test successful file read."""
+        mock_mcp_client.invoke_tool.return_value = {"content": [{"text": "Hello, World!"}]}
+
+        content = await bridge.read_file("/app/data/test.txt", context)
+
+        assert content == "Hello, World!"
+        mock_mcp_client.invoke_tool.assert_called_once_with(
+            "filesystem",
+            "read_file",
+            {"path": "/app/data/test.txt"},
+            context,
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_file_auto_starts(self, bridge, mock_mcp_client, context):
+        """Test read_file auto-starts the server."""
+        mock_mcp_client.invoke_tool.return_value = {"content": [{"text": "content"}]}
+
+        await bridge.read_file("/app/data/test.txt", context)
+
+        mock_mcp_client.start_server.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_read_file_bytes_validates_path(self, bridge, mock_mcp_client, context):
+        """Test read_file_bytes validates path against allowed paths."""
+        with pytest.raises(MCPError, match="Path not allowed"):
+            await bridge.read_file_bytes("/etc/passwd", context)
+
+    @pytest.mark.asyncio
+    async def test_read_file_bytes_success(self, bridge, mock_mcp_client, context, tmp_path):
+        """Test successful binary file read."""
+        # Create a test file
+        test_file = tmp_path / "data" / "test.bin"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_bytes(b"\x00\x01\x02\x03")
+
+        # Configure bridge with tmp_path
+        bridge.config.allowed_paths = [str(tmp_path)]
+
+        data = await bridge.read_file_bytes(str(test_file), context)
+
+        assert data == b"\x00\x01\x02\x03"
+
+
+# ===========================================================================
+# Write Operations Tests
+# ===========================================================================
+
+
+class TestWriteOperations:
+    """Test file write operations."""
+
+    @pytest.mark.asyncio
+    async def test_write_file_success(self, bridge, mock_mcp_client, context):
+        """Test successful file write."""
+        mock_mcp_client.invoke_tool.return_value = {}
+
+        await bridge.write_file("/app/data/output.txt", "test content", context)
+
+        mock_mcp_client.invoke_tool.assert_called_once_with(
+            "filesystem",
+            "write_file",
+            {"path": "/app/data/output.txt", "content": "test content"},
+            context,
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_file_bytes_validates_path(self, bridge, mock_mcp_client, context):
+        """Test write_file_bytes validates path against allowed paths."""
+        with pytest.raises(MCPError, match="Path not allowed"):
+            await bridge.write_file_bytes("/etc/passwd", b"data", context)
+
+    @pytest.mark.asyncio
+    async def test_write_file_bytes_success(self, bridge, mock_mcp_client, context, tmp_path):
+        """Test successful binary file write."""
+        # Configure bridge with tmp_path
+        bridge.config.allowed_paths = [str(tmp_path)]
+
+        test_file = tmp_path / "output.bin"
+        await bridge.write_file_bytes(str(test_file), b"\x00\x01\x02\x03", context)
+
+        assert test_file.read_bytes() == b"\x00\x01\x02\x03"
+
+    @pytest.mark.asyncio
+    async def test_write_file_bytes_creates_directories(
+        self, bridge, mock_mcp_client, context, tmp_path
+    ):
+        """Test write_file_bytes creates parent directories."""
+        bridge.config.allowed_paths = [str(tmp_path)]
+
+        test_file = tmp_path / "nested" / "dirs" / "output.bin"
+        await bridge.write_file_bytes(str(test_file), b"data", context)
+
+        assert test_file.exists()
+        assert test_file.read_bytes() == b"data"
+
+
+# ===========================================================================
+# Directory Operations Tests
+# ===========================================================================
+
+
+class TestDirectoryOperations:
+    """Test directory operations."""
+
+    @pytest.mark.asyncio
+    async def test_list_directory(self, bridge, mock_mcp_client, context):
+        """Test listing directory contents."""
+        mock_mcp_client.invoke_tool.return_value = {
+            "content": [{"text": "[DIR] subdir\n[FILE] file.txt"}]
+        }
+
+        entries = await bridge.list_directory("/app/data", context)
+
+        assert len(entries) == 2
+        assert entries[0]["name"] == "subdir"
+        assert entries[0]["type"] == "directory"
+        assert entries[1]["name"] == "file.txt"
+        assert entries[1]["type"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_create_directory(self, bridge, mock_mcp_client, context):
+        """Test creating a directory."""
+        mock_mcp_client.invoke_tool.return_value = {}
+
+        await bridge.create_directory("/app/data/new_folder", context)
+
+        mock_mcp_client.invoke_tool.assert_called_once_with(
+            "filesystem",
+            "create_directory",
+            {"path": "/app/data/new_folder"},
+            context,
+        )
+
+
+# ===========================================================================
+# File Operations Tests
+# ===========================================================================
+
+
+class TestFileOperations:
+    """Test file manipulation operations."""
+
+    @pytest.mark.asyncio
+    async def test_move_file(self, bridge, mock_mcp_client, context):
+        """Test moving a file."""
+        mock_mcp_client.invoke_tool.return_value = {}
+
+        await bridge.move_file("/app/data/old.txt", "/app/data/new.txt", context)
+
+        mock_mcp_client.invoke_tool.assert_called_once_with(
+            "filesystem",
+            "move_file",
+            {"source": "/app/data/old.txt", "destination": "/app/data/new.txt"},
+            context,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_file_info(self, bridge, mock_mcp_client, context):
+        """Test getting file metadata."""
+        mock_mcp_client.invoke_tool.return_value = {
+            "content": [{"text": "size: 1024\nmodified: 2024-01-15T10:00:00"}]
+        }
+
+        info = await bridge.get_file_info("/app/data/test.txt", context)
+
+        assert "size" in info
+        assert "modified" in info
+        mock_mcp_client.invoke_tool.assert_called_once_with(
+            "filesystem",
+            "get_file_info",
+            {"path": "/app/data/test.txt"},
+            context,
+        )
+
+
+# ===========================================================================
+# Error Handling Tests
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Test error handling scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_read_file_propagates_mcp_error(self, bridge, mock_mcp_client, context):
+        """Test that MCP errors are propagated."""
+        mock_mcp_client.invoke_tool.side_effect = MCPError("File not found")
+
+        with pytest.raises(MCPError, match="File not found"):
+            await bridge.read_file("/app/data/missing.txt", context)
+
+    @pytest.mark.asyncio
+    async def test_write_file_bytes_handles_os_error(
+        self, bridge, mock_mcp_client, context, tmp_path
+    ):
+        """Test that OS errors during binary write are handled."""
+        bridge.config.allowed_paths = [str(tmp_path)]
+
+        # Try to write to a directory path (should fail)
+        with pytest.raises(MCPError, match="Failed to write file"):
+            await bridge.write_file_bytes(str(tmp_path), b"data", context)

--- a/tests/unit/test_google_workspace.py
+++ b/tests/unit/test_google_workspace.py
@@ -7,6 +7,7 @@ Uses mocking for Google API services to test parsing and error handling logic.
 
 import base64
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1416,3 +1417,275 @@ class TestRecurringCalendarEvents:
         body = call_args[1]["body"]
         assert "recurrence" in body
         assert body["recurrence"] == ["RRULE:FREQ=DAILY"]
+
+
+# ===========================================================================
+# Email Attachment Tests
+# ===========================================================================
+
+
+class TestEmailAttachments:
+    """Test email attachment parsing and handling."""
+
+    @pytest.mark.asyncio
+    async def test_parse_email_with_attachments(self, bridge, mock_gmail_service):
+        """Test parsing email with attachments."""
+        mock_gmail_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "msg1"}]
+        }
+
+        # Email with multipart payload including attachment
+        mock_gmail_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+            "id": "msg1",
+            "threadId": "thread1",
+            "snippet": "Email with attachment",
+            "labelIds": [],
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": "Document attached"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Mon, 15 Jan 2024 10:30:00 +0000"},
+                ],
+                "parts": [
+                    {
+                        "mimeType": "text/plain",
+                        "body": {"data": base64.urlsafe_b64encode(b"See attached").decode()},
+                    },
+                    {
+                        "mimeType": "application/pdf",
+                        "filename": "report.pdf",
+                        "body": {"attachmentId": "attach-123", "size": 12345},
+                    },
+                ],
+            },
+        }
+
+        emails = await bridge.search_emails("test")
+
+        assert len(emails) == 1
+        assert emails[0].has_attachments is True
+        assert len(emails[0].attachments) == 1
+        assert emails[0].attachments[0].filename == "report.pdf"
+        assert emails[0].attachments[0].mime_type == "application/pdf"
+        assert emails[0].attachments[0].attachment_id == "attach-123"
+        assert emails[0].attachments[0].size == 12345
+        assert emails[0].body == "See attached"
+
+    @pytest.mark.asyncio
+    async def test_parse_email_multiple_attachments(self, bridge, mock_gmail_service):
+        """Test parsing email with multiple attachments."""
+        mock_gmail_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "msg1"}]
+        }
+
+        mock_gmail_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+            "id": "msg1",
+            "threadId": "thread1",
+            "snippet": "Multiple attachments",
+            "labelIds": [],
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": "Files"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Mon, 15 Jan 2024 10:30:00 +0000"},
+                ],
+                "parts": [
+                    {
+                        "mimeType": "text/plain",
+                        "body": {"data": base64.urlsafe_b64encode(b"Body text").decode()},
+                    },
+                    {
+                        "mimeType": "image/png",
+                        "filename": "screenshot.png",
+                        "body": {"attachmentId": "attach-1", "size": 50000},
+                    },
+                    {
+                        "mimeType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        "filename": "data.xlsx",
+                        "body": {"attachmentId": "attach-2", "size": 25000},
+                    },
+                ],
+            },
+        }
+
+        emails = await bridge.search_emails("test")
+
+        assert len(emails) == 1
+        assert len(emails[0].attachments) == 2
+        assert emails[0].attachments[0].filename == "screenshot.png"
+        assert emails[0].attachments[1].filename == "data.xlsx"
+
+    @pytest.mark.asyncio
+    async def test_parse_email_nested_multipart(self, bridge, mock_gmail_service):
+        """Test parsing email with nested multipart structure."""
+        mock_gmail_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "msg1"}]
+        }
+
+        # Nested multipart structure (common with HTML emails)
+        mock_gmail_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+            "id": "msg1",
+            "threadId": "thread1",
+            "snippet": "Nested structure",
+            "labelIds": [],
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": "Nested email"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Mon, 15 Jan 2024 10:30:00 +0000"},
+                ],
+                "parts": [
+                    {
+                        "mimeType": "multipart/alternative",
+                        "parts": [
+                            {
+                                "mimeType": "text/plain",
+                                "body": {
+                                    "data": base64.urlsafe_b64encode(b"Plain text body").decode()
+                                },
+                            },
+                            {
+                                "mimeType": "text/html",
+                                "body": {
+                                    "data": base64.urlsafe_b64encode(
+                                        b"<html><body>HTML body</body></html>"
+                                    ).decode()
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        "mimeType": "application/pdf",
+                        "filename": "doc.pdf",
+                        "body": {"attachmentId": "attach-nested", "size": 5000},
+                    },
+                ],
+            },
+        }
+
+        emails = await bridge.search_emails("test")
+
+        assert len(emails) == 1
+        assert emails[0].body == "Plain text body"
+        assert len(emails[0].attachments) == 1
+        assert emails[0].attachments[0].filename == "doc.pdf"
+
+    @pytest.mark.asyncio
+    async def test_parse_email_no_attachments(self, bridge, mock_gmail_service):
+        """Test parsing email without attachments."""
+        mock_gmail_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [{"id": "msg1"}]
+        }
+
+        mock_gmail_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+            "id": "msg1",
+            "threadId": "thread1",
+            "snippet": "Plain email",
+            "labelIds": [],
+            "payload": {
+                "headers": [
+                    {"name": "Subject", "value": "No attachment"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Mon, 15 Jan 2024 10:30:00 +0000"},
+                ],
+                "body": {"data": base64.urlsafe_b64encode(b"Just text").decode()},
+            },
+        }
+
+        emails = await bridge.search_emails("test")
+
+        assert len(emails) == 1
+        assert emails[0].has_attachments is False
+        assert len(emails[0].attachments) == 0
+
+    @pytest.mark.asyncio
+    async def test_download_attachment(self, bridge, mock_gmail_service):
+        """Test downloading attachment data."""
+        attachment_data = b"PDF binary content here"
+        mock_gmail_service.users.return_value.messages.return_value.attachments.return_value.get.return_value.execute.return_value = {
+            "data": base64.urlsafe_b64encode(attachment_data).decode()
+        }
+
+        result = await bridge.download_attachment("msg1", "attach-123")
+
+        assert result == attachment_data
+        mock_gmail_service.users.return_value.messages.return_value.attachments.return_value.get.assert_called_once_with(
+            userId="me", messageId="msg1", id="attach-123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_attachment(self, bridge, mock_gmail_service, tmp_path):
+        """Test saving attachment to filesystem."""
+        attachment_data = b"Test file content"
+        mock_gmail_service.users.return_value.messages.return_value.attachments.return_value.get.return_value.execute.return_value = {
+            "data": base64.urlsafe_b64encode(attachment_data).decode()
+        }
+
+        from klabautermann.mcp.google_workspace import EmailAttachment
+
+        attachment = EmailAttachment(
+            attachment_id="attach-123",
+            filename="test.txt",
+            mime_type="text/plain",
+            size=len(attachment_data),
+        )
+
+        save_path = str(tmp_path)
+        result = await bridge.save_attachment("msg1", attachment, save_path)
+
+        assert result.endswith("test.txt")
+        assert Path(result).read_bytes() == attachment_data
+
+    @pytest.mark.asyncio
+    async def test_save_attachment_duplicate_filename(self, bridge, mock_gmail_service, tmp_path):
+        """Test saving attachment with duplicate filename creates unique name."""
+        attachment_data = b"Test file content"
+        mock_gmail_service.users.return_value.messages.return_value.attachments.return_value.get.return_value.execute.return_value = {
+            "data": base64.urlsafe_b64encode(attachment_data).decode()
+        }
+
+        from klabautermann.mcp.google_workspace import EmailAttachment
+
+        # Create existing file
+        existing_file = tmp_path / "test.txt"
+        existing_file.write_bytes(b"existing content")
+
+        attachment = EmailAttachment(
+            attachment_id="attach-123",
+            filename="test.txt",
+            mime_type="text/plain",
+            size=len(attachment_data),
+        )
+
+        save_path = str(tmp_path)
+        result = await bridge.save_attachment("msg1", attachment, save_path)
+
+        # Should create test_1.txt since test.txt exists
+        assert "test_1.txt" in result
+
+    def test_attachment_size_human_bytes(self):
+        """Test human-readable size formatting for bytes."""
+        from klabautermann.mcp.google_workspace import EmailAttachment
+
+        attachment = EmailAttachment(
+            attachment_id="test", filename="small.txt", mime_type="text/plain", size=500
+        )
+        assert attachment.size_human == "500 B"
+
+    def test_attachment_size_human_kilobytes(self):
+        """Test human-readable size formatting for kilobytes."""
+        from klabautermann.mcp.google_workspace import EmailAttachment
+
+        attachment = EmailAttachment(
+            attachment_id="test", filename="medium.txt", mime_type="text/plain", size=2048
+        )
+        assert attachment.size_human == "2.0 KB"
+
+    def test_attachment_size_human_megabytes(self):
+        """Test human-readable size formatting for megabytes."""
+        from klabautermann.mcp.google_workspace import EmailAttachment
+
+        attachment = EmailAttachment(
+            attachment_id="test", filename="large.pdf", mime_type="application/pdf", size=5242880
+        )
+        assert attachment.size_human == "5.0 MB"


### PR DESCRIPTION
## Summary

- **Email Attachment Support (#208)**: Read attachments from emails, download and save to local storage
- **Filesystem MCP Server (#213)**: Wire the filesystem MCP server for sandboxed file operations

## Changes

### Email Attachments (#208)
- Added `EmailAttachment` model with `attachment_id`, `filename`, `mime_type`, `size`
- Added `has_attachments` property and `attachments` list to `EmailMessage`
- Implemented recursive `_extract_parts()` method for nested multipart email parsing
- Added `download_attachment()` method to get raw attachment bytes
- Added `save_attachment()` method to save to local filesystem with duplicate name handling
- Attachments are now parsed and included in email search results

### Filesystem MCP Server (#213)
- Created `FilesystemBridge` class wrapping `@modelcontextprotocol/server-filesystem`
- Added `FilesystemConfig` with `allowed_paths` and `timeout` configuration
- Implemented file operations:
  - `read_file()`, `read_file_bytes()` with path validation
  - `write_file()`, `write_file_bytes()` with automatic directory creation
  - `list_directory()`, `create_directory()`, `move_file()`, `get_file_info()`
- Path sandboxing enforced via MCP server and local validation

## Test plan

- [x] 10 new email attachment tests
  - Parsing single attachment
  - Parsing multiple attachments  
  - Parsing nested multipart structures
  - Downloading attachment bytes
  - Saving attachment to filesystem
  - Duplicate filename handling
  - Human-readable size formatting
- [x] 18 new filesystem tests
  - Configuration defaults and custom paths
  - Bridge lifecycle (start, stop, idempotency)
  - Read operations (text, binary, path validation)
  - Write operations (text, binary, directory creation)
  - Directory operations (list, create)
  - File operations (move, info)
  - Error handling

## Closes
- Closes #208
- Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)