### PR TITLE
feat(agents): Add workflow inspection system for debugging (#357)

### DIFF
--- a/src/klabautermann/agents/base_agent.py
+++ b/src/klabautermann/agents/base_agent.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from klabautermann.core.logger import logger
 from klabautermann.core.models import AgentMessage
+from klabautermann.core.workflow_inspector import get_inspector
 
 
 class BaseAgent(ABC):
@@ -131,6 +132,7 @@ class BaseAgent(ABC):
         """
         start_time = time.time()
         self._request_count += 1
+        inspector = get_inspector()
 
         try:
             logger.debug(
@@ -142,10 +144,44 @@ class BaseAgent(ABC):
                 },
             )
 
+            # Log REQUEST phase for workflow inspection
+            inspector.log_request(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "intent": msg.intent,
+                    "source": msg.source_agent,
+                    "payload": msg.payload,
+                    "priority": msg.priority,
+                },
+            )
+
             response = await self.process_message(msg)
+
+            elapsed_ms = (time.time() - start_time) * 1000
 
             if response:
                 await self._route_response(response, original_msg=msg)
+                # Log OUTPUT phase with response
+                inspector.log_output(
+                    trace_id=msg.trace_id,
+                    agent_name=self.name,
+                    data={
+                        "status": "success",
+                        "response_intent": response.intent,
+                        "response_target": response.target_agent,
+                        "response_payload": response.payload,
+                    },
+                    duration_ms=elapsed_ms,
+                )
+            else:
+                # Log OUTPUT phase without response (fire-and-forget)
+                inspector.log_output(
+                    trace_id=msg.trace_id,
+                    agent_name=self.name,
+                    data={"status": "success", "response": None},
+                    duration_ms=elapsed_ms,
+                )
 
             self._success_count += 1
             logger.debug(
@@ -155,6 +191,16 @@ class BaseAgent(ABC):
 
         except Exception as e:
             self._error_count += 1
+            elapsed_ms = (time.time() - start_time) * 1000
+
+            # Log OUTPUT phase with error
+            inspector.log_output(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={"status": "error", "error": str(e), "error_type": type(e).__name__},
+                duration_ms=elapsed_ms,
+            )
+
             logger.error(
                 f"[STORM] {self.name} failed: {e}",
                 extra={"trace_id": msg.trace_id, "agent_name": self.name},

--- a/src/klabautermann/agents/executor.py
+++ b/src/klabautermann/agents/executor.py
@@ -23,6 +23,7 @@ from klabautermann.agents.calendar_handlers import (
 from klabautermann.agents.gmail_handlers import EmailComposer, EmailFormatter, GmailQueryBuilder
 from klabautermann.core.logger import logger
 from klabautermann.core.models import ActionRequest, ActionResult, ActionType, AgentMessage
+from klabautermann.core.workflow_inspector import log_thinking
 from klabautermann.mcp.client import ToolInvocationContext
 from klabautermann.mcp.google_workspace import GoogleWorkspaceBridge
 
@@ -123,8 +124,33 @@ ERROR HANDLING:
             )
 
         try:
+            # Log THINKING phase: parsing decision
+            log_thinking(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "parsing",
+                    "decision": "parsing action request",
+                    "action": action[:100] if action else None,
+                    "action_type": action_type,
+                    "has_gmail_query": bool(gmail_query),
+                },
+            )
+
             # Parse the action request
             request = await self._parse_action(action, context, msg.trace_id)
+
+            # Log THINKING phase: parsed result
+            log_thinking(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "parsed",
+                    "action_type": request.type.value if request.type else "unknown",
+                    "target": request.target,
+                    "subject": request.subject[:50] if request.subject else None,
+                },
+            )
 
             logger.debug(
                 f"[WHISPER] Parsed action: {request.type}",
@@ -133,8 +159,31 @@ ERROR HANDLING:
 
             # Validate the request
             validation = await self._validate_request(request, context, msg.trace_id)
+
+            # Log THINKING phase: validation result
+            log_thinking(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "validation",
+                    "passed": validation.success,
+                    "message": validation.message[:100] if validation.message else None,
+                },
+            )
+
             if not validation.success:
                 return self._create_response(msg, validation)
+
+            # Log THINKING phase: execution decision
+            log_thinking(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "execution",
+                    "decision": f"executing {request.type.value if request.type else 'action'}",
+                    "target": request.target,
+                },
+            )
 
             # Execute the action
             result = await self._execute_action(request, context, msg.trace_id)

--- a/src/klabautermann/agents/ingestor.py
+++ b/src/klabautermann/agents/ingestor.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from klabautermann.agents.base_agent import BaseAgent
 from klabautermann.core.logger import logger
+from klabautermann.core.workflow_inspector import log_thinking
 
 
 if TYPE_CHECKING:
@@ -109,6 +110,20 @@ class Ingestor(BaseAgent):
         # Clean input before sending to Graphiti
         cleaned = self.clean_input(text)
 
+        # Log THINKING phase: text cleaning decision
+        log_thinking(
+            trace_id=msg.trace_id,
+            agent_name=self.name,
+            data={
+                "step": "text_cleaning",
+                "original_length": len(text),
+                "cleaned_length": len(cleaned),
+                "removed_chars": len(text) - len(cleaned),
+                "text_preview": text[:100] + "..." if len(text) > 100 else text,
+                "cleaned_preview": cleaned[:100] + "..." if len(cleaned) > 100 else cleaned,
+            },
+        )
+
         if not cleaned:
             logger.debug(
                 "[WHISPER] Text cleaned to empty - skipping ingestion",
@@ -128,6 +143,19 @@ class Ingestor(BaseAgent):
         )
 
         try:
+            # Log THINKING phase: Graphiti ingestion decision
+            log_thinking(
+                trace_id=msg.trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "graphiti_ingestion",
+                    "decision": "sending to Graphiti for entity extraction",
+                    "content_length": len(cleaned),
+                    "captain_uuid": captain_uuid,
+                    "will_link_entities": bool(message_uuid and self.neo4j and self.graphiti),
+                },
+            )
+
             # Pass cleaned text directly to Graphiti
             # Graphiti's internal LLM handles entity/relationship extraction
             episode_name = await self._ingest_to_graphiti(
@@ -138,6 +166,17 @@ class Ingestor(BaseAgent):
 
             # Link extracted entities to source message (Bug #350 fix)
             if episode_name and message_uuid and self.neo4j and self.graphiti:
+                # Log THINKING phase: entity linking
+                log_thinking(
+                    trace_id=msg.trace_id,
+                    agent_name=self.name,
+                    data={
+                        "step": "entity_linking",
+                        "decision": "linking entities to source message",
+                        "episode_name": episode_name,
+                        "message_uuid": message_uuid[:8] if message_uuid else None,
+                    },
+                )
                 await self._link_entities_to_message(
                     episode_name=episode_name,
                     message_uuid=message_uuid,

--- a/src/klabautermann/agents/researcher.py
+++ b/src/klabautermann/agents/researcher.py
@@ -39,6 +39,7 @@ from klabautermann.agents.researcher_models import (
 from klabautermann.agents.researcher_prompts import PLANNING_PROMPT, SYNTHESIS_PROMPT
 from klabautermann.core.logger import logger
 from klabautermann.core.models import AgentMessage
+from klabautermann.core.workflow_inspector import log_thinking
 
 
 if TYPE_CHECKING:
@@ -259,9 +260,43 @@ class Researcher(BaseAgent):
             start_time = time.time()
 
             # Step 1: Plan search strategies using Opus
+            # Log THINKING phase: planning decision
+            log_thinking(
+                trace_id=trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "planning",
+                    "decision": "using Opus to plan search strategies",
+                    "query": query,
+                    "context_keys": list(context.keys()) if context else [],
+                },
+            )
+
             plan = await self._plan_search(query, context, trace_id)
 
             planning_time = (time.time() - start_time) * 1000
+
+            # Log THINKING phase: plan result
+            log_thinking(
+                trace_id=trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "plan_ready",
+                    "reasoning": plan.reasoning,
+                    "strategies": [
+                        {
+                            "technique": s.technique.value,
+                            "query": s.query,
+                            "rationale": s.rationale,
+                        }
+                        for s in plan.strategies
+                    ],
+                    "expected_result_type": plan.expected_result_type,
+                    "zoom_level": plan.zoom_level,
+                    "planning_ms": planning_time,
+                },
+            )
+
             logger.info(
                 "[BEACON] Search plan ready",
                 extra={
@@ -279,6 +314,24 @@ class Researcher(BaseAgent):
             # Step 3: Aggregate and score results
             aggregated = self._aggregate_results(results_by_technique, max_results)
 
+            # Log THINKING phase: search results summary
+            log_thinking(
+                trace_id=trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "search_complete",
+                    "raw_results_by_technique": {
+                        k: len(v) for k, v in results_by_technique.items()
+                    },
+                    "aggregated_count": len(aggregated),
+                    "top_results": [
+                        {"content": r.content[:100], "technique": r.source_technique.value}
+                        for r in aggregated[:5]
+                    ],
+                    "execution_ms": execution_time,
+                },
+            )
+
             logger.info(
                 "[BEACON] Search execution complete",
                 extra={
@@ -290,6 +343,17 @@ class Researcher(BaseAgent):
             )
 
             # Step 4: Synthesize report using Opus
+            # Log THINKING phase: synthesis decision
+            log_thinking(
+                trace_id=trace_id,
+                agent_name=self.name,
+                data={
+                    "step": "synthesis",
+                    "decision": "using Opus to synthesize report from results",
+                    "result_count": len(aggregated),
+                },
+            )
+
             synth_start = time.time()
             report = await self._synthesize_report(query, aggregated, plan, trace_id)
             synthesis_time = (time.time() - synth_start) * 1000

--- a/src/klabautermann/core/__init__.py
+++ b/src/klabautermann/core/__init__.py
@@ -6,6 +6,7 @@ Contains:
 - ontology: Graph schema constants
 - logger: Nautical logging system
 - exceptions: Custom exception types
+- workflow_inspector: Agent workflow inspection for debugging
 """
 
 from klabautermann.core.exceptions import (
@@ -15,6 +16,15 @@ from klabautermann.core.exceptions import (
     KlabautermannError,
     ValidationError,
 )
+from klabautermann.core.workflow_inspector import (
+    WorkflowEntry,
+    WorkflowInspector,
+    WorkflowPhase,
+    get_inspector,
+    log_output,
+    log_request,
+    log_thinking,
+)
 
 
 __all__ = [
@@ -23,4 +33,11 @@ __all__ = [
     "GraphConnectionError",
     "KlabautermannError",
     "ValidationError",
+    "WorkflowEntry",
+    "WorkflowInspector",
+    "WorkflowPhase",
+    "get_inspector",
+    "log_output",
+    "log_request",
+    "log_thinking",
 ]

--- a/src/klabautermann/core/workflow_inspector.py
+++ b/src/klabautermann/core/workflow_inspector.py
@@ -1,0 +1,383 @@
+"""
+Agent workflow inspection system for Klabautermann.
+
+Provides detailed logging of agent workflows for debugging and analysis.
+Each agent logs three phases:
+1. REQUEST: The incoming message/task
+2. THINKING: Internal processing, decisions, LLM calls
+3. OUTPUT: The result/response
+
+The inspector can be configured to log to file, console, or both,
+with optional filtering by agent name or trace ID.
+
+Reference: Issue #357
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from klabautermann.core.logger import logger
+
+
+class WorkflowPhase(str, Enum):
+    """Phases of agent workflow execution."""
+
+    REQUEST = "REQUEST"
+    THINKING = "THINKING"
+    OUTPUT = "OUTPUT"
+
+
+@dataclass
+class WorkflowEntry:
+    """A single workflow log entry."""
+
+    trace_id: str
+    agent_name: str
+    phase: WorkflowPhase
+    timestamp: datetime
+    data: dict[str, Any]
+    duration_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "trace_id": self.trace_id,
+            "agent": self.agent_name,
+            "phase": self.phase.value,
+            "timestamp": self.timestamp.isoformat(),
+            "duration_ms": self.duration_ms,
+            "data": self.data,
+        }
+
+    def format_console(self) -> str:
+        """Format for console display with clear visual separation."""
+        timestamp_str = self.timestamp.strftime("%H:%M:%S.%f")[:-3]
+        phase_markers = {
+            WorkflowPhase.REQUEST: ">>>",
+            WorkflowPhase.THINKING: "...",
+            WorkflowPhase.OUTPUT: "<<<",
+        }
+        marker = phase_markers.get(self.phase, "---")
+
+        # Build header line
+        header = f"{marker} [{self.phase.value}] {self.agent_name} | trace={self.trace_id[:8]} | {timestamp_str}"
+        if self.duration_ms is not None:
+            header += f" | {self.duration_ms:.1f}ms"
+
+        # Build data section with indentation
+        lines = [header]
+        for key, value in self.data.items():
+            if isinstance(value, dict):
+                lines.append(f"    {key}:")
+                for k, v in value.items():
+                    # Truncate long values
+                    v_str = str(v)
+                    if len(v_str) > 200:
+                        v_str = v_str[:200] + "..."
+                    lines.append(f"      {k}: {v_str}")
+            elif isinstance(value, list) and len(value) > 5:
+                lines.append(f"    {key}: [{len(value)} items]")
+            else:
+                v_str = str(value)
+                if len(v_str) > 200:
+                    v_str = v_str[:200] + "..."
+                lines.append(f"    {key}: {v_str}")
+
+        return "\n".join(lines)
+
+
+@dataclass
+class WorkflowInspector:
+    """
+    Inspects and logs agent workflows.
+
+    Provides methods for agents to log their REQUEST, THINKING, and OUTPUT
+    phases with structured data. Can write to file, console, or both.
+
+    Usage:
+        inspector = WorkflowInspector.get_instance()
+        inspector.log_request(trace_id, "researcher", {"query": "find John"})
+        inspector.log_thinking(trace_id, "researcher", {"search_type": "hybrid"})
+        inspector.log_output(trace_id, "researcher", {"results": [...]})
+    """
+
+    enabled: bool = True
+    log_to_file: bool = True
+    log_to_console: bool = True
+    log_file: Path | None = None
+    filter_agents: set[str] = field(default_factory=set)
+    filter_trace_ids: set[str] = field(default_factory=set)
+
+    # In-memory buffer for recent entries (for testing/inspection)
+    _entries: list[WorkflowEntry] = field(default_factory=list)
+    _max_entries: int = 1000
+
+    # Singleton instance
+    _instance: WorkflowInspector | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize from environment variables."""
+        # Check if inspection is enabled
+        if os.getenv("WORKFLOW_INSPECT", "").lower() in ("false", "0", "no"):
+            self.enabled = False
+
+        # Log file path - only override if not explicitly passed and env var set
+        log_path = os.getenv("WORKFLOW_LOG_FILE")
+        if log_path:
+            self.log_file = Path(log_path)
+        elif self.log_file is None and self.log_to_file:
+            self.log_file = Path("logs/workflow_inspection.jsonl")
+
+        # Console output
+        if os.getenv("WORKFLOW_CONSOLE", "").lower() in ("false", "0", "no"):
+            self.log_to_console = False
+
+        # Filter by agent names (comma-separated)
+        if agent_filter := os.getenv("WORKFLOW_FILTER_AGENTS"):
+            self.filter_agents = set(agent_filter.split(","))
+
+    def _ensure_log_directory(self) -> None:
+        """Ensure log file directory exists."""
+        if self.log_file:
+            self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def get_instance(cls) -> WorkflowInspector:
+        """Get or create the singleton inspector instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton instance (for testing)."""
+        cls._instance = None
+
+    def _should_log(self, agent_name: str, trace_id: str) -> bool:
+        """Check if this entry should be logged based on filters."""
+        if not self.enabled:
+            return False
+
+        # If filters are set, entry must match at least one
+        if self.filter_agents and agent_name not in self.filter_agents:
+            return False
+
+        if self.filter_trace_ids and trace_id not in self.filter_trace_ids:
+            return False
+
+        return True
+
+    def _log_entry(self, entry: WorkflowEntry) -> None:
+        """Log an entry to all configured outputs."""
+        if not self._should_log(entry.agent_name, entry.trace_id):
+            return
+
+        # Add to in-memory buffer
+        self._entries.append(entry)
+        if len(self._entries) > self._max_entries:
+            self._entries = self._entries[-self._max_entries :]
+
+        # Log to file (JSON lines format)
+        if self.log_to_file and self.log_file:
+            self._ensure_log_directory()
+            with self.log_file.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry.to_dict()) + "\n")
+
+        # Log to console via logger
+        if self.log_to_console:
+            # Use info level with special marker for workflow inspection
+            logger.info(
+                f"[WORKFLOW] {entry.format_console()}",
+                extra={
+                    "trace_id": entry.trace_id,
+                    "agent_name": entry.agent_name,
+                    "workflow_phase": entry.phase.value,
+                },
+            )
+
+    def log_request(
+        self,
+        trace_id: str,
+        agent_name: str,
+        data: dict[str, Any],
+    ) -> None:
+        """
+        Log the REQUEST phase of an agent workflow.
+
+        Args:
+            trace_id: Request trace ID for correlation.
+            agent_name: Name of the agent receiving the request.
+            data: Request data (intent, payload, source, etc.).
+        """
+        entry = WorkflowEntry(
+            trace_id=trace_id,
+            agent_name=agent_name,
+            phase=WorkflowPhase.REQUEST,
+            timestamp=datetime.now(UTC),
+            data=data,
+        )
+        self._log_entry(entry)
+
+    def log_thinking(
+        self,
+        trace_id: str,
+        agent_name: str,
+        data: dict[str, Any],
+    ) -> None:
+        """
+        Log the THINKING phase of an agent workflow.
+
+        Args:
+            trace_id: Request trace ID for correlation.
+            agent_name: Name of the agent processing.
+            data: Thinking data (decisions, LLM prompts, intermediate results).
+        """
+        entry = WorkflowEntry(
+            trace_id=trace_id,
+            agent_name=agent_name,
+            phase=WorkflowPhase.THINKING,
+            timestamp=datetime.now(UTC),
+            data=data,
+        )
+        self._log_entry(entry)
+
+    def log_output(
+        self,
+        trace_id: str,
+        agent_name: str,
+        data: dict[str, Any],
+        duration_ms: float | None = None,
+    ) -> None:
+        """
+        Log the OUTPUT phase of an agent workflow.
+
+        Args:
+            trace_id: Request trace ID for correlation.
+            agent_name: Name of the agent producing output.
+            data: Output data (results, response, errors).
+            duration_ms: Total processing time in milliseconds.
+        """
+        entry = WorkflowEntry(
+            trace_id=trace_id,
+            agent_name=agent_name,
+            phase=WorkflowPhase.OUTPUT,
+            timestamp=datetime.now(UTC),
+            data=data,
+            duration_ms=duration_ms,
+        )
+        self._log_entry(entry)
+
+    def get_entries(
+        self,
+        trace_id: str | None = None,
+        agent_name: str | None = None,
+        phase: WorkflowPhase | None = None,
+    ) -> list[WorkflowEntry]:
+        """
+        Get workflow entries from the in-memory buffer.
+
+        Args:
+            trace_id: Filter by trace ID.
+            agent_name: Filter by agent name.
+            phase: Filter by workflow phase.
+
+        Returns:
+            List of matching workflow entries.
+        """
+        entries = self._entries
+
+        if trace_id:
+            entries = [e for e in entries if e.trace_id == trace_id]
+
+        if agent_name:
+            entries = [e for e in entries if e.agent_name == agent_name]
+
+        if phase:
+            entries = [e for e in entries if e.phase == phase]
+
+        return entries
+
+    def get_workflow_summary(self, trace_id: str) -> dict[str, Any]:
+        """
+        Get a summary of all workflow entries for a trace.
+
+        Args:
+            trace_id: The trace ID to summarize.
+
+        Returns:
+            Dictionary with agents and their phases.
+        """
+        entries = self.get_entries(trace_id=trace_id)
+
+        summary: dict[str, dict[str, Any]] = {}
+        for entry in entries:
+            if entry.agent_name not in summary:
+                summary[entry.agent_name] = {
+                    "phases": [],
+                    "total_duration_ms": 0.0,
+                }
+            summary[entry.agent_name]["phases"].append(entry.phase.value)
+            if entry.duration_ms:
+                summary[entry.agent_name]["total_duration_ms"] += entry.duration_ms
+
+        return {
+            "trace_id": trace_id,
+            "agents": summary,
+            "total_entries": len(entries),
+        }
+
+    def clear(self) -> None:
+        """Clear the in-memory entry buffer."""
+        self._entries = []
+
+
+# ===========================================================================
+# Convenience Functions
+# ===========================================================================
+
+
+def get_inspector() -> WorkflowInspector:
+    """Get the global workflow inspector instance."""
+    return WorkflowInspector.get_instance()
+
+
+def log_request(trace_id: str, agent_name: str, data: dict[str, Any]) -> None:
+    """Log a REQUEST phase entry."""
+    get_inspector().log_request(trace_id, agent_name, data)
+
+
+def log_thinking(trace_id: str, agent_name: str, data: dict[str, Any]) -> None:
+    """Log a THINKING phase entry."""
+    get_inspector().log_thinking(trace_id, agent_name, data)
+
+
+def log_output(
+    trace_id: str,
+    agent_name: str,
+    data: dict[str, Any],
+    duration_ms: float | None = None,
+) -> None:
+    """Log an OUTPUT phase entry."""
+    get_inspector().log_output(trace_id, agent_name, data, duration_ms)
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "WorkflowEntry",
+    "WorkflowInspector",
+    "WorkflowPhase",
+    "get_inspector",
+    "log_output",
+    "log_request",
+    "log_thinking",
+]

--- a/tests/unit/test_workflow_inspector.py
+++ b/tests/unit/test_workflow_inspector.py
@@ -1,0 +1,385 @@
+"""
+Tests for the agent workflow inspection system.
+
+Reference: Issue #357
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from klabautermann.core.workflow_inspector import (
+    WorkflowEntry,
+    WorkflowInspector,
+    WorkflowPhase,
+    get_inspector,
+    log_output,
+    log_request,
+    log_thinking,
+)
+
+
+class TestWorkflowPhase:
+    """Tests for WorkflowPhase enum."""
+
+    def test_phase_values(self) -> None:
+        """Verify phase enum values."""
+        assert WorkflowPhase.REQUEST.value == "REQUEST"
+        assert WorkflowPhase.THINKING.value == "THINKING"
+        assert WorkflowPhase.OUTPUT.value == "OUTPUT"
+
+    def test_phase_string_enum(self) -> None:
+        """Verify phase is a string enum for JSON serialization."""
+        assert isinstance(WorkflowPhase.REQUEST.value, str)
+
+
+class TestWorkflowEntry:
+    """Tests for WorkflowEntry dataclass."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        timestamp = datetime.now(UTC)
+        entry = WorkflowEntry(
+            trace_id="abc123",
+            agent_name="researcher",
+            phase=WorkflowPhase.REQUEST,
+            timestamp=timestamp,
+            data={"query": "find John"},
+            duration_ms=150.5,
+        )
+
+        result = entry.to_dict()
+
+        assert result["trace_id"] == "abc123"
+        assert result["agent"] == "researcher"
+        assert result["phase"] == "REQUEST"
+        assert result["timestamp"] == timestamp.isoformat()
+        assert result["duration_ms"] == 150.5
+        assert result["data"]["query"] == "find John"
+
+    def test_to_dict_without_duration(self) -> None:
+        """Test conversion when duration is None."""
+        entry = WorkflowEntry(
+            trace_id="abc123",
+            agent_name="ingestor",
+            phase=WorkflowPhase.THINKING,
+            timestamp=datetime.now(UTC),
+            data={"step": "cleaning"},
+        )
+
+        result = entry.to_dict()
+        assert result["duration_ms"] is None
+
+    def test_format_console_request(self) -> None:
+        """Test console formatting for REQUEST phase."""
+        entry = WorkflowEntry(
+            trace_id="abc12345",
+            agent_name="executor",
+            phase=WorkflowPhase.REQUEST,
+            timestamp=datetime.now(UTC),
+            data={"action": "send email", "to": "john@example.com"},
+        )
+
+        output = entry.format_console()
+
+        assert ">>>" in output  # REQUEST marker
+        assert "[REQUEST]" in output
+        assert "executor" in output
+        assert "abc12345"[:8] in output
+        assert "action: send email" in output
+
+    def test_format_console_thinking(self) -> None:
+        """Test console formatting for THINKING phase."""
+        entry = WorkflowEntry(
+            trace_id="def67890",
+            agent_name="researcher",
+            phase=WorkflowPhase.THINKING,
+            timestamp=datetime.now(UTC),
+            data={"step": "planning search"},
+        )
+
+        output = entry.format_console()
+
+        assert "..." in output  # THINKING marker
+        assert "[THINKING]" in output
+
+    def test_format_console_output(self) -> None:
+        """Test console formatting for OUTPUT phase."""
+        entry = WorkflowEntry(
+            trace_id="ghi11111",
+            agent_name="ingestor",
+            phase=WorkflowPhase.OUTPUT,
+            timestamp=datetime.now(UTC),
+            data={"status": "success"},
+            duration_ms=250.0,
+        )
+
+        output = entry.format_console()
+
+        assert "<<<" in output  # OUTPUT marker
+        assert "[OUTPUT]" in output
+        assert "250.0ms" in output
+
+    def test_format_console_truncates_long_values(self) -> None:
+        """Test that long values are truncated in console output."""
+        long_text = "x" * 300
+        entry = WorkflowEntry(
+            trace_id="truncate123",
+            agent_name="test",
+            phase=WorkflowPhase.REQUEST,
+            timestamp=datetime.now(UTC),
+            data={"long_field": long_text},
+        )
+
+        output = entry.format_console()
+
+        assert "..." in output
+        # Should not contain the full 300 chars
+        assert len(output) < len(long_text) + 200
+
+
+class TestWorkflowInspector:
+    """Tests for WorkflowInspector class."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> None:
+        """Reset the singleton before each test."""
+        WorkflowInspector.reset_instance()
+
+    def test_singleton_pattern(self) -> None:
+        """Test that get_instance returns singleton."""
+        inspector1 = WorkflowInspector.get_instance()
+        inspector2 = WorkflowInspector.get_instance()
+
+        assert inspector1 is inspector2
+
+    def test_log_request(self) -> None:
+        """Test logging a REQUEST phase entry."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_request(
+            trace_id="req123",
+            agent_name="researcher",
+            data={"query": "find Sarah"},
+        )
+
+        entries = inspector.get_entries()
+        assert len(entries) == 1
+        assert entries[0].phase == WorkflowPhase.REQUEST
+        assert entries[0].agent_name == "researcher"
+        assert entries[0].data["query"] == "find Sarah"
+
+    def test_log_thinking(self) -> None:
+        """Test logging a THINKING phase entry."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_thinking(
+            trace_id="think456",
+            agent_name="executor",
+            data={"step": "validating email"},
+        )
+
+        entries = inspector.get_entries()
+        assert len(entries) == 1
+        assert entries[0].phase == WorkflowPhase.THINKING
+        assert entries[0].data["step"] == "validating email"
+
+    def test_log_output(self) -> None:
+        """Test logging an OUTPUT phase entry."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_output(
+            trace_id="out789",
+            agent_name="ingestor",
+            data={"status": "success", "entities_created": 3},
+            duration_ms=100.5,
+        )
+
+        entries = inspector.get_entries()
+        assert len(entries) == 1
+        assert entries[0].phase == WorkflowPhase.OUTPUT
+        assert entries[0].duration_ms == 100.5
+        assert entries[0].data["entities_created"] == 3
+
+    def test_disabled_inspector_doesnt_log(self) -> None:
+        """Test that disabled inspector doesn't record entries."""
+        inspector = WorkflowInspector(enabled=False, log_to_file=False, log_to_console=False)
+
+        inspector.log_request("test", "agent", {"key": "value"})
+
+        assert len(inspector.get_entries()) == 0
+
+    def test_filter_by_agent(self) -> None:
+        """Test filtering entries by agent name."""
+        inspector = WorkflowInspector(
+            enabled=True,
+            log_to_file=False,
+            log_to_console=False,
+            filter_agents={"researcher"},
+        )
+
+        inspector.log_request("trace1", "researcher", {"a": 1})
+        inspector.log_request("trace2", "executor", {"b": 2})
+        inspector.log_request("trace3", "researcher", {"c": 3})
+
+        # Only researcher entries should be logged
+        entries = inspector.get_entries()
+        assert len(entries) == 2
+        assert all(e.agent_name == "researcher" for e in entries)
+
+    def test_get_entries_filters(self) -> None:
+        """Test filtering when retrieving entries."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_request("trace1", "agent1", {})
+        inspector.log_thinking("trace1", "agent1", {})
+        inspector.log_output("trace1", "agent1", {})
+        inspector.log_request("trace2", "agent2", {})
+
+        # Filter by trace_id
+        entries = inspector.get_entries(trace_id="trace1")
+        assert len(entries) == 3
+
+        # Filter by agent_name
+        entries = inspector.get_entries(agent_name="agent2")
+        assert len(entries) == 1
+
+        # Filter by phase
+        entries = inspector.get_entries(phase=WorkflowPhase.REQUEST)
+        assert len(entries) == 2
+
+        # Combined filters
+        entries = inspector.get_entries(trace_id="trace1", phase=WorkflowPhase.THINKING)
+        assert len(entries) == 1
+
+    def test_get_workflow_summary(self) -> None:
+        """Test generating workflow summary."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_request("trace1", "researcher", {})
+        inspector.log_thinking("trace1", "researcher", {})
+        inspector.log_output("trace1", "researcher", {}, duration_ms=100.0)
+        inspector.log_request("trace1", "executor", {})
+        inspector.log_output("trace1", "executor", {}, duration_ms=50.0)
+
+        summary = inspector.get_workflow_summary("trace1")
+
+        assert summary["trace_id"] == "trace1"
+        assert summary["total_entries"] == 5
+        assert "researcher" in summary["agents"]
+        assert "executor" in summary["agents"]
+        assert summary["agents"]["researcher"]["total_duration_ms"] == 100.0
+        assert summary["agents"]["executor"]["total_duration_ms"] == 50.0
+
+    def test_max_entries_limit(self) -> None:
+        """Test that buffer respects max entries limit."""
+        inspector = WorkflowInspector(
+            enabled=True, log_to_file=False, log_to_console=False, _max_entries=5
+        )
+
+        for i in range(10):
+            inspector.log_request(f"trace{i}", "agent", {"index": i})
+
+        entries = inspector.get_entries()
+        assert len(entries) == 5
+        # Should keep the latest entries
+        assert entries[-1].data["index"] == 9
+
+    def test_clear_entries(self) -> None:
+        """Test clearing the entry buffer."""
+        inspector = WorkflowInspector(enabled=True, log_to_file=False, log_to_console=False)
+
+        inspector.log_request("trace1", "agent", {})
+        inspector.log_request("trace2", "agent", {})
+
+        inspector.clear()
+
+        assert len(inspector.get_entries()) == 0
+
+    def test_log_to_file(self) -> None:
+        """Test logging entries to a file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_file = Path(tmpdir) / "workflow.jsonl"
+            inspector = WorkflowInspector(
+                enabled=True,
+                log_to_file=True,
+                log_to_console=False,
+                log_file=log_file,
+            )
+
+            inspector.log_request("file_trace", "agent", {"key": "value"})
+
+            # Verify file was written
+            assert log_file.exists()
+
+            # Verify content
+            with log_file.open() as f:
+                line = f.readline()
+                entry = json.loads(line)
+                assert entry["trace_id"] == "file_trace"
+                assert entry["phase"] == "REQUEST"
+
+
+class TestConvenienceFunctions:
+    """Tests for module-level convenience functions."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> None:
+        """Reset the singleton before each test."""
+        WorkflowInspector.reset_instance()
+
+    def test_get_inspector(self) -> None:
+        """Test get_inspector returns singleton."""
+        inspector = get_inspector()
+        assert isinstance(inspector, WorkflowInspector)
+        assert get_inspector() is inspector
+
+    @patch.object(WorkflowInspector, "log_request")
+    def test_log_request_function(self, mock_log: object) -> None:
+        """Test log_request convenience function."""
+        log_request("trace", "agent", {"data": 1})
+        # Verifies the function calls through to the singleton
+
+    @patch.object(WorkflowInspector, "log_thinking")
+    def test_log_thinking_function(self, mock_log: object) -> None:
+        """Test log_thinking convenience function."""
+        log_thinking("trace", "agent", {"step": "test"})
+
+    @patch.object(WorkflowInspector, "log_output")
+    def test_log_output_function(self, mock_log: object) -> None:
+        """Test log_output convenience function."""
+        log_output("trace", "agent", {"result": "ok"}, duration_ms=50.0)
+
+
+class TestEnvironmentConfiguration:
+    """Tests for environment variable configuration."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self) -> None:
+        """Reset the singleton before each test."""
+        WorkflowInspector.reset_instance()
+
+    def test_disabled_via_env(self) -> None:
+        """Test disabling via WORKFLOW_INSPECT=false."""
+        with patch.dict("os.environ", {"WORKFLOW_INSPECT": "false"}):
+            inspector = WorkflowInspector()
+            assert not inspector.enabled
+
+    def test_filter_agents_via_env(self) -> None:
+        """Test filtering agents via WORKFLOW_FILTER_AGENTS."""
+        with patch.dict("os.environ", {"WORKFLOW_FILTER_AGENTS": "researcher,executor"}):
+            inspector = WorkflowInspector()
+            assert "researcher" in inspector.filter_agents
+            assert "executor" in inspector.filter_agents
+
+    def test_console_disabled_via_env(self) -> None:
+        """Test disabling console via WORKFLOW_CONSOLE=false."""
+        with patch.dict("os.environ", {"WORKFLOW_CONSOLE": "false"}):
+            inspector = WorkflowInspector()
+            assert not inspector.log_to_console


### PR DESCRIPTION
## Summary
- Add `WorkflowInspector` class for debugging agent workflows
- Log each agent's REQUEST, THINKING, and OUTPUT phases separately
- Support file output, console output, and in-memory buffer for testing
- Environment variable configuration for filtering and enabling/disabling

## Changes
- `src/klabautermann/core/workflow_inspector.py`: New module with inspection system
- `src/klabautermann/agents/base_agent.py`: Automatic REQUEST/OUTPUT logging
- `src/klabautermann/agents/ingestor.py`: THINKING phase logging
- `src/klabautermann/agents/researcher.py`: THINKING phase logging
- `src/klabautermann/agents/executor.py`: THINKING phase logging
- 26 new unit tests

## Test plan
- [x] Run `pytest tests/unit/test_workflow_inspector.py` - 26 tests pass
- [x] Run full unit test suite - 1651 tests pass
- [x] All pre-commit hooks pass (ruff, mypy)

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)