### PR TITLE
feat(metrics): Add Prometheus metrics export (#271)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "apscheduler>=3.10",
     # File watching for config hot-reload
     "watchdog>=4.0",
+    # Prometheus metrics
+    "prometheus-client>=0.20",
 ]
 
 [project.optional-dependencies]

--- a/src/klabautermann/agents/base_agent.py
+++ b/src/klabautermann/agents/base_agent.py
@@ -15,6 +15,14 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from klabautermann.core.logger import logger
+from klabautermann.core.metrics import (
+    record_agent_error,
+    record_agent_latency,
+    record_agent_request,
+    record_agent_success,
+    set_agent_inbox_size,
+    set_agent_running,
+)
 from klabautermann.core.models import AgentMessage
 from klabautermann.core.workflow_inspector import get_inspector
 
@@ -92,6 +100,7 @@ class BaseAgent(ABC):
         with timing, error handling, and metrics collection.
         """
         self._running = True
+        set_agent_running(self.name, running=True)
         logger.info(
             f"[CHART] Agent '{self.name}' started",
             extra={"agent_name": self.name},
@@ -118,6 +127,7 @@ class BaseAgent(ABC):
                     exc_info=True,
                 )
 
+        set_agent_running(self.name, running=False)
         logger.info(
             f"[CHART] Agent '{self.name}' stopped",
             extra={"agent_name": self.name},
@@ -132,6 +142,8 @@ class BaseAgent(ABC):
         """
         start_time = time.time()
         self._request_count += 1
+        record_agent_request(self.name)
+        set_agent_inbox_size(self.name, self.inbox.qsize())
         inspector = get_inspector()
 
         try:
@@ -184,6 +196,7 @@ class BaseAgent(ABC):
                 )
 
             self._success_count += 1
+            record_agent_success(self.name)
             logger.debug(
                 f"[WHISPER] {self.name} completed",
                 extra={"trace_id": msg.trace_id, "agent_name": self.name},
@@ -191,6 +204,7 @@ class BaseAgent(ABC):
 
         except Exception as e:
             self._error_count += 1
+            record_agent_error(self.name)
             elapsed_ms = (time.time() - start_time) * 1000
 
             # Log OUTPUT phase with error
@@ -211,6 +225,8 @@ class BaseAgent(ABC):
         finally:
             elapsed_ms = (time.time() - start_time) * 1000
             self._total_latency_ms += elapsed_ms
+            record_agent_latency(self.name, elapsed_ms)
+            set_agent_inbox_size(self.name, self.inbox.qsize())
             self.inbox.task_done()
 
     async def _route_response(

--- a/src/klabautermann/api/server.py
+++ b/src/klabautermann/api/server.py
@@ -2,12 +2,22 @@
 FastAPI WebSocket server for Klabautermann.
 
 Provides WebSocket endpoint for TUI clients to communicate with the orchestrator.
+Exposes Prometheus metrics at /metrics endpoint.
 """
 
 import json
+import time
 from typing import Any
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+
+from klabautermann.core.metrics import (
+    decrement_websocket_connections,
+    get_metrics,
+    increment_websocket_connections,
+    record_api_latency,
+    record_api_request,
+)
 
 
 app = FastAPI(title="Klabautermann API", version="0.1.0")
@@ -22,16 +32,53 @@ def set_orchestrator(orchestrator: Any) -> None:
     _orchestrator = orchestrator
 
 
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+    """Middleware to record API request metrics."""
+    start_time = time.perf_counter()
+    response = await call_next(request)
+    elapsed = time.perf_counter() - start_time
+
+    # Skip metrics endpoint to avoid recursion
+    if request.url.path != "/metrics":
+        record_api_request(
+            method=request.method,
+            endpoint=request.url.path,
+            status_code=response.status_code,
+        )
+        record_api_latency(
+            method=request.method,
+            endpoint=request.url.path,
+            latency_seconds=elapsed,
+        )
+
+    return response
+
+
 @app.get("/health")
 async def health_check() -> dict[str, str]:
     """Health check endpoint."""
     return {"status": "healthy"}
 
 
+@app.get("/metrics")
+async def metrics_endpoint() -> Response:
+    """
+    Prometheus metrics endpoint.
+
+    Returns metrics in Prometheus text exposition format.
+    """
+    return Response(
+        content=get_metrics(),
+        media_type="text/plain; version=0.0.4; charset=utf-8",
+    )
+
+
 @app.websocket("/ws/chat")
 async def websocket_chat(websocket: WebSocket) -> None:
     """WebSocket endpoint for chat communication."""
     await websocket.accept()
+    increment_websocket_connections()
 
     try:
         while True:
@@ -58,6 +105,8 @@ async def websocket_chat(websocket: WebSocket) -> None:
 
     except WebSocketDisconnect:
         pass
+    finally:
+        decrement_websocket_connections()
 
 
 async def handle_chat_message(websocket: WebSocket, message: dict[str, Any]) -> None:

--- a/src/klabautermann/core/metrics.py
+++ b/src/klabautermann/core/metrics.py
@@ -1,0 +1,362 @@
+"""
+Prometheus metrics for Klabautermann.
+
+Provides instrumentation for agent performance, API health, and system observability.
+Metrics are exposed via /metrics endpoint in Prometheus text format.
+
+Reference: specs/infrastructure/DEPLOYMENT.md
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from prometheus_client.multiprocess import MultiProcessCollector
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# ===========================================================================
+# Default Registry
+# ===========================================================================
+
+# Use a custom registry to avoid conflicts and support multiprocess mode
+REGISTRY = CollectorRegistry()
+
+# Check if running in multiprocess mode (e.g., gunicorn with multiple workers)
+try:
+    MultiProcessCollector(REGISTRY)
+    _MULTIPROCESS_MODE = True
+except ValueError:
+    # Not in multiprocess mode, use default collector
+    _MULTIPROCESS_MODE = False
+
+
+# ===========================================================================
+# Agent Metrics
+# ===========================================================================
+
+# Request counter per agent
+AGENT_REQUESTS_TOTAL = Counter(
+    "klabautermann_agent_requests_total",
+    "Total number of requests processed by agents",
+    ["agent_name"],
+    registry=REGISTRY,
+)
+
+# Success counter per agent
+AGENT_SUCCESSES_TOTAL = Counter(
+    "klabautermann_agent_successes_total",
+    "Total number of successful requests by agents",
+    ["agent_name"],
+    registry=REGISTRY,
+)
+
+# Error counter per agent
+AGENT_ERRORS_TOTAL = Counter(
+    "klabautermann_agent_errors_total",
+    "Total number of errors by agents",
+    ["agent_name"],
+    registry=REGISTRY,
+)
+
+# Request latency histogram per agent (in milliseconds)
+AGENT_REQUEST_LATENCY_MS = Histogram(
+    "klabautermann_agent_request_latency_ms",
+    "Request latency in milliseconds by agent",
+    ["agent_name"],
+    buckets=[10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    registry=REGISTRY,
+)
+
+# Currently running agents gauge
+AGENT_RUNNING = Gauge(
+    "klabautermann_agent_running",
+    "Whether an agent is currently running (1=running, 0=stopped)",
+    ["agent_name"],
+    registry=REGISTRY,
+)
+
+# Agent inbox queue size
+AGENT_INBOX_SIZE = Gauge(
+    "klabautermann_agent_inbox_size",
+    "Number of messages in agent inbox queue",
+    ["agent_name"],
+    registry=REGISTRY,
+)
+
+
+# ===========================================================================
+# API Metrics
+# ===========================================================================
+
+# HTTP request counter
+API_REQUESTS_TOTAL = Counter(
+    "klabautermann_api_requests_total",
+    "Total number of API requests",
+    ["method", "endpoint", "status_code"],
+    registry=REGISTRY,
+)
+
+# HTTP request latency histogram (in seconds)
+API_REQUEST_LATENCY_SECONDS = Histogram(
+    "klabautermann_api_request_latency_seconds",
+    "API request latency in seconds",
+    ["method", "endpoint"],
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0],
+    registry=REGISTRY,
+)
+
+# Active WebSocket connections
+API_WEBSOCKET_CONNECTIONS = Gauge(
+    "klabautermann_api_websocket_connections",
+    "Number of active WebSocket connections",
+    registry=REGISTRY,
+)
+
+
+# ===========================================================================
+# Memory/Graph Metrics
+# ===========================================================================
+
+# Graph operations counter
+GRAPH_OPERATIONS_TOTAL = Counter(
+    "klabautermann_graph_operations_total",
+    "Total number of graph operations",
+    ["operation_type"],  # search, add_episode, get_entity, etc.
+    registry=REGISTRY,
+)
+
+# Graph operation latency
+GRAPH_OPERATION_LATENCY_SECONDS = Histogram(
+    "klabautermann_graph_operation_latency_seconds",
+    "Graph operation latency in seconds",
+    ["operation_type"],
+    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
+    registry=REGISTRY,
+)
+
+
+# ===========================================================================
+# LLM Metrics
+# ===========================================================================
+
+# LLM calls counter
+LLM_CALLS_TOTAL = Counter(
+    "klabautermann_llm_calls_total",
+    "Total number of LLM API calls",
+    ["model", "purpose"],  # model: haiku/sonnet/opus, purpose: extraction/search/reasoning
+    registry=REGISTRY,
+)
+
+# LLM token usage
+LLM_TOKENS_TOTAL = Counter(
+    "klabautermann_llm_tokens_total",
+    "Total tokens used in LLM calls",
+    ["model", "token_type"],  # token_type: input/output
+    registry=REGISTRY,
+)
+
+# LLM call latency
+LLM_CALL_LATENCY_SECONDS = Histogram(
+    "klabautermann_llm_call_latency_seconds",
+    "LLM API call latency in seconds",
+    ["model"],
+    buckets=[0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0],
+    registry=REGISTRY,
+)
+
+
+# ===========================================================================
+# Helper Functions
+# ===========================================================================
+
+
+def get_metrics() -> bytes:
+    """
+    Generate metrics in Prometheus text format.
+
+    Returns:
+        Metrics as bytes in Prometheus exposition format.
+    """
+    return bytes(generate_latest(REGISTRY))
+
+
+def record_agent_request(agent_name: str) -> None:
+    """Record an agent request."""
+    AGENT_REQUESTS_TOTAL.labels(agent_name=agent_name).inc()
+
+
+def record_agent_success(agent_name: str) -> None:
+    """Record an agent success."""
+    AGENT_SUCCESSES_TOTAL.labels(agent_name=agent_name).inc()
+
+
+def record_agent_error(agent_name: str) -> None:
+    """Record an agent error."""
+    AGENT_ERRORS_TOTAL.labels(agent_name=agent_name).inc()
+
+
+def record_agent_latency(agent_name: str, latency_ms: float) -> None:
+    """Record agent request latency in milliseconds."""
+    AGENT_REQUEST_LATENCY_MS.labels(agent_name=agent_name).observe(latency_ms)
+
+
+def set_agent_running(agent_name: str, running: bool) -> None:
+    """Set agent running status."""
+    AGENT_RUNNING.labels(agent_name=agent_name).set(1 if running else 0)
+
+
+def set_agent_inbox_size(agent_name: str, size: int) -> None:
+    """Set agent inbox queue size."""
+    AGENT_INBOX_SIZE.labels(agent_name=agent_name).set(size)
+
+
+def record_api_request(method: str, endpoint: str, status_code: int) -> None:
+    """Record an API request."""
+    API_REQUESTS_TOTAL.labels(method=method, endpoint=endpoint, status_code=str(status_code)).inc()
+
+
+def record_api_latency(method: str, endpoint: str, latency_seconds: float) -> None:
+    """Record API request latency in seconds."""
+    API_REQUEST_LATENCY_SECONDS.labels(method=method, endpoint=endpoint).observe(latency_seconds)
+
+
+def set_websocket_connections(count: int) -> None:
+    """Set the number of active WebSocket connections."""
+    API_WEBSOCKET_CONNECTIONS.set(count)
+
+
+def increment_websocket_connections() -> None:
+    """Increment WebSocket connection count."""
+    API_WEBSOCKET_CONNECTIONS.inc()
+
+
+def decrement_websocket_connections() -> None:
+    """Decrement WebSocket connection count."""
+    API_WEBSOCKET_CONNECTIONS.dec()
+
+
+def record_graph_operation(operation_type: str) -> None:
+    """Record a graph operation."""
+    GRAPH_OPERATIONS_TOTAL.labels(operation_type=operation_type).inc()
+
+
+def record_graph_latency(operation_type: str, latency_seconds: float) -> None:
+    """Record graph operation latency in seconds."""
+    GRAPH_OPERATION_LATENCY_SECONDS.labels(operation_type=operation_type).observe(latency_seconds)
+
+
+def record_llm_call(model: str, purpose: str) -> None:
+    """Record an LLM API call."""
+    LLM_CALLS_TOTAL.labels(model=model, purpose=purpose).inc()
+
+
+def record_llm_tokens(model: str, input_tokens: int, output_tokens: int) -> None:
+    """Record LLM token usage."""
+    LLM_TOKENS_TOTAL.labels(model=model, token_type="input").inc(input_tokens)
+    LLM_TOKENS_TOTAL.labels(model=model, token_type="output").inc(output_tokens)
+
+
+def record_llm_latency(model: str, latency_seconds: float) -> None:
+    """Record LLM API call latency in seconds."""
+    LLM_CALL_LATENCY_SECONDS.labels(model=model).observe(latency_seconds)
+
+
+def timed_operation(metric_func: Callable[[str, float], None], label: str) -> Callable:
+    """
+    Decorator for timing operations.
+
+    Args:
+        metric_func: Function to record latency (e.g., record_graph_latency).
+        label: Label value for the metric.
+
+    Returns:
+        Decorator function.
+    """
+    import functools
+    import time
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            start = time.perf_counter()
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                elapsed = time.perf_counter() - start
+                metric_func(label, elapsed)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            start = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                elapsed = time.perf_counter() - start
+                metric_func(label, elapsed)
+
+        import asyncio
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorator
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "AGENT_ERRORS_TOTAL",
+    "AGENT_INBOX_SIZE",
+    # Agent metrics
+    "AGENT_REQUESTS_TOTAL",
+    "AGENT_REQUEST_LATENCY_MS",
+    "AGENT_RUNNING",
+    "AGENT_SUCCESSES_TOTAL",
+    # API metrics
+    "API_REQUESTS_TOTAL",
+    "API_REQUEST_LATENCY_SECONDS",
+    "API_WEBSOCKET_CONNECTIONS",
+    # Graph metrics
+    "GRAPH_OPERATIONS_TOTAL",
+    "GRAPH_OPERATION_LATENCY_SECONDS",
+    # LLM metrics
+    "LLM_CALLS_TOTAL",
+    "LLM_CALL_LATENCY_SECONDS",
+    "LLM_TOKENS_TOTAL",
+    # Registry
+    "REGISTRY",
+    "decrement_websocket_connections",
+    "get_metrics",
+    "increment_websocket_connections",
+    "record_agent_error",
+    "record_agent_latency",
+    # Agent helpers
+    "record_agent_request",
+    "record_agent_success",
+    "record_api_latency",
+    # API helpers
+    "record_api_request",
+    "record_graph_latency",
+    "record_graph_operation",
+    "record_llm_call",
+    "record_llm_latency",
+    "record_llm_tokens",
+    "set_agent_inbox_size",
+    "set_agent_running",
+    "set_websocket_connections",
+    # Utilities
+    "timed_operation",
+]

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -1,0 +1,389 @@
+"""
+Tests for Prometheus metrics module.
+
+Tests cover:
+- Metric registration and generation
+- Agent metrics recording
+- API metrics recording
+- Graph operation metrics
+- LLM metrics
+- Timed operation decorator
+"""
+
+import asyncio
+
+import pytest
+
+from klabautermann.core.metrics import (
+    AGENT_ERRORS_TOTAL,
+    AGENT_INBOX_SIZE,
+    AGENT_REQUESTS_TOTAL,
+    AGENT_RUNNING,
+    AGENT_SUCCESSES_TOTAL,
+    API_REQUESTS_TOTAL,
+    API_WEBSOCKET_CONNECTIONS,
+    GRAPH_OPERATIONS_TOTAL,
+    LLM_CALLS_TOTAL,
+    LLM_TOKENS_TOTAL,
+    REGISTRY,
+    decrement_websocket_connections,
+    get_metrics,
+    increment_websocket_connections,
+    record_agent_error,
+    record_agent_latency,
+    record_agent_request,
+    record_agent_success,
+    record_api_latency,
+    record_api_request,
+    record_graph_latency,
+    record_graph_operation,
+    record_llm_call,
+    record_llm_latency,
+    record_llm_tokens,
+    set_agent_inbox_size,
+    set_agent_running,
+    set_websocket_connections,
+    timed_operation,
+)
+
+
+# ===========================================================================
+# Registry and Generation Tests
+# ===========================================================================
+
+
+class TestRegistry:
+    """Tests for the Prometheus registry."""
+
+    def test_registry_exists(self):
+        """Registry should be initialized."""
+        assert REGISTRY is not None
+
+    def test_get_metrics_returns_bytes(self):
+        """get_metrics should return bytes in Prometheus format."""
+        metrics = get_metrics()
+        assert isinstance(metrics, bytes)
+
+    def test_get_metrics_contains_metric_names(self):
+        """Metrics output should contain expected metric names."""
+        metrics = get_metrics().decode("utf-8")
+
+        # Check for agent metrics
+        assert "klabautermann_agent_requests_total" in metrics
+        assert "klabautermann_agent_successes_total" in metrics
+        assert "klabautermann_agent_errors_total" in metrics
+        assert "klabautermann_agent_request_latency_ms" in metrics
+
+        # Check for API metrics
+        assert "klabautermann_api_requests_total" in metrics
+        assert "klabautermann_api_request_latency_seconds" in metrics
+
+        # Check for graph metrics
+        assert "klabautermann_graph_operations_total" in metrics
+        assert "klabautermann_graph_operation_latency_seconds" in metrics
+
+        # Check for LLM metrics
+        assert "klabautermann_llm_calls_total" in metrics
+        assert "klabautermann_llm_tokens_total" in metrics
+
+
+# ===========================================================================
+# Agent Metrics Tests
+# ===========================================================================
+
+
+class TestAgentMetrics:
+    """Tests for agent metrics recording."""
+
+    def test_record_agent_request(self):
+        """Should increment agent request counter."""
+        initial = AGENT_REQUESTS_TOTAL.labels(agent_name="test_agent")._value.get()
+        record_agent_request("test_agent")
+        after = AGENT_REQUESTS_TOTAL.labels(agent_name="test_agent")._value.get()
+        assert after == initial + 1
+
+    def test_record_agent_success(self):
+        """Should increment agent success counter."""
+        initial = AGENT_SUCCESSES_TOTAL.labels(agent_name="test_agent")._value.get()
+        record_agent_success("test_agent")
+        after = AGENT_SUCCESSES_TOTAL.labels(agent_name="test_agent")._value.get()
+        assert after == initial + 1
+
+    def test_record_agent_error(self):
+        """Should increment agent error counter."""
+        initial = AGENT_ERRORS_TOTAL.labels(agent_name="test_agent")._value.get()
+        record_agent_error("test_agent")
+        after = AGENT_ERRORS_TOTAL.labels(agent_name="test_agent")._value.get()
+        assert after == initial + 1
+
+    def test_record_agent_latency(self):
+        """Should record latency in histogram."""
+        record_agent_latency("latency_test_agent", 100.5)
+        # Verify the metric was recorded by checking it appears in output
+        metrics = get_metrics().decode("utf-8")
+        assert 'agent_name="latency_test_agent"' in metrics
+        assert "klabautermann_agent_request_latency_ms" in metrics
+
+    def test_set_agent_running_true(self):
+        """Should set running gauge to 1."""
+        set_agent_running("test_agent", running=True)
+        value = AGENT_RUNNING.labels(agent_name="test_agent")._value.get()
+        assert value == 1
+
+    def test_set_agent_running_false(self):
+        """Should set running gauge to 0."""
+        set_agent_running("test_agent", running=False)
+        value = AGENT_RUNNING.labels(agent_name="test_agent")._value.get()
+        assert value == 0
+
+    def test_set_agent_inbox_size(self):
+        """Should set inbox size gauge."""
+        set_agent_inbox_size("test_agent", 5)
+        value = AGENT_INBOX_SIZE.labels(agent_name="test_agent")._value.get()
+        assert value == 5
+
+
+# ===========================================================================
+# API Metrics Tests
+# ===========================================================================
+
+
+class TestAPIMetrics:
+    """Tests for API metrics recording."""
+
+    def test_record_api_request(self):
+        """Should increment API request counter with labels."""
+        initial = API_REQUESTS_TOTAL.labels(
+            method="GET", endpoint="/test", status_code="200"
+        )._value.get()
+        record_api_request("GET", "/test", 200)
+        after = API_REQUESTS_TOTAL.labels(
+            method="GET", endpoint="/test", status_code="200"
+        )._value.get()
+        assert after == initial + 1
+
+    def test_record_api_request_different_status(self):
+        """Should track different status codes separately."""
+        initial_200 = API_REQUESTS_TOTAL.labels(
+            method="POST", endpoint="/api", status_code="200"
+        )._value.get()
+        initial_500 = API_REQUESTS_TOTAL.labels(
+            method="POST", endpoint="/api", status_code="500"
+        )._value.get()
+
+        record_api_request("POST", "/api", 200)
+        record_api_request("POST", "/api", 500)
+
+        after_200 = API_REQUESTS_TOTAL.labels(
+            method="POST", endpoint="/api", status_code="200"
+        )._value.get()
+        after_500 = API_REQUESTS_TOTAL.labels(
+            method="POST", endpoint="/api", status_code="500"
+        )._value.get()
+
+        assert after_200 == initial_200 + 1
+        assert after_500 == initial_500 + 1
+
+    def test_record_api_latency(self):
+        """Should record API latency in histogram."""
+        record_api_latency("GET", "/api_latency_test", 0.05)
+        # Verify the metric was recorded by checking it appears in output
+        metrics = get_metrics().decode("utf-8")
+        assert 'endpoint="/api_latency_test"' in metrics
+        assert "klabautermann_api_request_latency_seconds" in metrics
+
+    def test_websocket_connections_increment(self):
+        """Should increment WebSocket connection count."""
+        initial = API_WEBSOCKET_CONNECTIONS._value.get()
+        increment_websocket_connections()
+        after = API_WEBSOCKET_CONNECTIONS._value.get()
+        assert after == initial + 1
+
+    def test_websocket_connections_decrement(self):
+        """Should decrement WebSocket connection count."""
+        # Ensure we have at least 1 connection
+        set_websocket_connections(5)
+        initial = API_WEBSOCKET_CONNECTIONS._value.get()
+        decrement_websocket_connections()
+        after = API_WEBSOCKET_CONNECTIONS._value.get()
+        assert after == initial - 1
+
+    def test_set_websocket_connections(self):
+        """Should set WebSocket connection count directly."""
+        set_websocket_connections(10)
+        value = API_WEBSOCKET_CONNECTIONS._value.get()
+        assert value == 10
+
+
+# ===========================================================================
+# Graph Metrics Tests
+# ===========================================================================
+
+
+class TestGraphMetrics:
+    """Tests for graph operation metrics."""
+
+    def test_record_graph_operation(self):
+        """Should increment graph operation counter."""
+        initial = GRAPH_OPERATIONS_TOTAL.labels(operation_type="search")._value.get()
+        record_graph_operation("search")
+        after = GRAPH_OPERATIONS_TOTAL.labels(operation_type="search")._value.get()
+        assert after == initial + 1
+
+    def test_record_graph_latency(self):
+        """Should record graph operation latency."""
+        record_graph_latency("add_episode_test", 0.25)
+        # Verify the metric was recorded by checking it appears in output
+        metrics = get_metrics().decode("utf-8")
+        assert 'operation_type="add_episode_test"' in metrics
+        assert "klabautermann_graph_operation_latency_seconds" in metrics
+
+
+# ===========================================================================
+# LLM Metrics Tests
+# ===========================================================================
+
+
+class TestLLMMetrics:
+    """Tests for LLM metrics recording."""
+
+    def test_record_llm_call(self):
+        """Should increment LLM call counter with labels."""
+        initial = LLM_CALLS_TOTAL.labels(model="haiku", purpose="extraction")._value.get()
+        record_llm_call("haiku", "extraction")
+        after = LLM_CALLS_TOTAL.labels(model="haiku", purpose="extraction")._value.get()
+        assert after == initial + 1
+
+    def test_record_llm_tokens(self):
+        """Should increment token counters."""
+        initial_input = LLM_TOKENS_TOTAL.labels(model="sonnet", token_type="input")._value.get()
+        initial_output = LLM_TOKENS_TOTAL.labels(model="sonnet", token_type="output")._value.get()
+
+        record_llm_tokens("sonnet", input_tokens=500, output_tokens=200)
+
+        after_input = LLM_TOKENS_TOTAL.labels(model="sonnet", token_type="input")._value.get()
+        after_output = LLM_TOKENS_TOTAL.labels(model="sonnet", token_type="output")._value.get()
+
+        assert after_input == initial_input + 500
+        assert after_output == initial_output + 200
+
+    def test_record_llm_latency(self):
+        """Should record LLM call latency."""
+        record_llm_latency("opus_test", 2.5)
+        # Verify the metric was recorded by checking it appears in output
+        metrics = get_metrics().decode("utf-8")
+        assert 'model="opus_test"' in metrics
+        assert "klabautermann_llm_call_latency_seconds" in metrics
+
+
+# ===========================================================================
+# Timed Operation Decorator Tests
+# ===========================================================================
+
+
+class TestTimedOperation:
+    """Tests for the timed_operation decorator."""
+
+    def test_timed_operation_sync(self):
+        """Should time synchronous functions."""
+        recorded_latencies = []
+
+        def mock_record(label: str, latency: float) -> None:
+            recorded_latencies.append((label, latency))
+
+        @timed_operation(mock_record, "sync_op")
+        def sync_function():
+            return "result"
+
+        result = sync_function()
+        assert result == "result"
+        assert len(recorded_latencies) == 1
+        assert recorded_latencies[0][0] == "sync_op"
+        assert recorded_latencies[0][1] >= 0
+
+    @pytest.mark.asyncio
+    async def test_timed_operation_async(self):
+        """Should time asynchronous functions."""
+        recorded_latencies = []
+
+        def mock_record(label: str, latency: float) -> None:
+            recorded_latencies.append((label, latency))
+
+        @timed_operation(mock_record, "async_op")
+        async def async_function():
+            await asyncio.sleep(0.01)
+            return "async_result"
+
+        result = await async_function()
+        assert result == "async_result"
+        assert len(recorded_latencies) == 1
+        assert recorded_latencies[0][0] == "async_op"
+        assert recorded_latencies[0][1] >= 0.01
+
+    def test_timed_operation_with_exception(self):
+        """Should record timing even when exception occurs."""
+        recorded_latencies = []
+
+        def mock_record(label: str, latency: float) -> None:
+            recorded_latencies.append((label, latency))
+
+        @timed_operation(mock_record, "error_op")
+        def failing_function():
+            raise ValueError("test error")
+
+        with pytest.raises(ValueError, match="test error"):
+            failing_function()
+
+        # Should still have recorded the latency
+        assert len(recorded_latencies) == 1
+        assert recorded_latencies[0][0] == "error_op"
+
+
+# ===========================================================================
+# Integration Tests
+# ===========================================================================
+
+
+class TestIntegration:
+    """Integration tests for metrics system."""
+
+    def test_metrics_output_format(self):
+        """Metrics should be in valid Prometheus format."""
+        # Record some metrics
+        record_agent_request("integration_test")
+        record_agent_latency("integration_test", 50.0)
+        record_api_request("GET", "/test", 200)
+
+        metrics = get_metrics().decode("utf-8")
+
+        # Check format (should have HELP and TYPE lines)
+        assert "# HELP klabautermann_agent_requests_total" in metrics
+        assert "# TYPE klabautermann_agent_requests_total counter" in metrics
+
+        # Check that our labels appear
+        assert 'agent_name="integration_test"' in metrics
+
+    def test_histogram_buckets_in_output(self):
+        """Histogram metrics should include bucket information."""
+        record_agent_latency("histogram_test", 100.0)
+
+        metrics = get_metrics().decode("utf-8")
+
+        # Histograms should have _bucket, _count, _sum
+        assert "klabautermann_agent_request_latency_ms_bucket" in metrics
+        assert "klabautermann_agent_request_latency_ms_count" in metrics
+        assert "klabautermann_agent_request_latency_ms_sum" in metrics
+
+    def test_multiple_labels_work_correctly(self):
+        """Different label combinations should be tracked separately."""
+        # Record for different agents
+        for _ in range(3):
+            record_agent_request("agent_a")
+        for _ in range(5):
+            record_agent_request("agent_b")
+
+        metrics = get_metrics().decode("utf-8")
+
+        # Both should appear in output
+        assert 'agent_name="agent_a"' in metrics
+        assert 'agent_name="agent_b"' in metrics


### PR DESCRIPTION
## Summary

- Add comprehensive Prometheus metrics for observability
- Expose `/metrics` endpoint in Prometheus text exposition format
- Integrate metrics with agent lifecycle and API middleware

## Details

### Agent Metrics
- `klabautermann_agent_requests_total`: Request counter per agent
- `klabautermann_agent_successes_total`: Success counter per agent
- `klabautermann_agent_errors_total`: Error counter per agent
- `klabautermann_agent_request_latency_ms`: Request latency histogram (10-10000ms buckets)
- `klabautermann_agent_running`: Running status gauge (1=running, 0=stopped)
- `klabautermann_agent_inbox_size`: Inbox queue size gauge

### API Metrics
- `klabautermann_api_requests_total`: Request counter by method/endpoint/status
- `klabautermann_api_request_latency_seconds`: Request latency histogram
- `klabautermann_api_websocket_connections`: Active WebSocket connection gauge

### Graph Metrics
- `klabautermann_graph_operations_total`: Operation counter by type
- `klabautermann_graph_operation_latency_seconds`: Operation latency histogram

### LLM Metrics
- `klabautermann_llm_calls_total`: Call counter by model/purpose
- `klabautermann_llm_tokens_total`: Token usage counter (input/output)
- `klabautermann_llm_call_latency_seconds`: Call latency histogram

### Helper Functions
- `record_agent_*`: Agent metric recording helpers
- `record_api_*`: API metric recording helpers
- `record_graph_*`: Graph operation metric helpers
- `record_llm_*`: LLM metric recording helpers
- `timed_operation`: Decorator for automatic latency tracking

## Test plan
- [x] 27 unit tests for all metric types
- [x] All 1701 existing tests pass
- [x] Ruff linting passes
- [x] mypy type checking passes
- [x] Prometheus format output verified

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)