### PR TITLE
feat(skills): Add summarize-thread skill (#295)

### DIFF
--- a/.claude/skills/summarize-thread/SKILL.md
+++ b/.claude/skills/summarize-thread/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: summarize-thread
+description: Summarize a conversation thread or email thread to extract key points, action items, and decisions. Use when user asks "summarize this thread", "what was discussed", "give me the gist", or "TLDR".
+allowed-tools: Read, Grep
+model: claude-3-5-haiku-20241022
+user-invocable: true
+klabautermann-task-type: research
+klabautermann-agent: researcher
+klabautermann-blocking: true
+klabautermann-payload-schema:
+  thread_id:
+    type: string
+    required: false
+    extract-from: user-message
+    description: Thread ID for email or conversation thread (if known)
+  thread_type:
+    type: string
+    required: false
+    default: conversation
+    extract-from: user-message
+    description: Type of thread - "email" or "conversation"
+  query:
+    type: string
+    required: false
+    extract-from: user-message
+    description: Search query to find the thread if ID not provided
+---
+
+# Summarize Thread
+
+Summarize a conversation thread or email thread to extract structured information.
+
+## Instructions
+
+1. **Determine Thread Type**
+   - If thread_type is "email" or user mentions emails/inbox, use email thread summarization
+   - Otherwise, use conversation thread summarization
+
+2. **Find the Thread**
+   - If thread_id is provided, use it directly
+   - If query is provided, search for matching threads
+   - If neither, summarize the current/recent conversation
+
+3. **Generate Summary**
+   - Extract the essence, not verbatim transcription
+   - Identify key topics discussed
+   - List decisions made
+   - Extract action items with owners if mentioned
+   - Detect sentiment (positive/neutral/negative)
+
+4. **Return Structured Results**
+   - Summary: 2-3 sentence overview
+   - Key Points: Bullet list of main topics
+   - Action Items: Tasks with owners
+   - Participants: Who was involved
+   - Sentiment: Overall tone
+
+## Examples
+
+**User**: "Summarize the email thread from Sarah"
+- thread_type: "email"
+- query: "Sarah"
+- Action: Search emails from Sarah, get thread, summarize with key points and action items
+
+**User**: "What did we discuss yesterday?"
+- thread_type: "conversation"
+- query: "yesterday"
+- Action: Find yesterday's conversation thread, extract topics and decisions
+
+**User**: "TLDR on the project meeting thread"
+- thread_type: "conversation" (or "email" if context suggests)
+- query: "project meeting"
+- Action: Summarize the project meeting discussion
+
+## Output Format
+
+```
+## Summary
+[2-3 sentence summary of the thread]
+
+## Key Points
+- [Point 1]
+- [Point 2]
+- [Point 3]
+
+## Action Items
+- [ ] [Action] (Owner: [Name])
+- [ ] [Action] (Owner: [Name])
+
+## Participants
+[List of participants]
+
+## Sentiment
+[positive/neutral/negative]
+```
+
+## Safety Rules
+
+- Only summarize threads the user has access to
+- Preserve attribution (who said what)
+- Be conservative - don't infer information not in the thread
+- Mark low-confidence extractions accordingly

--- a/.gitignore
+++ b/.gitignore
@@ -106,9 +106,7 @@ site/
 # Ignore AI agent-specific directories (except skills)
 .claude/*
 !.claude/skills/
+!.claude/skills/**
 
 # Ignore git worktrees directory
 worktrees/
-
-# Ignore AI agent-specific directories
-.claude/

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -884,3 +884,125 @@ class TestSkillRegistryDescriptions:
 
         assert descriptions["skill-a"] == "Description A"
         assert descriptions["skill-b"] == "Description B"
+
+
+class TestSummarizeThreadSkill:
+    """Tests for the summarize-thread skill."""
+
+    @pytest.fixture
+    def summarize_skill_loader(self) -> SkillLoader:
+        """Create loader with project skills directory containing summarize-thread."""
+        # Use the actual project skills directory
+        project_root = Path(__file__).parent.parent.parent
+        skills_dir = project_root / ".claude" / "skills"
+        return SkillLoader(
+            project_skills_dir=skills_dir,
+            personal_skills_dir=Path("/nonexistent"),
+        )
+
+    def test_summarize_thread_skill_loads(self, summarize_skill_loader: SkillLoader) -> None:
+        """Test that summarize-thread skill loads correctly."""
+        summarize_skill_loader.load_all()
+        skill = summarize_skill_loader.get("summarize-thread")
+
+        assert skill is not None
+        assert skill.name == "summarize-thread"
+        assert "summarize" in skill.description.lower()
+        assert "thread" in skill.description.lower()
+
+    def test_summarize_thread_skill_metadata(self, summarize_skill_loader: SkillLoader) -> None:
+        """Test summarize-thread skill metadata is correct."""
+        summarize_skill_loader.load_all()
+        skill = summarize_skill_loader.get("summarize-thread")
+
+        assert skill is not None
+        assert skill.metadata.user_invocable is True
+        assert skill.metadata.model == "claude-3-5-haiku-20241022"
+
+    def test_summarize_thread_skill_orchestrator_config(
+        self, summarize_skill_loader: SkillLoader
+    ) -> None:
+        """Test summarize-thread skill has correct orchestrator config."""
+        summarize_skill_loader.load_all()
+        skill = summarize_skill_loader.get("summarize-thread")
+
+        assert skill is not None
+        assert skill.is_orchestrator_enabled is True
+        assert skill.klabautermann.task_type == "research"
+        assert skill.klabautermann.agent == "researcher"
+        assert skill.klabautermann.blocking is True
+
+    def test_summarize_thread_skill_payload_schema(
+        self, summarize_skill_loader: SkillLoader
+    ) -> None:
+        """Test summarize-thread skill has correct payload schema."""
+        summarize_skill_loader.load_all()
+        skill = summarize_skill_loader.get("summarize-thread")
+
+        assert skill is not None
+        fields = skill.klabautermann.get_payload_fields()
+
+        assert "thread_id" in fields
+        assert fields["thread_id"].type == "string"
+        assert fields["thread_id"].required is False
+
+        assert "thread_type" in fields
+        assert fields["thread_type"].type == "string"
+        assert fields["thread_type"].default == "conversation"
+
+        assert "query" in fields
+        assert fields["query"].type == "string"
+        assert fields["query"].required is False
+
+    def test_summarize_thread_skill_body_contains_instructions(
+        self, summarize_skill_loader: SkillLoader
+    ) -> None:
+        """Test summarize-thread skill body contains usage instructions."""
+        summarize_skill_loader.load_all()
+        skill = summarize_skill_loader.get("summarize-thread")
+
+        assert skill is not None
+        assert "# Summarize Thread" in skill.body
+        assert "Instructions" in skill.body
+        assert "Examples" in skill.body
+        assert "Output Format" in skill.body
+
+    def test_summarize_thread_planner_matching(self, tmp_path: Path) -> None:
+        """Test that planner can match summarize-thread skill by patterns."""
+        # Create summarize-thread skill in temp directory
+        skill_dir = tmp_path / "summarize-thread"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            dedent("""
+            ---
+            name: summarize-thread
+            description: Summarize a conversation thread or email thread. Use when user asks "summarize this thread", "what was discussed", "give me the gist", or "TLDR".
+            klabautermann-task-type: research
+            klabautermann-agent: researcher
+            ---
+
+            # Summarize Thread
+
+            Summarize threads.
+        """).strip()
+        )
+
+        loader = SkillLoader(project_skills_dir=tmp_path, personal_skills_dir=tmp_path / "none")
+        planner = SkillAwarePlanner(loader)
+
+        # Test various trigger phrases
+        test_cases = [
+            ("summarize this thread", True),
+            ("what was discussed", True),
+            ("give me the gist", True),
+            ("TLDR", True),
+            ("/summarize-thread", True),
+            ("what's the weather", False),
+        ]
+
+        for user_input, should_match in test_cases:
+            skill = planner.match_skill(user_input)
+            if should_match:
+                assert skill is not None, f"Expected match for: {user_input}"
+                assert skill.name == "summarize-thread"
+            # Note: "should_match=False" cases may or may not match depending on keyword patterns


### PR DESCRIPTION
## Summary
- Add new `summarize-thread` skill for AI-powered thread summarization
- Support both email threads (via GoogleWorkspaceBridge) and conversation threads (via Archivist)
- Configure with orchestrator integration: research task type, researcher agent
- Fix .gitignore to properly allow `.claude/skills/` directory

## Test plan
- [x] Skill loads correctly from `.claude/skills/summarize-thread/SKILL.md`
- [x] Metadata validation (name, description, model, user-invocable)
- [x] Orchestrator config validation (task_type=research, agent=researcher)
- [x] Payload schema validation (thread_id, thread_type, query fields)
- [x] Body contains required sections (Instructions, Examples, Output Format)
- [x] Planner matches skill by trigger phrases (summarize, TLDR, gist)
- [x] All 45 skills tests pass

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)