### PR TITLE
feat(gmail): Add email draft and label management (#217, #219)

### DIFF
--- a/src/klabautermann/mcp/google_workspace.py
+++ b/src/klabautermann/mcp/google_workspace.py
@@ -266,6 +266,29 @@ class GmailLabel(BaseModel):
     unread_count: int | None = None
 
 
+class EmailDraft(BaseModel):
+    """Email draft from Gmail."""
+
+    id: str  # Draft ID (different from message ID)
+    message_id: str  # Associated message ID
+    thread_id: str | None = None
+    subject: str
+    to: str | None = None
+    cc: str | None = None
+    body: str | None = None
+    snippet: str = ""
+
+
+class DraftOperationResult(BaseModel):
+    """Result of draft operations (update, send, delete)."""
+
+    success: bool
+    draft_id: str | None = None
+    message_id: str | None = None
+    operation: str = ""  # "update", "send", "delete"
+    error: str | None = None
+
+
 class EmailSearchResult(BaseModel):
     """Email search results with pagination metadata."""
 
@@ -958,6 +981,338 @@ class GoogleWorkspaceBridge:
             )
             return SendEmailResult(success=False, error=str(e), is_draft=draft_only)
 
+    # ===========================================================================
+    # Draft Management Operations
+    # ===========================================================================
+
+    async def list_drafts(
+        self,
+        max_results: int = 20,
+        context: Any = None,  # noqa: ARG002
+    ) -> list[EmailDraft]:
+        """
+        List email drafts.
+
+        Args:
+            max_results: Maximum number of drafts to return (default: 20)
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            List of EmailDraft objects
+
+        Reference: Issue #219 (MCP-013)
+        """
+        await self.start()
+
+        def do_list_drafts() -> list[dict[str, Any]]:
+            results = (
+                self._gmail_service.users()
+                .drafts()
+                .list(userId="me", maxResults=max_results)
+                .execute()
+            )
+            drafts_list: list[dict[str, Any]] = results.get("drafts", [])
+            return drafts_list
+
+        def get_draft_details(draft_id: str) -> dict[str, Any]:
+            result: dict[str, Any] = (
+                self._gmail_service.users()
+                .drafts()
+                .get(userId="me", id=draft_id, format="full")
+                .execute()
+            )
+            return result
+
+        try:
+            raw_drafts = await self._rate_limited_call("gmail", do_list_drafts)
+            drafts: list[EmailDraft] = []
+
+            for raw_draft in raw_drafts:
+                draft_id = raw_draft.get("id", "")
+                # Get full draft details
+                full_draft = await self._rate_limited_call(
+                    "gmail",
+                    lambda d=draft_id: get_draft_details(d),  # type: ignore[misc]
+                )
+                message = full_draft.get("message", {})
+                headers = {
+                    h["name"]: h["value"] for h in message.get("payload", {}).get("headers", [])
+                }
+
+                # Extract body
+                body = None
+                payload = message.get("payload", {})
+                if "body" in payload and payload["body"].get("data"):
+                    body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8")
+                elif "parts" in payload:
+                    for part in payload["parts"]:
+                        if part.get("mimeType") == "text/plain" and part.get("body", {}).get(
+                            "data"
+                        ):
+                            body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8")
+                            break
+
+                drafts.append(
+                    EmailDraft(
+                        id=draft_id,
+                        message_id=message.get("id", ""),
+                        thread_id=message.get("threadId"),
+                        subject=headers.get("Subject", "(no subject)"),
+                        to=headers.get("To"),
+                        cc=headers.get("Cc"),
+                        body=body,
+                        snippet=message.get("snippet", ""),
+                    )
+                )
+
+            logger.info(
+                f"[BEACON] Listed {len(drafts)} drafts",
+                extra={"count": len(drafts)},
+            )
+            return drafts
+        except HttpError as e:
+            logger.error(f"[STORM] List drafts failed: {e}")
+            raise ExternalServiceError("gmail", f"List drafts failed: {e}") from e
+
+    async def get_draft(
+        self,
+        draft_id: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> EmailDraft | None:
+        """
+        Get a specific draft by ID.
+
+        Args:
+            draft_id: Gmail draft ID
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            EmailDraft if found, None otherwise
+
+        Reference: Issue #219 (MCP-013)
+        """
+        await self.start()
+
+        def do_get_draft() -> dict[str, Any]:
+            result: dict[str, Any] = (
+                self._gmail_service.users()
+                .drafts()
+                .get(userId="me", id=draft_id, format="full")
+                .execute()
+            )
+            return result
+
+        try:
+            full_draft = await self._rate_limited_call("gmail", do_get_draft)
+            message = full_draft.get("message", {})
+            headers = {h["name"]: h["value"] for h in message.get("payload", {}).get("headers", [])}
+
+            # Extract body
+            body = None
+            payload = message.get("payload", {})
+            if "body" in payload and payload["body"].get("data"):
+                body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8")
+            elif "parts" in payload:
+                for part in payload["parts"]:
+                    if part.get("mimeType") == "text/plain" and part.get("body", {}).get("data"):
+                        body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8")
+                        break
+
+            return EmailDraft(
+                id=draft_id,
+                message_id=message.get("id", ""),
+                thread_id=message.get("threadId"),
+                subject=headers.get("Subject", "(no subject)"),
+                to=headers.get("To"),
+                cc=headers.get("Cc"),
+                body=body,
+                snippet=message.get("snippet", ""),
+            )
+        except HttpError as e:
+            if e.resp.status == 404:
+                return None
+            logger.error(f"[STORM] Get draft failed: {e}")
+            raise ExternalServiceError("gmail", f"Get draft failed: {e}") from e
+
+    async def update_draft(
+        self,
+        draft_id: str,
+        to: str | None = None,
+        subject: str | None = None,
+        body: str | None = None,
+        cc: str | None = None,
+        context: Any = None,  # noqa: ARG002
+    ) -> DraftOperationResult:
+        """
+        Update an existing draft.
+
+        Args:
+            draft_id: Gmail draft ID to update
+            to: New recipient (optional, keeps existing if None)
+            subject: New subject (optional, keeps existing if None)
+            body: New body (optional, keeps existing if None)
+            cc: New CC recipients (optional, keeps existing if None)
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            DraftOperationResult with success status
+
+        Reference: Issue #219 (MCP-013)
+        """
+        await self.start()
+
+        # First get the existing draft to preserve fields
+        existing = await self.get_draft(draft_id)
+        if not existing:
+            return DraftOperationResult(
+                success=False,
+                draft_id=draft_id,
+                operation="update",
+                error="Draft not found",
+            )
+
+        # Use existing values if not provided
+        final_to = to if to is not None else existing.to
+        final_subject = subject if subject is not None else existing.subject
+        final_body = body if body is not None else existing.body or ""
+        final_cc = cc if cc is not None else existing.cc
+
+        def do_update() -> dict[str, Any]:
+            # Create the updated message
+            message = MIMEText(final_body)
+            if final_to:
+                message["to"] = final_to
+            message["subject"] = final_subject
+            if final_cc:
+                message["cc"] = final_cc
+
+            raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+
+            draft_body: dict[str, Any] = {"message": {"raw": raw}}
+            # Preserve thread if it exists
+            if existing.thread_id:
+                draft_body["message"]["threadId"] = existing.thread_id
+
+            result: dict[str, Any] = (
+                self._gmail_service.users()
+                .drafts()
+                .update(userId="me", id=draft_id, body=draft_body)
+                .execute()
+            )
+            return result
+
+        try:
+            result = await self._rate_limited_call("gmail", do_update)
+            logger.info(
+                f"[BEACON] Draft updated: {draft_id[:8]}...",
+                extra={"draft_id": draft_id},
+            )
+            return DraftOperationResult(
+                success=True,
+                draft_id=result.get("id", draft_id),
+                message_id=result.get("message", {}).get("id"),
+                operation="update",
+            )
+        except HttpError as e:
+            logger.error(f"[STORM] Update draft failed: {e}")
+            return DraftOperationResult(
+                success=False,
+                draft_id=draft_id,
+                operation="update",
+                error=str(e),
+            )
+
+    async def send_draft(
+        self,
+        draft_id: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> DraftOperationResult:
+        """
+        Send an existing draft.
+
+        Args:
+            draft_id: Gmail draft ID to send
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            DraftOperationResult with sent message ID
+
+        Reference: Issue #219 (MCP-013)
+        """
+        await self.start()
+
+        def do_send() -> dict[str, Any]:
+            result: dict[str, Any] = (
+                self._gmail_service.users()
+                .drafts()
+                .send(userId="me", body={"id": draft_id})
+                .execute()
+            )
+            return result
+
+        try:
+            result = await self._rate_limited_call("gmail", do_send)
+            logger.info(
+                f"[BEACON] Draft sent: {draft_id[:8]}... -> message {result.get('id', '')[:8]}...",
+                extra={"draft_id": draft_id, "message_id": result.get("id")},
+            )
+            return DraftOperationResult(
+                success=True,
+                draft_id=draft_id,
+                message_id=result.get("id"),
+                operation="send",
+            )
+        except HttpError as e:
+            logger.error(f"[STORM] Send draft failed: {e}")
+            return DraftOperationResult(
+                success=False,
+                draft_id=draft_id,
+                operation="send",
+                error=str(e),
+            )
+
+    async def delete_draft(
+        self,
+        draft_id: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> DraftOperationResult:
+        """
+        Delete a draft.
+
+        Args:
+            draft_id: Gmail draft ID to delete
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            DraftOperationResult with success status
+
+        Reference: Issue #219 (MCP-013)
+        """
+        await self.start()
+
+        def do_delete() -> None:
+            self._gmail_service.users().drafts().delete(userId="me", id=draft_id).execute()
+
+        try:
+            await self._rate_limited_call("gmail", do_delete)
+            logger.info(
+                f"[BEACON] Draft deleted: {draft_id[:8]}...",
+                extra={"draft_id": draft_id},
+            )
+            return DraftOperationResult(
+                success=True,
+                draft_id=draft_id,
+                operation="delete",
+            )
+        except HttpError as e:
+            logger.error(f"[STORM] Delete draft failed: {e}")
+            return DraftOperationResult(
+                success=False,
+                draft_id=draft_id,
+                operation="delete",
+                error=str(e),
+            )
+
     async def get_recent_emails(
         self,
         hours: int = 24,
@@ -1343,6 +1698,161 @@ class GoogleWorkspaceBridge:
             if label.name.lower() == name_lower:
                 return label
         return None
+
+    async def create_label(
+        self,
+        name: str,
+        label_list_visibility: str = "labelShow",
+        message_list_visibility: str = "show",
+        context: Any = None,  # noqa: ARG002
+    ) -> GmailLabel:
+        """
+        Create a custom Gmail label.
+
+        Args:
+            name: Label name (can include "/" for nested labels, e.g., "Projects/Work")
+            label_list_visibility: Visibility in label list
+                - "labelShow": Show in label list
+                - "labelShowIfUnread": Show only if there are unread messages
+                - "labelHide": Hide from label list
+            message_list_visibility: Visibility when viewing message list
+                - "show": Show label in message list
+                - "hide": Hide label from message list
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            Created GmailLabel object
+
+        Raises:
+            ExternalServiceError: If label creation fails (e.g., label already exists)
+
+        Reference: Issue #217 (MCP-011)
+        """
+        await self.start()
+
+        def do_create_label() -> dict[str, Any]:
+            label_body = {
+                "name": name,
+                "labelListVisibility": label_list_visibility,
+                "messageListVisibility": message_list_visibility,
+            }
+            result: dict[str, Any] = (
+                self._gmail_service.users().labels().create(userId="me", body=label_body).execute()
+            )
+            return result
+
+        try:
+            result = await self._rate_limited_call("gmail", do_create_label)
+            logger.info(
+                f"[BEACON] Label created: {name}",
+                extra={"label_id": result.get("id"), "label_name": name},
+            )
+            return GmailLabel(
+                id=result.get("id", ""),
+                name=result.get("name", name),
+                type="user",
+            )
+        except HttpError as e:
+            logger.error(f"[STORM] Create label failed: {e}")
+            raise ExternalServiceError("gmail", f"Create label failed: {e}") from e
+
+    async def delete_label(
+        self,
+        label_id: str,
+        context: Any = None,  # noqa: ARG002
+    ) -> bool:
+        """
+        Delete a custom Gmail label.
+
+        Note: System labels (INBOX, SENT, etc.) cannot be deleted.
+
+        Args:
+            label_id: Gmail label ID to delete
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            True if deletion succeeded, False otherwise
+
+        Raises:
+            ExternalServiceError: If deletion fails
+
+        Reference: Issue #217 (MCP-011)
+        """
+        await self.start()
+
+        def do_delete_label() -> None:
+            self._gmail_service.users().labels().delete(userId="me", id=label_id).execute()
+
+        try:
+            await self._rate_limited_call("gmail", do_delete_label)
+            logger.info(
+                f"[BEACON] Label deleted: {label_id}",
+                extra={"label_id": label_id},
+            )
+            return True
+        except HttpError as e:
+            logger.error(f"[STORM] Delete label failed: {e}")
+            raise ExternalServiceError("gmail", f"Delete label failed: {e}") from e
+
+    async def update_label(
+        self,
+        label_id: str,
+        name: str | None = None,
+        label_list_visibility: str | None = None,
+        message_list_visibility: str | None = None,
+        context: Any = None,  # noqa: ARG002
+    ) -> GmailLabel:
+        """
+        Update a custom Gmail label.
+
+        Args:
+            label_id: Gmail label ID to update
+            name: New label name (optional)
+            label_list_visibility: New visibility in label list (optional)
+            message_list_visibility: New visibility in message list (optional)
+            context: Ignored (kept for interface compatibility)
+
+        Returns:
+            Updated GmailLabel object
+
+        Raises:
+            ExternalServiceError: If update fails
+
+        Reference: Issue #217 (MCP-011)
+        """
+        await self.start()
+
+        def do_update_label() -> dict[str, Any]:
+            label_body: dict[str, Any] = {}
+            if name is not None:
+                label_body["name"] = name
+            if label_list_visibility is not None:
+                label_body["labelListVisibility"] = label_list_visibility
+            if message_list_visibility is not None:
+                label_body["messageListVisibility"] = message_list_visibility
+
+            result: dict[str, Any] = (
+                self._gmail_service.users()
+                .labels()
+                .patch(userId="me", id=label_id, body=label_body)
+                .execute()
+            )
+            return result
+
+        try:
+            result = await self._rate_limited_call("gmail", do_update_label)
+            logger.info(
+                f"[BEACON] Label updated: {label_id}",
+                extra={"label_id": label_id, "label_name": result.get("name")},
+            )
+            return GmailLabel(
+                id=result.get("id", label_id),
+                name=result.get("name", ""),
+                type=result.get("type", "user").lower(),
+            )
+        except HttpError as e:
+            logger.error(f"[STORM] Update label failed: {e}")
+            raise ExternalServiceError("gmail", f"Update label failed: {e}") from e
 
     # ===========================================================================
     # Calendar Operations

--- a/tests/unit/test_google_workspace.py
+++ b/tests/unit/test_google_workspace.py
@@ -2031,3 +2031,429 @@ class TestFreeSlotModel:
         assert "09:00 AM" in display
         assert "10:00 AM" in display
         assert "1 hr" in display
+
+
+# ===========================================================================
+# Draft Management Tests (Issue #219)
+# ===========================================================================
+
+
+class TestDraftManagement:
+    """Test Gmail draft management operations."""
+
+    @pytest.mark.asyncio
+    async def test_list_drafts(self, bridge, mock_gmail_service):
+        """Test listing drafts."""
+        # Setup mock response for list
+        mock_gmail_service.users().drafts().list().execute.return_value = {
+            "drafts": [
+                {"id": "draft1"},
+                {"id": "draft2"},
+            ]
+        }
+
+        # Setup mock response for individual draft details
+        def get_draft_details(*args, **kwargs):
+            draft_id = kwargs.get("id", "draft1")
+            return {
+                "id": draft_id,
+                "message": {
+                    "id": f"msg_{draft_id}",
+                    "threadId": f"thread_{draft_id}",
+                    "snippet": "Test snippet",
+                    "payload": {
+                        "headers": [
+                            {"name": "Subject", "value": f"Subject {draft_id}"},
+                            {"name": "To", "value": "test@example.com"},
+                        ],
+                        "body": {"data": base64.urlsafe_b64encode(b"Test body").decode()},
+                    },
+                },
+            }
+
+        mock_gmail_service.users().drafts().get().execute.side_effect = get_draft_details
+
+        drafts = await bridge.list_drafts(max_results=10)
+
+        assert len(drafts) == 2
+        mock_gmail_service.users().drafts().list.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_draft(self, bridge, mock_gmail_service):
+        """Test getting a specific draft."""
+        mock_gmail_service.users().drafts().get().execute.return_value = {
+            "id": "draft123",
+            "message": {
+                "id": "msg123",
+                "threadId": "thread123",
+                "snippet": "Test snippet",
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "Test Subject"},
+                        {"name": "To", "value": "recipient@example.com"},
+                        {"name": "Cc", "value": "cc@example.com"},
+                    ],
+                    "body": {"data": base64.urlsafe_b64encode(b"Draft body content").decode()},
+                },
+            },
+        }
+
+        draft = await bridge.get_draft("draft123")
+
+        assert draft is not None
+        assert draft.id == "draft123"
+        assert draft.message_id == "msg123"
+        assert draft.thread_id == "thread123"
+        assert draft.subject == "Test Subject"
+        assert draft.to == "recipient@example.com"
+        assert draft.cc == "cc@example.com"
+        assert draft.body == "Draft body content"
+
+    @pytest.mark.asyncio
+    async def test_get_draft_not_found(self, bridge, mock_gmail_service):
+        """Test getting a non-existent draft."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 404
+        mock_gmail_service.users().drafts().get().execute.side_effect = HttpError(
+            error_resp, b"Draft not found"
+        )
+
+        draft = await bridge.get_draft("nonexistent")
+
+        assert draft is None
+
+    @pytest.mark.asyncio
+    async def test_update_draft(self, bridge, mock_gmail_service):
+        """Test updating a draft."""
+        # Mock get_draft for existing draft
+        mock_gmail_service.users().drafts().get().execute.return_value = {
+            "id": "draft123",
+            "message": {
+                "id": "msg123",
+                "threadId": "thread123",
+                "snippet": "Old snippet",
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "Old Subject"},
+                        {"name": "To", "value": "old@example.com"},
+                    ],
+                    "body": {"data": base64.urlsafe_b64encode(b"Old body").decode()},
+                },
+            },
+        }
+
+        # Mock update
+        mock_gmail_service.users().drafts().update().execute.return_value = {
+            "id": "draft123",
+            "message": {"id": "msg123_updated"},
+        }
+
+        result = await bridge.update_draft(
+            draft_id="draft123",
+            subject="New Subject",
+            body="New body content",
+        )
+
+        assert result.success is True
+        assert result.draft_id == "draft123"
+        assert result.operation == "update"
+        mock_gmail_service.users().drafts().update.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_draft_not_found(self, bridge, mock_gmail_service):
+        """Test updating a non-existent draft."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 404
+        mock_gmail_service.users().drafts().get().execute.side_effect = HttpError(
+            error_resp, b"Draft not found"
+        )
+
+        result = await bridge.update_draft(
+            draft_id="nonexistent",
+            subject="New Subject",
+        )
+
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_draft(self, bridge, mock_gmail_service):
+        """Test sending a draft."""
+        mock_gmail_service.users().drafts().send().execute.return_value = {
+            "id": "sent_msg_id",
+            "threadId": "thread123",
+        }
+
+        result = await bridge.send_draft("draft123")
+
+        assert result.success is True
+        assert result.draft_id == "draft123"
+        assert result.message_id == "sent_msg_id"
+        assert result.operation == "send"
+        mock_gmail_service.users().drafts().send.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_send_draft_error(self, bridge, mock_gmail_service):
+        """Test sending a draft that fails."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 400
+        mock_gmail_service.users().drafts().send().execute.side_effect = HttpError(
+            error_resp, b"Send failed"
+        )
+
+        result = await bridge.send_draft("draft123")
+
+        assert result.success is False
+        assert result.operation == "send"
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_draft(self, bridge, mock_gmail_service):
+        """Test deleting a draft."""
+        mock_gmail_service.users().drafts().delete().execute.return_value = None
+
+        result = await bridge.delete_draft("draft123")
+
+        assert result.success is True
+        assert result.draft_id == "draft123"
+        assert result.operation == "delete"
+        mock_gmail_service.users().drafts().delete.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_draft_error(self, bridge, mock_gmail_service):
+        """Test deleting a draft that fails."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 404
+        mock_gmail_service.users().drafts().delete().execute.side_effect = HttpError(
+            error_resp, b"Draft not found"
+        )
+
+        result = await bridge.delete_draft("nonexistent")
+
+        assert result.success is False
+        assert result.operation == "delete"
+
+
+class TestDraftModel:
+    """Test EmailDraft Pydantic model."""
+
+    def test_draft_model_creation(self):
+        """Test creating an EmailDraft model."""
+        from klabautermann.mcp.google_workspace import EmailDraft
+
+        draft = EmailDraft(
+            id="draft123",
+            message_id="msg123",
+            thread_id="thread123",
+            subject="Test Subject",
+            to="recipient@example.com",
+            cc="cc@example.com",
+            body="Test body",
+            snippet="Test snippet",
+        )
+
+        assert draft.id == "draft123"
+        assert draft.message_id == "msg123"
+        assert draft.thread_id == "thread123"
+        assert draft.subject == "Test Subject"
+        assert draft.to == "recipient@example.com"
+        assert draft.cc == "cc@example.com"
+        assert draft.body == "Test body"
+        assert draft.snippet == "Test snippet"
+
+    def test_draft_model_optional_fields(self):
+        """Test EmailDraft with optional fields."""
+        from klabautermann.mcp.google_workspace import EmailDraft
+
+        draft = EmailDraft(
+            id="draft123",
+            message_id="msg123",
+            subject="Test Subject",
+        )
+
+        assert draft.id == "draft123"
+        assert draft.thread_id is None
+        assert draft.to is None
+        assert draft.cc is None
+        assert draft.body is None
+        assert draft.snippet == ""
+
+
+class TestDraftOperationResult:
+    """Test DraftOperationResult Pydantic model."""
+
+    def test_draft_operation_success(self):
+        """Test successful draft operation result."""
+        from klabautermann.mcp.google_workspace import DraftOperationResult
+
+        result = DraftOperationResult(
+            success=True,
+            draft_id="draft123",
+            message_id="msg123",
+            operation="send",
+        )
+
+        assert result.success is True
+        assert result.draft_id == "draft123"
+        assert result.message_id == "msg123"
+        assert result.operation == "send"
+        assert result.error is None
+
+    def test_draft_operation_failure(self):
+        """Test failed draft operation result."""
+        from klabautermann.mcp.google_workspace import DraftOperationResult
+
+        result = DraftOperationResult(
+            success=False,
+            draft_id="draft123",
+            operation="update",
+            error="Draft not found",
+        )
+
+        assert result.success is False
+        assert result.error == "Draft not found"
+
+
+# ===========================================================================
+# Label Management Tests (Issue #217)
+# ===========================================================================
+
+
+class TestLabelManagement:
+    """Test Gmail label management operations."""
+
+    @pytest.mark.asyncio
+    async def test_create_label(self, bridge, mock_gmail_service):
+        """Test creating a custom label."""
+        mock_gmail_service.users().labels().create().execute.return_value = {
+            "id": "Label_123",
+            "name": "Projects/Work",
+            "type": "user",
+        }
+
+        label = await bridge.create_label("Projects/Work")
+
+        assert label.id == "Label_123"
+        assert label.name == "Projects/Work"
+        assert label.type == "user"
+        mock_gmail_service.users().labels().create.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_create_label_with_visibility(self, bridge, mock_gmail_service):
+        """Test creating a label with custom visibility settings."""
+        mock_gmail_service.users().labels().create().execute.return_value = {
+            "id": "Label_456",
+            "name": "Archive",
+            "type": "user",
+        }
+
+        label = await bridge.create_label(
+            name="Archive",
+            label_list_visibility="labelHide",
+            message_list_visibility="hide",
+        )
+
+        assert label.id == "Label_456"
+        assert label.name == "Archive"
+        # Verify the call was made with correct visibility settings
+        call_args = mock_gmail_service.users().labels().create.call_args
+        assert call_args is not None
+
+    @pytest.mark.asyncio
+    async def test_create_label_already_exists(self, bridge, mock_gmail_service):
+        """Test creating a label that already exists."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 409
+        mock_gmail_service.users().labels().create().execute.side_effect = HttpError(
+            error_resp, b"Label already exists"
+        )
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            await bridge.create_label("Existing Label")
+
+        assert "Create label failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_delete_label(self, bridge, mock_gmail_service):
+        """Test deleting a custom label."""
+        mock_gmail_service.users().labels().delete().execute.return_value = None
+
+        result = await bridge.delete_label("Label_123")
+
+        assert result is True
+        mock_gmail_service.users().labels().delete.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_label_not_found(self, bridge, mock_gmail_service):
+        """Test deleting a non-existent label."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 404
+        mock_gmail_service.users().labels().delete().execute.side_effect = HttpError(
+            error_resp, b"Label not found"
+        )
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            await bridge.delete_label("nonexistent")
+
+        assert "Delete label failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_label_name(self, bridge, mock_gmail_service):
+        """Test updating a label name."""
+        mock_gmail_service.users().labels().patch().execute.return_value = {
+            "id": "Label_123",
+            "name": "New Name",
+            "type": "user",
+        }
+
+        label = await bridge.update_label("Label_123", name="New Name")
+
+        assert label.id == "Label_123"
+        assert label.name == "New Name"
+        mock_gmail_service.users().labels().patch.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_label_visibility(self, bridge, mock_gmail_service):
+        """Test updating label visibility settings."""
+        mock_gmail_service.users().labels().patch().execute.return_value = {
+            "id": "Label_123",
+            "name": "Projects",
+            "type": "user",
+        }
+
+        label = await bridge.update_label(
+            "Label_123",
+            label_list_visibility="labelHide",
+            message_list_visibility="hide",
+        )
+
+        assert label.id == "Label_123"
+        mock_gmail_service.users().labels().patch.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_label_error(self, bridge, mock_gmail_service):
+        """Test updating a label that fails."""
+        from googleapiclient.errors import HttpError
+
+        error_resp = MagicMock()
+        error_resp.status = 400
+        mock_gmail_service.users().labels().patch().execute.side_effect = HttpError(
+            error_resp, b"Update failed"
+        )
+
+        with pytest.raises(ExternalServiceError) as exc_info:
+            await bridge.update_label("Label_123", name="New Name")
+
+        assert "Update label failed" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Implements full email draft management and custom label creation for Gmail integration.

### Draft Management (#219)
- `list_drafts()`: List all drafts with full details (subject, recipients, body)
- `get_draft()`: Get a specific draft by ID
- `update_draft()`: Update draft content (to, subject, body, cc) while preserving thread context
- `send_draft()`: Send an existing draft
- `delete_draft()`: Delete a draft
- New `EmailDraft` model with comprehensive fields
- New `DraftOperationResult` model for operation responses

### Label Management (#217)
- `create_label()`: Create custom labels with visibility settings
- `delete_label()`: Delete custom labels
- `update_label()`: Update label name and visibility settings
- Support for nested labels (e.g., "Projects/Work")
- Visibility options: `labelShow`, `labelShowIfUnread`, `labelHide`

## Test plan
- [x] 9 tests for draft management operations
- [x] 4 tests for draft and result models  
- [x] 8 tests for label management operations
- [x] All 107 google_workspace tests pass
- [x] Pre-commit hooks pass (ruff, mypy)

Closes #217, Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)