### PR TITLE
feat(calendar): Add event search and free slot finder (#218, #220)

### DIFF
--- a/src/klabautermann/mcp/google_workspace.py
+++ b/src/klabautermann/mcp/google_workspace.py
@@ -98,6 +98,36 @@ class CalendarEvent(BaseModel):
     recurring_event_id: str | None = None  # ID of parent recurring event (for instances)
 
 
+class FreeSlot(BaseModel):
+    """A free time slot in the calendar."""
+
+    start: datetime
+    end: datetime
+
+    @property
+    def duration_minutes(self) -> int:
+        """Duration of the slot in minutes."""
+        return int((self.end - self.start).total_seconds() / 60)
+
+    @property
+    def duration_human(self) -> str:
+        """Human-readable duration."""
+        minutes = self.duration_minutes
+        if minutes < 60:
+            return f"{minutes} min"
+        hours = minutes // 60
+        mins = minutes % 60
+        if mins == 0:
+            return f"{hours} hr"
+        return f"{hours} hr {mins} min"
+
+    def format_display(self) -> str:
+        """Format slot for display."""
+        start_str = self.start.strftime("%a %b %d, %I:%M %p")
+        end_str = self.end.strftime("%I:%M %p")
+        return f"{start_str} - {end_str} ({self.duration_human})"
+
+
 class RecurrenceBuilder:
     """
     Build RFC 5545 RRULE strings for common recurrence patterns.
@@ -1682,6 +1712,212 @@ class GoogleWorkspaceBridge:
         end = tomorrow.replace(hour=23, minute=59, second=59, microsecond=999999)
         return await self.list_events(start, end, max_results=50)
 
+    async def search_events(
+        self,
+        query: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        max_results: int = 25,
+        calendar_id: str = "primary",
+        context: Any = None,  # noqa: ARG002
+    ) -> list[CalendarEvent]:
+        """
+        Search calendar events by title/description.
+
+        Args:
+            query: Search query to match against event title/description
+            start: Start of time range (default: now)
+            end: End of time range (default: 30 days from start)
+            max_results: Maximum number of events to return (default: 25)
+            calendar_id: Calendar ID to search in (default: "primary")
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            List of matching calendar events sorted by start time
+
+        Raises:
+            ExternalServiceError: If search fails
+        """
+        await self.start()
+
+        if start is None:
+            start = datetime.now()
+        if end is None:
+            end = start + timedelta(days=30)
+
+        # Capture for closure
+        search_query = query
+        start_time = start
+        end_time = end
+
+        def do_search() -> list[dict[str, Any]]:
+            # Format as RFC3339 for Google Calendar API
+            time_min = start_time.replace(tzinfo=None).isoformat() + "Z"
+            time_max = end_time.replace(tzinfo=None).isoformat() + "Z"
+            results = (
+                self._calendar_service.events()
+                .list(
+                    calendarId=calendar_id,
+                    timeMin=time_min,
+                    timeMax=time_max,
+                    maxResults=max_results,
+                    singleEvents=True,
+                    orderBy="startTime",
+                    q=search_query,  # Google Calendar's query parameter
+                )
+                .execute()
+            )
+            items: list[dict[str, Any]] = results.get("items", [])
+            return items
+
+        try:
+            raw_events = await self._rate_limited_call("calendar", do_search)
+            events = self._parse_calendar_events(raw_events, calendar_id, None)
+            logger.info(
+                f"[BEACON] Calendar search found {len(events)} events",
+                extra={"query": query, "results": len(events)},
+            )
+            return events
+        except HttpError as e:
+            logger.error(
+                f"[STORM] Calendar search failed: {e}",
+                extra={"query": query},
+            )
+            raise ExternalServiceError("calendar", f"Search failed: {e}") from e
+
+    async def find_free_slots(
+        self,
+        duration_minutes: int,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        working_hours_start: int = 9,
+        working_hours_end: int = 17,
+        calendar_ids: list[str] | None = None,
+        context: Any = None,  # noqa: ARG002
+    ) -> list[FreeSlot]:
+        """
+        Find free time slots in the calendar.
+
+        Queries the FreeBusy API to find available meeting times within
+        working hours.
+
+        Args:
+            duration_minutes: Required meeting duration in minutes
+            start: Start of search range (default: now)
+            end: End of search range (default: 7 days from start)
+            working_hours_start: Start of working hours, 0-23 (default: 9)
+            working_hours_end: End of working hours, 0-23 (default: 17)
+            calendar_ids: List of calendar IDs to check (default: ["primary"])
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            List of FreeSlot objects representing available time slots
+
+        Raises:
+            ExternalServiceError: If FreeBusy query fails
+        """
+        await self.start()
+
+        if start is None:
+            start = datetime.now()
+        if end is None:
+            end = start + timedelta(days=7)
+        if calendar_ids is None:
+            calendar_ids = ["primary"]
+
+        # Capture for closure
+        search_start = start
+        search_end = end
+        cal_ids = calendar_ids
+
+        def do_freebusy() -> dict[str, Any]:
+            time_min = search_start.replace(tzinfo=None).isoformat() + "Z"
+            time_max = search_end.replace(tzinfo=None).isoformat() + "Z"
+            body = {
+                "timeMin": time_min,
+                "timeMax": time_max,
+                "items": [{"id": cal_id} for cal_id in cal_ids],
+            }
+            result: dict[str, Any] = self._calendar_service.freebusy().query(body=body).execute()
+            return result
+
+        try:
+            freebusy_result = await self._rate_limited_call("calendar", do_freebusy)
+        except HttpError as e:
+            logger.error(f"[STORM] FreeBusy query failed: {e}")
+            raise ExternalServiceError("calendar", f"FreeBusy query failed: {e}") from e
+
+        # Collect all busy periods across all calendars
+        busy_periods: list[tuple[datetime, datetime]] = []
+        calendars = freebusy_result.get("calendars", {})
+        for cal_id in calendar_ids:
+            cal_data = calendars.get(cal_id, {})
+            for busy in cal_data.get("busy", []):
+                busy_start = datetime.fromisoformat(busy["start"].replace("Z", "+00:00"))
+                busy_end = datetime.fromisoformat(busy["end"].replace("Z", "+00:00"))
+                # Convert to naive datetime for comparison
+                busy_periods.append(
+                    (busy_start.replace(tzinfo=None), busy_end.replace(tzinfo=None))
+                )
+
+        # Sort busy periods by start time
+        busy_periods.sort(key=lambda x: x[0])
+
+        # Find free slots
+        free_slots: list[FreeSlot] = []
+        duration = timedelta(minutes=duration_minutes)
+
+        # Iterate through each day in the range
+        current_day = start.replace(hour=0, minute=0, second=0, microsecond=0)
+        while current_day < end:
+            # Working hours for this day
+            day_start = current_day.replace(hour=working_hours_start, minute=0, second=0)
+            day_end = current_day.replace(hour=working_hours_end, minute=0, second=0)
+
+            # Skip if day_start is in the past
+            if day_start < start:
+                day_start = start
+            # Skip weekends (Saturday=5, Sunday=6)
+            if current_day.weekday() >= 5:
+                current_day += timedelta(days=1)
+                continue
+            # Skip if day has already ended
+            if day_end <= start:
+                current_day += timedelta(days=1)
+                continue
+
+            # Find free slots within working hours for this day
+            slot_start = day_start
+            for busy_start, busy_end in busy_periods:
+                # Skip busy periods outside this day
+                if busy_end <= day_start or busy_start >= day_end:
+                    continue
+
+                # If there's a gap before this busy period
+                if busy_start > slot_start:
+                    gap_end = min(busy_start, day_end)
+                    # Check if gap is long enough
+                    if gap_end - slot_start >= duration:
+                        free_slots.append(FreeSlot(start=slot_start, end=gap_end))
+
+                # Move slot_start past this busy period
+                slot_start = max(slot_start, busy_end)
+
+            # Check for free time after the last busy period
+            if slot_start < day_end and day_end - slot_start >= duration:
+                free_slots.append(FreeSlot(start=slot_start, end=day_end))
+
+            current_day += timedelta(days=1)
+
+        logger.info(
+            f"[BEACON] Found {len(free_slots)} free slots",
+            extra={
+                "duration_minutes": duration_minutes,
+                "slots_found": len(free_slots),
+            },
+        )
+        return free_slots
+
     # ===========================================================================
     # Helper Methods
     # ===========================================================================
@@ -1854,6 +2090,7 @@ __all__ = [
     "CreateEventResult",
     "EmailAttachment",
     "EmailMessage",
+    "FreeSlot",
     "GoogleWorkspaceBridge",
     "RecurrenceBuilder",
     "SendEmailResult",

--- a/tests/unit/test_google_workspace.py
+++ b/tests/unit/test_google_workspace.py
@@ -1689,3 +1689,345 @@ class TestEmailAttachments:
             attachment_id="test", filename="large.pdf", mime_type="application/pdf", size=5242880
         )
         assert attachment.size_human == "5.0 MB"
+
+
+# ===========================================================================
+# Calendar Search Tests
+# ===========================================================================
+
+
+class TestCalendarSearch:
+    """Test calendar event search functionality."""
+
+    @pytest.mark.asyncio
+    async def test_search_events_by_title(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test searching events by title."""
+        mock_calendar_service.events.return_value.list.return_value.execute.return_value = {
+            "items": [
+                {
+                    "id": "event-1",
+                    "summary": "Team Standup",
+                    "start": {"dateTime": "2026-01-22T09:00:00Z"},
+                    "end": {"dateTime": "2026-01-22T09:30:00Z"},
+                },
+                {
+                    "id": "event-2",
+                    "summary": "Standup Review",
+                    "start": {"dateTime": "2026-01-22T10:00:00Z"},
+                    "end": {"dateTime": "2026-01-22T10:30:00Z"},
+                },
+            ]
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        events = await bridge.search_events("standup")
+
+        assert len(events) == 2
+        assert events[0].title == "Team Standup"
+        assert events[1].title == "Standup Review"
+
+        # Verify query parameter was passed
+        call_args = mock_calendar_service.events.return_value.list.call_args
+        assert call_args[1]["q"] == "standup"
+
+    @pytest.mark.asyncio
+    async def test_search_events_with_date_range(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test searching events within a date range."""
+        mock_calendar_service.events.return_value.list.return_value.execute.return_value = {
+            "items": []
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        start = datetime(2026, 1, 22, 0, 0, 0)
+        end = datetime(2026, 1, 29, 23, 59, 59)
+
+        await bridge.search_events("meeting", start=start, end=end)
+
+        # Verify time range was passed
+        call_args = mock_calendar_service.events.return_value.list.call_args
+        assert "timeMin" in call_args[1]
+        assert "timeMax" in call_args[1]
+        assert "2026-01-22" in call_args[1]["timeMin"]
+        assert "2026-01-29" in call_args[1]["timeMax"]
+
+    @pytest.mark.asyncio
+    async def test_search_events_no_results(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test search returning no results."""
+        mock_calendar_service.events.return_value.list.return_value.execute.return_value = {
+            "items": []
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        events = await bridge.search_events("nonexistent-event-xyz")
+
+        assert len(events) == 0
+
+    @pytest.mark.asyncio
+    async def test_search_events_default_date_range(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test search uses 30 day default range when not specified."""
+        mock_calendar_service.events.return_value.list.return_value.execute.return_value = {
+            "items": []
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        await bridge.search_events("test")
+
+        # Should use 30 day range by default
+        call_args = mock_calendar_service.events.return_value.list.call_args
+        assert call_args[1]["maxResults"] == 25  # Default max results
+
+
+# ===========================================================================
+# Calendar Free Slot Tests
+# ===========================================================================
+
+
+class TestCalendarFreeSlots:
+    """Test calendar free slot finder functionality."""
+
+    @pytest.mark.asyncio
+    async def test_find_free_slots_basic(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test finding free slots with no busy periods."""
+        mock_calendar_service.freebusy.return_value.query.return_value.execute.return_value = {
+            "calendars": {
+                "primary": {
+                    "busy": []  # No busy periods
+                }
+            }
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        # Search for 30-minute slots on a Monday
+        start = datetime(2026, 1, 26, 9, 0)  # Monday
+        end = datetime(2026, 1, 26, 17, 0)
+
+        slots = await bridge.find_free_slots(
+            duration_minutes=30,
+            start=start,
+            end=end,
+            working_hours_start=9,
+            working_hours_end=17,
+        )
+
+        # Should find 1 slot covering the entire day (9am-5pm)
+        assert len(slots) == 1
+        assert slots[0].start == datetime(2026, 1, 26, 9, 0)
+        assert slots[0].end == datetime(2026, 1, 26, 17, 0)
+
+    @pytest.mark.asyncio
+    async def test_find_free_slots_with_busy_periods(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test finding free slots around busy periods."""
+        mock_calendar_service.freebusy.return_value.query.return_value.execute.return_value = {
+            "calendars": {
+                "primary": {
+                    "busy": [
+                        {"start": "2026-01-26T10:00:00Z", "end": "2026-01-26T11:00:00Z"},
+                        {"start": "2026-01-26T14:00:00Z", "end": "2026-01-26T15:00:00Z"},
+                    ]
+                }
+            }
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        start = datetime(2026, 1, 26, 9, 0)  # Monday
+        end = datetime(2026, 1, 26, 17, 0)
+
+        slots = await bridge.find_free_slots(
+            duration_minutes=30,
+            start=start,
+            end=end,
+            working_hours_start=9,
+            working_hours_end=17,
+        )
+
+        # Should find 3 slots:
+        # 9am-10am, 11am-2pm, 3pm-5pm
+        assert len(slots) == 3
+        assert slots[0].start.hour == 9
+        assert slots[0].end.hour == 10
+        assert slots[1].start.hour == 11
+        assert slots[1].end.hour == 14
+        assert slots[2].start.hour == 15
+        assert slots[2].end.hour == 17
+
+    @pytest.mark.asyncio
+    async def test_find_free_slots_skips_weekends(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test that free slots finder skips weekends."""
+        mock_calendar_service.freebusy.return_value.query.return_value.execute.return_value = {
+            "calendars": {"primary": {"busy": []}}
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        # Saturday and Sunday
+        start = datetime(2026, 1, 24, 9, 0)  # Saturday
+        end = datetime(2026, 1, 25, 17, 0)  # Sunday
+
+        slots = await bridge.find_free_slots(
+            duration_minutes=30,
+            start=start,
+            end=end,
+        )
+
+        # Should find no slots on weekends
+        assert len(slots) == 0
+
+    @pytest.mark.asyncio
+    async def test_find_free_slots_minimum_duration(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test that slots shorter than duration are excluded."""
+        mock_calendar_service.freebusy.return_value.query.return_value.execute.return_value = {
+            "calendars": {
+                "primary": {
+                    "busy": [
+                        # 20-minute gap at 10am
+                        {"start": "2026-01-26T09:00:00Z", "end": "2026-01-26T10:00:00Z"},
+                        {"start": "2026-01-26T10:20:00Z", "end": "2026-01-26T17:00:00Z"},
+                    ]
+                }
+            }
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        start = datetime(2026, 1, 26, 9, 0)
+        end = datetime(2026, 1, 26, 17, 0)
+
+        # Looking for 30-minute slots
+        slots = await bridge.find_free_slots(
+            duration_minutes=30,
+            start=start,
+            end=end,
+        )
+
+        # 20-minute gap should be excluded
+        assert len(slots) == 0
+
+    @pytest.mark.asyncio
+    async def test_find_free_slots_multiple_calendars(
+        self, mock_env, mock_credentials, mock_build, mock_calendar_service
+    ):
+        """Test finding free slots across multiple calendars."""
+        mock_calendar_service.freebusy.return_value.query.return_value.execute.return_value = {
+            "calendars": {
+                "primary": {
+                    "busy": [
+                        {"start": "2026-01-26T09:00:00Z", "end": "2026-01-26T10:00:00Z"},
+                    ]
+                },
+                "work@example.com": {
+                    "busy": [
+                        {"start": "2026-01-26T11:00:00Z", "end": "2026-01-26T12:00:00Z"},
+                    ]
+                },
+            }
+        }
+
+        bridge = GoogleWorkspaceBridge()
+        await bridge.start()
+
+        start = datetime(2026, 1, 26, 9, 0)
+        end = datetime(2026, 1, 26, 17, 0)
+
+        slots = await bridge.find_free_slots(
+            duration_minutes=30,
+            start=start,
+            end=end,
+            calendar_ids=["primary", "work@example.com"],
+        )
+
+        # Should account for busy times from both calendars
+        # Free: 10-11, 12-17
+        assert len(slots) == 2
+
+
+# ===========================================================================
+# FreeSlot Model Tests
+# ===========================================================================
+
+
+class TestFreeSlotModel:
+    """Test FreeSlot model functionality."""
+
+    def test_duration_minutes(self):
+        """Test duration calculation in minutes."""
+        from klabautermann.mcp.google_workspace import FreeSlot
+
+        slot = FreeSlot(
+            start=datetime(2026, 1, 26, 9, 0),
+            end=datetime(2026, 1, 26, 10, 30),
+        )
+        assert slot.duration_minutes == 90
+
+    def test_duration_human_minutes_only(self):
+        """Test human-readable duration for minutes only."""
+        from klabautermann.mcp.google_workspace import FreeSlot
+
+        slot = FreeSlot(
+            start=datetime(2026, 1, 26, 9, 0),
+            end=datetime(2026, 1, 26, 9, 45),
+        )
+        assert slot.duration_human == "45 min"
+
+    def test_duration_human_hours_only(self):
+        """Test human-readable duration for whole hours."""
+        from klabautermann.mcp.google_workspace import FreeSlot
+
+        slot = FreeSlot(
+            start=datetime(2026, 1, 26, 9, 0),
+            end=datetime(2026, 1, 26, 11, 0),
+        )
+        assert slot.duration_human == "2 hr"
+
+    def test_duration_human_hours_and_minutes(self):
+        """Test human-readable duration for hours and minutes."""
+        from klabautermann.mcp.google_workspace import FreeSlot
+
+        slot = FreeSlot(
+            start=datetime(2026, 1, 26, 9, 0),
+            end=datetime(2026, 1, 26, 10, 30),
+        )
+        assert slot.duration_human == "1 hr 30 min"
+
+    def test_format_display(self):
+        """Test display formatting of slot."""
+        from klabautermann.mcp.google_workspace import FreeSlot
+
+        slot = FreeSlot(
+            start=datetime(2026, 1, 26, 9, 0),
+            end=datetime(2026, 1, 26, 10, 0),
+        )
+        display = slot.format_display()
+        assert "Mon Jan 26" in display
+        assert "09:00 AM" in display
+        assert "10:00 AM" in display
+        assert "1 hr" in display


### PR DESCRIPTION
## Summary

- **Calendar Event Search (#220)**: Search events by title or description within a date range
- **Calendar Free Slot Finder (#218)**: Find available meeting times using the FreeBusy API

## Changes

### Calendar Event Search (#220)
- Added `search_events()` method to GoogleWorkspaceBridge
- Supports custom date ranges (defaults to 30 days from now)
- Uses Google Calendar's `q` parameter for full-text search
- Returns events sorted by start time
- Configurable max_results (default 25)

### Calendar Free Slot Finder (#218)
- Added `find_free_slots()` method to GoogleWorkspaceBridge
- Queries Google Calendar FreeBusy API to identify busy periods
- Respects configurable working hours (default 9am-5pm)
- Automatically skips weekends (Saturday, Sunday)
- Supports checking multiple calendars simultaneously
- Only returns slots >= minimum duration

### FreeSlot Model
- New Pydantic model for representing free time slots
- `duration_minutes` property for slot duration in minutes
- `duration_human` property for human-readable format ("1 hr 30 min")
- `format_display()` for formatted slot representation

## Test plan

- [x] 4 new calendar search tests
  - Search by title
  - Search with date range
  - Search with no results
  - Default 30-day range
- [x] 5 new free slot finder tests
  - Basic (no busy periods)
  - With busy periods
  - Skips weekends
  - Minimum duration filtering
  - Multiple calendars
- [x] 5 new FreeSlot model tests
  - Duration in minutes
  - Human-readable duration
  - Display formatting

## Closes
- Closes #218
- Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)