### PR TITLE
feat(channels): Add TelegramDriver for Telegram bot integration (#129-#134)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
     "watchdog>=4.0",
     # Prometheus metrics
     "prometheus-client>=0.20",
+    # Telegram bot
+    "python-telegram-bot>=21.0",
 ]
 
 [project.optional-dependencies]

--- a/src/klabautermann/channels/__init__.py
+++ b/src/klabautermann/channels/__init__.py
@@ -5,12 +5,12 @@ Contains:
 - base_channel: Abstract base class for all channels
 - cli_driver: Command-line interface with Rich rendering
 - cli_renderer: Rich-based terminal output formatting
+- telegram_driver: Telegram bot interface
 - sanitization: Input sanitization for security
 - manager: Channel lifecycle management
 - rate_limiter: Per-channel rate limiting
 
 Future channels (Sprint 4+):
-- telegram_driver: Telegram bot interface
 - discord_driver: Discord bot interface
 """
 
@@ -43,6 +43,7 @@ from klabautermann.channels.sanitization import (
     get_sanitizer,
     sanitize_input,
 )
+from klabautermann.channels.telegram_driver import TelegramDriver
 
 
 __all__ = [
@@ -50,6 +51,7 @@ __all__ = [
     "BaseChannel",
     "CLIDriver",
     "CLIRenderer",
+    "TelegramDriver",
     # Manager
     "ChannelConfig",
     "ChannelInfo",

--- a/src/klabautermann/channels/telegram_driver.py
+++ b/src/klabautermann/channels/telegram_driver.py
@@ -1,0 +1,479 @@
+"""
+Telegram driver for Klabautermann.
+
+Provides Telegram bot interface for interacting with the assistant.
+Supports text messages, commands, and voice message transcription.
+
+Reference: specs/architecture/CHANNELS.md Section 3
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from klabautermann.channels.base_channel import BaseChannel
+from klabautermann.channels.sanitization import InputSanitizer
+from klabautermann.core.logger import logger
+
+
+if TYPE_CHECKING:
+    from telegram import Update
+
+    from klabautermann.agents.orchestrator import Orchestrator
+
+
+class TelegramDriver(BaseChannel):
+    """
+    Telegram bot driver using python-telegram-bot.
+
+    Provides mobile access with support for:
+    - Text messages
+    - Bot commands (/start, /help, /status)
+    - Voice message transcription (requires OpenAI Whisper)
+
+    Thread isolation: Each chat_id maps to a unique thread UUID.
+    """
+
+    def __init__(
+        self,
+        orchestrator: Orchestrator | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Initialize Telegram driver.
+
+        Args:
+            orchestrator: Orchestrator agent to forward messages to.
+            config: Channel configuration with optional keys:
+                - bot_token: Telegram bot token (or use TELEGRAM_BOT_TOKEN env)
+                - allowed_user_ids: List of allowed user IDs (empty = allow all)
+                - enable_voice: Whether to handle voice messages (default True)
+        """
+        super().__init__(orchestrator, config)
+        self.bot_token = self.config.get("bot_token") or os.getenv("TELEGRAM_BOT_TOKEN")
+        self.allowed_user_ids: list[int] = self.config.get("allowed_user_ids", [])
+        self.enable_voice: bool = self.config.get("enable_voice", True)
+        self._app: Application | None = None
+        self._running = False
+        self._sanitizer = InputSanitizer()
+
+    @property
+    def channel_type(self) -> str:
+        """Return channel identifier."""
+        return "telegram"
+
+    def get_thread_id(self, event: Any) -> str:
+        """
+        Extract thread ID from Telegram Update.
+
+        Uses chat_id as the thread identifier, prefixed with 'telegram-'.
+
+        Args:
+            event: Telegram Update object.
+
+        Returns:
+            Thread identifier in format 'telegram-{chat_id}'.
+        """
+        # Check for message attribute (works with real Update and mocks)
+        if (
+            event is not None
+            and hasattr(event, "message")
+            and event.message is not None
+            and hasattr(event.message, "chat_id")
+        ):
+            return f"telegram-{event.message.chat_id}"
+        return f"telegram-unknown-{uuid.uuid4().hex[:8]}"
+
+    async def start(self) -> None:
+        """
+        Initialize and start the Telegram bot.
+
+        Starts polling for updates (no webhooks needed).
+
+        Raises:
+            ValueError: If TELEGRAM_BOT_TOKEN is not configured.
+        """
+        if not self.bot_token:
+            raise ValueError(
+                "TELEGRAM_BOT_TOKEN not configured. " "Set it in .env or pass bot_token in config."
+            )
+
+        logger.info(
+            "[CHART] Starting Telegram driver...",
+            extra={"agent_name": "telegram"},
+        )
+
+        # Build application
+        self._app = Application.builder().token(self.bot_token).build()
+
+        # Add command handlers
+        self._app.add_handler(CommandHandler("start", self._cmd_start))
+        self._app.add_handler(CommandHandler("help", self._cmd_help))
+        self._app.add_handler(CommandHandler("status", self._cmd_status))
+
+        # Add message handlers
+        self._app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))
+
+        if self.enable_voice:
+            self._app.add_handler(MessageHandler(filters.VOICE, self._on_voice))
+
+        # Initialize and start polling
+        await self._app.initialize()
+        await self._app.start()
+        if self._app.updater:
+            await self._app.updater.start_polling(drop_pending_updates=True)
+
+        self._running = True
+
+        logger.info(
+            "[BEACON] Telegram driver started successfully",
+            extra={"agent_name": "telegram"},
+        )
+
+    async def stop(self) -> None:
+        """Stop the Telegram bot gracefully."""
+        self._running = False
+
+        if self._app:
+            if self._app.updater:
+                await self._app.updater.stop()
+            await self._app.stop()
+            await self._app.shutdown()
+
+        logger.info(
+            "[CHART] Telegram driver stopped",
+            extra={"agent_name": "telegram"},
+        )
+
+    async def send_message(
+        self,
+        thread_id: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> None:
+        """
+        Send a message to a Telegram chat.
+
+        Args:
+            thread_id: Thread ID in format 'telegram-{chat_id}'.
+            content: Message content to send.
+            metadata: Optional metadata (unused, for interface compatibility).
+        """
+        if not self._app:
+            logger.error(
+                "[STORM] Cannot send message: Telegram app not initialized",
+                extra={"agent_name": "telegram"},
+            )
+            return
+
+        # Extract chat_id from thread_id
+        chat_id_str = thread_id.replace("telegram-", "")
+        try:
+            chat_id = int(chat_id_str)
+        except ValueError:
+            logger.error(
+                f"[STORM] Invalid thread_id format: {thread_id}",
+                extra={"agent_name": "telegram"},
+            )
+            return
+
+        await self._app.bot.send_message(
+            chat_id=chat_id,
+            text=content,
+            parse_mode="Markdown",
+        )
+
+    async def receive_message(
+        self,
+        thread_id: str,
+        content: str,
+        metadata: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> str:
+        """
+        Process an incoming message from Telegram.
+
+        Args:
+            thread_id: Thread ID for the conversation.
+            content: Message content.
+            metadata: Optional channel-specific metadata (unused, for interface compatibility).
+
+        Returns:
+            Response content from the orchestrator.
+        """
+        if not self._orchestrator:
+            return "I'm having trouble processing that right now. Please try again later."
+
+        # Generate trace ID
+        trace_id = f"tg-{uuid.uuid4().hex[:12]}"
+
+        try:
+            # Forward to orchestrator
+            response = await self._orchestrator.handle_user_input_v2(
+                text=content,
+                thread_uuid=thread_id,
+                trace_id=trace_id,
+            )
+            return response
+        except Exception as e:
+            logger.error(
+                f"[STORM] Orchestrator error: {e}",
+                extra={"agent_name": "telegram", "trace_id": trace_id},
+            )
+            return "Hit some rough waters processing that. Please try again."
+
+    # =========================================================================
+    # Command Handlers
+    # =========================================================================
+
+    async def _cmd_start(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,  # noqa: ARG002
+    ) -> None:
+        """Handle /start command - welcome message."""
+        if not update.message:
+            return
+
+        welcome = (
+            "*Ahoy, Captain!*\n\n"
+            "I'm Klabautermann, your personal navigator through the information storm.\n\n"
+            "Tell me about people you meet, projects you're working on, "
+            "or ask me to find something in The Locker (your knowledge graph).\n\n"
+            "Type /help for more information."
+        )
+        await update.message.reply_text(welcome, parse_mode="Markdown")
+
+        logger.info(
+            "[CHART] /start command received",
+            extra={
+                "agent_name": "telegram",
+                "chat_id": update.message.chat_id,
+                "user_id": update.message.from_user.id if update.message.from_user else None,
+            },
+        )
+
+    async def _cmd_help(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,  # noqa: ARG002
+    ) -> None:
+        """Handle /help command - show available commands."""
+        if not update.message:
+            return
+
+        help_text = (
+            "*Available Commands:*\n\n"
+            "/start - Welcome message\n"
+            "/help - Show this help\n"
+            "/status - System status\n\n"
+            "*What I can do:*\n\n"
+            "- Remember people, projects, and events you tell me about\n"
+            "- Search your knowledge graph for information\n"
+            "- Draft emails and create calendar events\n"
+            "- Transcribe voice messages\n\n"
+            "Just chat naturally - I'll figure out the rest!"
+        )
+        await update.message.reply_text(help_text, parse_mode="Markdown")
+
+    async def _cmd_status(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,  # noqa: ARG002
+    ) -> None:
+        """Handle /status command - show system status."""
+        if not update.message:
+            return
+
+        chat_id = update.message.chat_id
+        user = update.message.from_user
+        user_id = user.id if user else "unknown"
+        username = user.username if user and user.username else "N/A"
+
+        status = (
+            "*System Status:*\n\n"
+            f"- Channel: Telegram\n"
+            f"- Chat ID: `{chat_id}`\n"
+            f"- User ID: `{user_id}`\n"
+            f"- Username: @{username}\n"
+            f"- Status: Online\n"
+            f"- Voice: {'Enabled' if self.enable_voice else 'Disabled'}"
+        )
+        await update.message.reply_text(status, parse_mode="Markdown")
+
+    # =========================================================================
+    # Message Handlers
+    # =========================================================================
+
+    async def _on_text(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,  # noqa: ARG002
+    ) -> None:
+        """Handle incoming text messages."""
+        if not update.message or not update.message.text:
+            return
+
+        user = update.message.from_user
+        user_id = user.id if user else 0
+
+        # Check authorization if configured
+        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+            await update.message.reply_text("Sorry, I don't recognize you. This bot is private.")
+            logger.warning(
+                f"[SWELL] Unauthorized access attempt from user {user_id}",
+                extra={"agent_name": "telegram", "user_id": user_id},
+            )
+            return
+
+        # Show typing indicator
+        await update.message.chat.send_action("typing")
+
+        # Sanitize input
+        sanitize_result = self._sanitizer.sanitize(update.message.text)
+        content = sanitize_result.sanitized
+        if not content:
+            await update.message.reply_text("I couldn't understand that message. Please try again.")
+            return
+
+        # Get thread ID
+        thread_id = self.get_thread_id(update)
+
+        logger.info(
+            f"[CHART] Text message received: {content[:50]}...",
+            extra={
+                "agent_name": "telegram",
+                "chat_id": update.message.chat_id,
+                "user_id": user_id,
+                "thread_id": thread_id,
+            },
+        )
+
+        # Process message
+        try:
+            response = await self.receive_message(
+                thread_id=thread_id,
+                content=content,
+                metadata={
+                    "chat_id": update.message.chat_id,
+                    "user_id": user_id,
+                    "timestamp": datetime.now(UTC).timestamp(),
+                },
+            )
+            await update.message.reply_text(response, parse_mode="Markdown")
+        except Exception as e:
+            logger.error(
+                f"[STORM] Error processing text message: {e}",
+                extra={"agent_name": "telegram"},
+            )
+            await update.message.reply_text(
+                "Hit some rough waters processing that. Please try again."
+            )
+
+    async def _on_voice(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming voice messages."""
+        if not update.message or not update.message.voice:
+            return
+
+        user = update.message.from_user
+        user_id = user.id if user else 0
+
+        # Check authorization
+        if self.allowed_user_ids and user_id not in self.allowed_user_ids:
+            await update.message.reply_text("Sorry, I don't recognize you. This bot is private.")
+            return
+
+        await update.message.chat.send_action("typing")
+
+        # Download and transcribe voice
+        try:
+            voice = update.message.voice
+            file = await context.bot.get_file(voice.file_id)
+
+            import tempfile
+
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                await file.download_to_drive(f.name)
+                audio_path = f.name
+
+            # Transcribe using Whisper
+            transcription = await self._transcribe_audio(audio_path)
+
+            # Clean up temp file
+            Path(audio_path).unlink()
+
+            if not transcription:
+                await update.message.reply_text("Couldn't make out what you said. Try again?")
+                return
+
+            # Process as text message
+            thread_id = self.get_thread_id(update)
+            response = await self.receive_message(
+                thread_id=thread_id,
+                content=transcription,
+                metadata={
+                    "chat_id": update.message.chat_id,
+                    "user_id": user_id,
+                    "original_type": "voice",
+                    "transcription": transcription,
+                    "duration": voice.duration,
+                },
+            )
+            await update.message.reply_text(
+                f"_Transcribed: {transcription}_\n\n{response}",
+                parse_mode="Markdown",
+            )
+
+        except Exception as e:
+            logger.error(
+                f"[STORM] Voice processing error: {e}",
+                extra={"agent_name": "telegram"},
+            )
+            await update.message.reply_text(
+                "Had trouble with that voice message. Try typing instead?"
+            )
+
+    async def _transcribe_audio(self, audio_path: str) -> str | None:
+        """
+        Transcribe audio using OpenAI Whisper.
+
+        Args:
+            audio_path: Path to the audio file.
+
+        Returns:
+            Transcription text or None if failed.
+        """
+        try:
+            import openai
+
+            client = openai.AsyncOpenAI()
+            with Path(audio_path).open("rb") as audio_file:
+                transcript = await client.audio.transcriptions.create(
+                    model="whisper-1",
+                    file=audio_file,
+                )
+            return str(transcript.text)
+        except Exception as e:
+            logger.error(
+                f"[STORM] Whisper transcription failed: {e}",
+                extra={"agent_name": "telegram"},
+            )
+            return None
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = ["TelegramDriver"]

--- a/tests/unit/test_telegram_driver.py
+++ b/tests/unit/test_telegram_driver.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for TelegramDriver.
+
+Tests the Telegram channel implementation without real API calls.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klabautermann.channels.telegram_driver import TelegramDriver
+
+
+@pytest.fixture
+def mock_orchestrator() -> MagicMock:
+    """Create a mock orchestrator."""
+    orchestrator = MagicMock()
+    orchestrator.handle_user_input_v2 = AsyncMock(return_value="Test response")
+    return orchestrator
+
+
+@pytest.fixture
+def telegram_driver(mock_orchestrator: MagicMock) -> TelegramDriver:
+    """Create a TelegramDriver with mock orchestrator."""
+    return TelegramDriver(
+        orchestrator=mock_orchestrator,
+        config={
+            "bot_token": "test-token-12345",
+            "allowed_user_ids": [],
+            "enable_voice": True,
+        },
+    )
+
+
+@pytest.fixture
+def mock_update() -> MagicMock:
+    """Create a mock Telegram Update."""
+    update = MagicMock()
+    update.message = MagicMock()
+    update.message.chat_id = 123456789
+    update.message.from_user = MagicMock()
+    update.message.from_user.id = 987654321
+    update.message.from_user.username = "testuser"
+    update.message.text = "Hello, Klabautermann!"
+    update.message.reply_text = AsyncMock()
+    update.message.chat = MagicMock()
+    update.message.chat.send_action = AsyncMock()
+    return update
+
+
+def test_init_with_config_token() -> None:
+    """TelegramDriver uses bot_token from config."""
+    driver = TelegramDriver(
+        orchestrator=None,
+        config={"bot_token": "config-token"},
+    )
+    assert driver.bot_token == "config-token"
+
+
+def test_init_with_env_token() -> None:
+    """TelegramDriver falls back to TELEGRAM_BOT_TOKEN env var."""
+    with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "env-token"}):
+        driver = TelegramDriver(
+            orchestrator=None,
+            config={},
+        )
+        assert driver.bot_token == "env-token"
+
+
+def test_init_allowed_user_ids() -> None:
+    """TelegramDriver respects allowed_user_ids config."""
+    driver = TelegramDriver(
+        orchestrator=None,
+        config={"allowed_user_ids": [123, 456, 789]},
+    )
+    assert driver.allowed_user_ids == [123, 456, 789]
+
+
+def test_init_voice_disabled() -> None:
+    """TelegramDriver can disable voice handling."""
+    driver = TelegramDriver(
+        orchestrator=None,
+        config={"enable_voice": False},
+    )
+    assert driver.enable_voice is False
+
+
+def test_channel_type(telegram_driver: TelegramDriver) -> None:
+    """TelegramDriver returns correct channel type."""
+    assert telegram_driver.channel_type == "telegram"
+
+
+def test_get_thread_id_from_update(telegram_driver: TelegramDriver, mock_update: MagicMock) -> None:
+    """TelegramDriver extracts thread ID from Update."""
+    thread_id = telegram_driver.get_thread_id(mock_update)
+    assert thread_id == "telegram-123456789"
+
+
+def test_get_thread_id_invalid_event(telegram_driver: TelegramDriver) -> None:
+    """TelegramDriver handles invalid event gracefully."""
+    thread_id = telegram_driver.get_thread_id(None)
+    assert thread_id.startswith("telegram-unknown-")
+
+
+def test_get_thread_id_no_message(telegram_driver: TelegramDriver) -> None:
+    """TelegramDriver handles Update with no message."""
+    update = MagicMock()
+    update.message = None
+    thread_id = telegram_driver.get_thread_id(update)
+    assert thread_id.startswith("telegram-unknown-")
+
+
+@pytest.mark.asyncio
+async def test_start_without_token() -> None:
+    """TelegramDriver raises error if no token configured."""
+    driver = TelegramDriver(orchestrator=None, config={})
+    driver.bot_token = None
+
+    with pytest.raises(ValueError, match="TELEGRAM_BOT_TOKEN not configured"):
+        await driver.start()
+
+
+@pytest.mark.asyncio
+async def test_stop_without_start(telegram_driver: TelegramDriver) -> None:
+    """TelegramDriver handles stop when not started."""
+    # Should not raise
+    await telegram_driver.stop()
+    assert telegram_driver._running is False
+
+
+@pytest.mark.asyncio
+async def test_receive_message(
+    telegram_driver: TelegramDriver, mock_orchestrator: MagicMock
+) -> None:
+    """TelegramDriver forwards messages to orchestrator."""
+    response = await telegram_driver.receive_message(
+        thread_id="telegram-123",
+        content="Test message",
+        metadata={"chat_id": 123},
+    )
+
+    assert response == "Test response"
+    mock_orchestrator.handle_user_input_v2.assert_called_once()
+    call_kwargs = mock_orchestrator.handle_user_input_v2.call_args.kwargs
+    assert call_kwargs["text"] == "Test message"
+    assert call_kwargs["thread_uuid"] == "telegram-123"
+
+
+@pytest.mark.asyncio
+async def test_receive_message_no_orchestrator() -> None:
+    """TelegramDriver returns error when no orchestrator."""
+    driver = TelegramDriver(orchestrator=None, config={})
+    response = await driver.receive_message(
+        thread_id="telegram-123",
+        content="Test message",
+    )
+    assert "trouble processing" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_receive_message_orchestrator_error(
+    telegram_driver: TelegramDriver, mock_orchestrator: MagicMock
+) -> None:
+    """TelegramDriver handles orchestrator errors gracefully."""
+    mock_orchestrator.handle_user_input_v2.side_effect = Exception("API error")
+
+    response = await telegram_driver.receive_message(
+        thread_id="telegram-123",
+        content="Test message",
+    )
+
+    assert "rough waters" in response.lower()
+
+
+@pytest.mark.asyncio
+async def test_cmd_start(telegram_driver: TelegramDriver, mock_update: MagicMock) -> None:
+    """TelegramDriver /start command sends welcome message."""
+    context = MagicMock()
+
+    await telegram_driver._cmd_start(mock_update, context)
+
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    assert "Ahoy" in call_args[0][0]
+    assert "Klabautermann" in call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_cmd_help(telegram_driver: TelegramDriver, mock_update: MagicMock) -> None:
+    """TelegramDriver /help command shows available commands."""
+    context = MagicMock()
+
+    await telegram_driver._cmd_help(mock_update, context)
+
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    assert "/start" in call_args[0][0]
+    assert "/help" in call_args[0][0]
+    assert "/status" in call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_cmd_status(telegram_driver: TelegramDriver, mock_update: MagicMock) -> None:
+    """TelegramDriver /status command shows system status."""
+    context = MagicMock()
+
+    await telegram_driver._cmd_status(mock_update, context)
+
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    assert "System Status" in call_args[0][0]
+    assert "Telegram" in call_args[0][0]
+    assert "123456789" in call_args[0][0]  # chat_id
+
+
+@pytest.mark.asyncio
+async def test_on_text_authorized(
+    telegram_driver: TelegramDriver,
+    mock_update: MagicMock,
+    mock_orchestrator: MagicMock,
+) -> None:
+    """TelegramDriver processes messages from authorized users."""
+    telegram_driver.allowed_user_ids = []  # Empty = allow all
+    context = MagicMock()
+
+    await telegram_driver._on_text(mock_update, context)
+
+    # Should have sent typing action and reply
+    mock_update.message.chat.send_action.assert_called_once_with("typing")
+    mock_update.message.reply_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_text_unauthorized(
+    telegram_driver: TelegramDriver, mock_update: MagicMock
+) -> None:
+    """TelegramDriver rejects messages from unauthorized users."""
+    telegram_driver.allowed_user_ids = [111111]  # Different user
+    mock_update.message.from_user.id = 999999  # Not in allowed list
+    context = MagicMock()
+
+    await telegram_driver._on_text(mock_update, context)
+
+    # Should have sent rejection message
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    assert "don't recognize you" in call_args[0][0].lower()
+
+
+@pytest.mark.asyncio
+async def test_send_message_not_initialized(
+    telegram_driver: TelegramDriver,
+) -> None:
+    """TelegramDriver handles send when app not initialized."""
+    # _app is None
+    await telegram_driver.send_message(
+        thread_id="telegram-123",
+        content="Test",
+    )
+    # Should not raise, just log error
+
+
+@pytest.mark.asyncio
+async def test_send_message_invalid_thread_id(
+    telegram_driver: TelegramDriver,
+) -> None:
+    """TelegramDriver handles invalid thread_id format."""
+    telegram_driver._app = MagicMock()
+
+    # Should not raise
+    await telegram_driver.send_message(
+        thread_id="invalid-format",
+        content="Test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_text_empty_after_sanitization(
+    telegram_driver: TelegramDriver, mock_update: MagicMock
+) -> None:
+    """TelegramDriver rejects empty messages after sanitization."""
+    from klabautermann.channels.sanitization import SanitizationResult
+
+    mock_update.message.text = "   "  # Whitespace only
+    context = MagicMock()
+
+    # Mock sanitize to return empty result
+    empty_result = SanitizationResult(
+        original="   ",
+        sanitized="",
+        modifications=["stripped whitespace"],
+        original_length=3,
+        sanitized_length=0,
+    )
+
+    with patch.object(telegram_driver._sanitizer, "sanitize", return_value=empty_result):
+        await telegram_driver._on_text(mock_update, context)
+
+    # Should have sent error message
+    mock_update.message.reply_text.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    assert "couldn't understand" in call_args[0][0].lower()


### PR DESCRIPTION
## Summary
- Create TelegramDriver class extending BaseChannel
- Add bot token configuration via env var or config
- Implement /start, /help, /status commands
- Add text message handling with input sanitization
- Support voice message transcription (via OpenAI Whisper)
- Add user authorization via allowed_user_ids whitelist
- Implement thread isolation per chat_id

## Test plan
- [x] 21 unit tests covering initialization, thread ID extraction, message handling, commands, authorization, and error handling
- [x] All unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, type checks)

## Issues Closed
Closes #129, #130, #131, #132, #133, #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)