### PR TITLE
feat(archivist): Wire deduplication module for fuzzy matching (#35)

### DIFF
--- a/src/klabautermann/agents/archivist.py
+++ b/src/klabautermann/agents/archivist.py
@@ -24,8 +24,11 @@ from typing import TYPE_CHECKING, Any
 from klabautermann.agents.base_agent import BaseAgent
 from klabautermann.agents.summarization import summarize_thread
 from klabautermann.core.logger import logger
-from klabautermann.core.models import AgentMessage, ThreadSummary
-from klabautermann.memory.entity_merge import find_duplicate_persons, merge_entities
+from klabautermann.core.models import AgentMessage, DuplicateCandidate, ThreadSummary
+from klabautermann.memory.deduplication import (
+    merge_entities,
+    process_duplicates,
+)
 from klabautermann.memory.note_queries import create_note_with_links
 
 
@@ -284,10 +287,12 @@ class Archivist(BaseAgent):
 
         # Run deduplication after archival
         if archived_count > 0:
-            merged_count = await self.detect_and_merge_duplicates(trace_id)
-            if merged_count > 0:
+            dedup_stats = await self.detect_and_merge_duplicates(trace_id)
+            if dedup_stats["auto_merged"] > 0 or dedup_stats["flagged_for_review"] > 0:
                 logger.debug(
-                    f"[WHISPER] Post-archival deduplication merged {merged_count} entities",
+                    f"[WHISPER] Post-archival deduplication: "
+                    f"{dedup_stats['auto_merged']} merged, "
+                    f"{dedup_stats['flagged_for_review']} flagged for review",
                     extra={"trace_id": trace_id, "agent_name": self.name},
                 )
 
@@ -355,78 +360,211 @@ class Archivist(BaseAgent):
     async def detect_and_merge_duplicates(
         self,
         trace_id: str | None = None,
-    ) -> int:
+        auto_merge_threshold: float = 0.9,
+        review_threshold: float = 0.7,
+    ) -> dict[str, int]:
         """
-        Detect and merge duplicate entities in the graph.
+        Detect and process duplicate entities in the graph.
 
-        Scans for duplicate Person entities and merges high-confidence
-        duplicates (similarity >= 0.9).
+        Uses fuzzy matching to find duplicates. High-confidence duplicates
+        (score >= auto_merge_threshold) are merged automatically. Medium-confidence
+        duplicates (review_threshold <= score < auto_merge_threshold) are flagged
+        for user review via POTENTIAL_DUPLICATE relationships.
 
         Args:
             trace_id: Trace ID for logging
+            auto_merge_threshold: Score threshold for automatic merging (default: 0.9)
+            review_threshold: Minimum score to flag for review (default: 0.7)
 
         Returns:
-            Number of entities merged
+            Dictionary with processing statistics:
+            {
+                "auto_merged": int,
+                "flagged_for_review": int,
+                "ignored": int
+            }
         """
         if not self.neo4j:
             logger.warning(
                 "[SWELL] Cannot detect duplicates: Neo4j client not configured",
                 extra={"trace_id": trace_id, "agent_name": self.name},
             )
-            return 0
+            return {"auto_merged": 0, "flagged_for_review": 0, "ignored": 0}
 
         trace_id = trace_id or str(uuid.uuid4())
 
         logger.info(
-            "[CHART] Scanning for duplicate entities",
+            f"[CHART] Scanning for duplicate entities "
+            f"(auto_merge_threshold={auto_merge_threshold}, review_threshold={review_threshold})",
             extra={"trace_id": trace_id, "agent_name": self.name},
         )
 
-        # Find high-confidence person duplicates
-        duplicates = await find_duplicate_persons(
+        # Use the comprehensive process_duplicates pipeline
+        stats = await process_duplicates(
             self.neo4j,
-            limit=50,
+            auto_merge_threshold=auto_merge_threshold,
+            review_threshold=review_threshold,
             trace_id=trace_id,
         )
 
-        # Filter to high-confidence matches (>= 0.9 similarity)
-        high_confidence = [d for d in duplicates if d.similarity_score >= 0.9]
-
-        if not high_confidence:
-            logger.debug(
-                "[WHISPER] No high-confidence duplicates found",
-                extra={"trace_id": trace_id, "agent_name": self.name},
-            )
-            return 0
-
-        merged_count = 0
-        for dup in high_confidence:
-            # Merge source (uuid2) into target (uuid1)
-            result = await merge_entities(
-                self.neo4j,
-                source_uuid=dup.uuid2,
-                target_uuid=dup.uuid1,
-                trace_id=trace_id,
-            )
-            if result.source_deleted:
-                merged_count += 1
-                logger.info(
-                    f"[BEACON] Merged duplicate: {dup.name2} -> {dup.name1} "
-                    f"(reason: {dup.match_reason}, score: {dup.similarity_score})",
-                    extra={"trace_id": trace_id, "agent_name": self.name},
-                )
-
         logger.info(
-            f"[BEACON] Deduplication complete: {merged_count} entities merged",
+            f"[BEACON] Deduplication complete: {stats['auto_merged']} merged, "
+            f"{stats['flagged_for_review']} flagged for review, {stats['ignored']} ignored",
             extra={
                 "trace_id": trace_id,
                 "agent_name": self.name,
-                "merged_count": merged_count,
-                "candidates_found": len(duplicates),
+                **stats,
             },
         )
 
-        return merged_count
+        return stats
+
+    async def get_flagged_duplicates(
+        self,
+        trace_id: str | None = None,
+    ) -> list[DuplicateCandidate]:
+        """
+        Retrieve entities flagged for user review.
+
+        Returns duplicate candidates that were flagged with POTENTIAL_DUPLICATE
+        relationships and haven't been reviewed yet.
+
+        Args:
+            trace_id: Trace ID for logging
+
+        Returns:
+            List of DuplicateCandidate objects pending review
+        """
+        if not self.neo4j:
+            logger.warning(
+                "[SWELL] Cannot get flagged duplicates: Neo4j client not configured",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+            return []
+
+        trace_id = trace_id or str(uuid.uuid4())
+
+        query = """
+        MATCH (e1)-[r:POTENTIAL_DUPLICATE]->(e2)
+        WHERE r.reviewed = false
+        RETURN e1.uuid as uuid1, e1.name as name1,
+               e2.uuid as uuid2, e2.name as name2,
+               labels(e1)[0] as entity_type,
+               r.similarity_score as similarity_score,
+               r.match_reasons as match_reasons
+        ORDER BY r.similarity_score DESC
+        """
+
+        result = await self.neo4j.execute_query(query, {}, trace_id=trace_id)
+
+        candidates = [
+            DuplicateCandidate(
+                uuid1=row["uuid1"],
+                uuid2=row["uuid2"],
+                name1=row["name1"],
+                name2=row["name2"],
+                entity_type=row["entity_type"],
+                similarity_score=row["similarity_score"],
+                match_reasons=row.get("match_reasons", []),
+            )
+            for row in result
+        ]
+
+        logger.debug(
+            f"[WHISPER] Found {len(candidates)} flagged duplicates pending review",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return candidates
+
+    async def resolve_flagged_duplicate(
+        self,
+        uuid1: str,
+        uuid2: str,
+        merge: bool = True,
+        trace_id: str | None = None,
+    ) -> bool:
+        """
+        Resolve a flagged duplicate by merging or dismissing.
+
+        If merge=True, merges the entities (keeps uuid1, removes uuid2).
+        If merge=False, marks the relationship as reviewed (not a duplicate).
+
+        Args:
+            uuid1: UUID of first entity (kept if merging)
+            uuid2: UUID of second entity (removed if merging)
+            merge: Whether to merge the entities
+            trace_id: Trace ID for logging
+
+        Returns:
+            True if resolution was successful
+        """
+        if not self.neo4j:
+            logger.warning(
+                "[SWELL] Cannot resolve duplicate: Neo4j client not configured",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+            return False
+
+        trace_id = trace_id or str(uuid.uuid4())
+
+        if merge:
+            # Get entity type from the flag relationship
+            type_query = """
+            MATCH (e1 {uuid: $uuid1})-[r:POTENTIAL_DUPLICATE]-(e2 {uuid: $uuid2})
+            RETURN labels(e1)[0] as entity_type
+            """
+            result = await self.neo4j.execute_query(
+                type_query, {"uuid1": uuid1, "uuid2": uuid2}, trace_id=trace_id
+            )
+
+            if not result:
+                logger.warning(
+                    f"[SWELL] No POTENTIAL_DUPLICATE relationship found between {uuid1} and {uuid2}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+                return False
+
+            entity_type = result[0]["entity_type"]
+
+            # Merge entities
+            success = await merge_entities(
+                self.neo4j,
+                keep_uuid=uuid1,
+                remove_uuid=uuid2,
+                entity_type=entity_type,
+                trace_id=trace_id,
+            )
+
+            if success:
+                logger.info(
+                    f"[BEACON] Merged flagged duplicate: {uuid2} -> {uuid1}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+
+            return success
+        else:
+            # Mark as reviewed (not a duplicate)
+            dismiss_query = """
+            MATCH (e1 {uuid: $uuid1})-[r:POTENTIAL_DUPLICATE]-(e2 {uuid: $uuid2})
+            SET r.reviewed = true,
+                r.reviewed_at = timestamp(),
+                r.review_decision = 'not_duplicate'
+            RETURN count(r) as updated
+            """
+            result = await self.neo4j.execute_query(
+                dismiss_query, {"uuid1": uuid1, "uuid2": uuid2}, trace_id=trace_id
+            )
+
+            updated: int = int(result[0]["updated"]) if result else 0
+
+            if updated > 0:
+                logger.info(
+                    f"[BEACON] Dismissed flagged duplicate: {uuid1} <-> {uuid2}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+
+            return updated > 0
 
     # ========================================================================
     # Stub Methods (to be implemented in future tasks)

--- a/tests/unit/test_archivist.py
+++ b/tests/unit/test_archivist.py
@@ -574,12 +574,14 @@ class TestConfiguration:
 
 
 class TestDetectAndMergeDuplicates:
-    """Test suite for duplicate detection and merging (#191)."""
+    """Test suite for duplicate detection and merging (#35, #191)."""
 
     @pytest.fixture
     def mock_neo4j(self) -> Mock:
         """Create a mock Neo4jClient."""
-        return Mock()
+        mock = Mock()
+        mock.execute_query = AsyncMock(return_value=[])
+        return mock
 
     @pytest.fixture
     def archivist(self, mock_neo4j: Mock) -> Archivist:
@@ -592,87 +594,55 @@ class TestDetectAndMergeDuplicates:
         )
 
     @pytest.mark.asyncio
-    async def test_detect_duplicates_merges_high_confidence(
+    async def test_detect_duplicates_uses_process_duplicates(
         self, archivist: Archivist, mock_neo4j: Mock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Should merge duplicates with similarity >= 0.9."""
-        from datetime import datetime
-
-        from klabautermann.memory.entity_merge import DuplicateCandidate, MergeResult
-
-        mock_find = AsyncMock(
-            return_value=[
-                DuplicateCandidate(
-                    uuid1="person-001",
-                    uuid2="person-002",
-                    name1="John Doe",
-                    name2="John Doe",
-                    email1="john@example.com",
-                    email2="john@example.com",
-                    match_reason="both",
-                    similarity_score=1.0,
-                ),
-            ]
+        """Should use process_duplicates pipeline for comprehensive detection."""
+        mock_process = AsyncMock(
+            return_value={
+                "auto_merged": 2,
+                "flagged_for_review": 1,
+                "ignored": 3,
+            }
         )
-        mock_merge = AsyncMock(
-            return_value=MergeResult(
-                source_uuid="person-002",
-                target_uuid="person-001",
-                relationships_transferred=5,
-                properties_merged=["bio"],
-                source_deleted=True,
-                timestamp=datetime.now(),
-            )
-        )
-
-        monkeypatch.setattr("klabautermann.agents.archivist.find_duplicate_persons", mock_find)
-        monkeypatch.setattr("klabautermann.agents.archivist.merge_entities", mock_merge)
+        monkeypatch.setattr("klabautermann.agents.archivist.process_duplicates", mock_process)
 
         result = await archivist.detect_and_merge_duplicates(trace_id="test-trace-001")
 
-        assert result == 1
-        mock_find.assert_called_once_with(mock_neo4j, limit=50, trace_id="test-trace-001")
-        mock_merge.assert_called_once_with(
+        assert result == {"auto_merged": 2, "flagged_for_review": 1, "ignored": 3}
+        mock_process.assert_called_once_with(
             mock_neo4j,
-            source_uuid="person-002",
-            target_uuid="person-001",
+            auto_merge_threshold=0.9,
+            review_threshold=0.7,
             trace_id="test-trace-001",
         )
 
     @pytest.mark.asyncio
-    async def test_detect_duplicates_skips_low_confidence(
+    async def test_detect_duplicates_custom_thresholds(
         self, archivist: Archivist, mock_neo4j: Mock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Should not merge duplicates with similarity < 0.9."""
-        from klabautermann.memory.entity_merge import DuplicateCandidate
-
-        mock_find = AsyncMock(
-            return_value=[
-                DuplicateCandidate(
-                    uuid1="person-001",
-                    uuid2="person-002",
-                    name1="John Doe",
-                    name2="John D.",
-                    email1=None,
-                    email2=None,
-                    match_reason="name",
-                    similarity_score=0.7,  # Below threshold
-                ),
-            ]
+        """Should pass custom thresholds to process_duplicates."""
+        mock_process = AsyncMock(
+            return_value={"auto_merged": 0, "flagged_for_review": 0, "ignored": 0}
         )
-        mock_merge = AsyncMock()
+        monkeypatch.setattr("klabautermann.agents.archivist.process_duplicates", mock_process)
 
-        monkeypatch.setattr("klabautermann.agents.archivist.find_duplicate_persons", mock_find)
-        monkeypatch.setattr("klabautermann.agents.archivist.merge_entities", mock_merge)
+        await archivist.detect_and_merge_duplicates(
+            trace_id="test-trace-002",
+            auto_merge_threshold=0.95,
+            review_threshold=0.8,
+        )
 
-        result = await archivist.detect_and_merge_duplicates(trace_id="test-trace-002")
-
-        assert result == 0
-        mock_merge.assert_not_called()
+        mock_process.assert_called_once_with(
+            mock_neo4j,
+            auto_merge_threshold=0.95,
+            review_threshold=0.8,
+            trace_id="test-trace-002",
+        )
 
     @pytest.mark.asyncio
-    async def test_detect_duplicates_returns_zero_without_neo4j(self) -> None:
-        """Should return 0 when Neo4j client not configured."""
+    async def test_detect_duplicates_returns_empty_stats_without_neo4j(self) -> None:
+        """Should return empty stats when Neo4j client not configured."""
         archivist = Archivist(
             name="archivist",
             config={},
@@ -682,73 +652,152 @@ class TestDetectAndMergeDuplicates:
 
         result = await archivist.detect_and_merge_duplicates(trace_id="test-trace-003")
 
-        assert result == 0
+        assert result == {"auto_merged": 0, "flagged_for_review": 0, "ignored": 0}
+
+
+class TestGetFlaggedDuplicates:
+    """Test suite for retrieving flagged duplicates (#35)."""
+
+    @pytest.fixture
+    def mock_neo4j(self) -> Mock:
+        """Create a mock Neo4jClient."""
+        mock = Mock()
+        mock.execute_query = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def archivist(self, mock_neo4j: Mock) -> Archivist:
+        """Create an Archivist instance with mocked Neo4j client."""
+        return Archivist(
+            name="archivist",
+            config={},
+            thread_manager=None,
+            neo4j_client=mock_neo4j,
+        )
 
     @pytest.mark.asyncio
-    async def test_detect_duplicates_counts_only_deleted(
+    async def test_returns_flagged_duplicates(self, archivist: Archivist, mock_neo4j: Mock) -> None:
+        """Should return DuplicateCandidate objects for flagged pairs."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid1": "person-001",
+                "uuid2": "person-002",
+                "name1": "John Doe",
+                "name2": "John D.",
+                "entity_type": "Person",
+                "similarity_score": 0.85,
+                "match_reasons": ["similar_name"],
+            },
+        ]
+
+        result = await archivist.get_flagged_duplicates(trace_id="test-trace-001")
+
+        assert len(result) == 1
+        assert result[0].uuid1 == "person-001"
+        assert result[0].uuid2 == "person-002"
+        assert result[0].entity_type == "Person"
+        assert result[0].similarity_score == 0.85
+        assert result[0].match_reasons == ["similar_name"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_without_neo4j(self) -> None:
+        """Should return empty list when Neo4j client not configured."""
+        archivist = Archivist(
+            name="archivist",
+            config={},
+            thread_manager=None,
+            neo4j_client=None,
+        )
+
+        result = await archivist.get_flagged_duplicates(trace_id="test-trace-002")
+
+        assert result == []
+
+
+class TestResolveFlaggedDuplicate:
+    """Test suite for resolving flagged duplicates (#35)."""
+
+    @pytest.fixture
+    def mock_neo4j(self) -> Mock:
+        """Create a mock Neo4jClient."""
+        mock = Mock()
+        mock.execute_query = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def archivist(self, mock_neo4j: Mock) -> Archivist:
+        """Create an Archivist instance with mocked Neo4j client."""
+        return Archivist(
+            name="archivist",
+            config={},
+            thread_manager=None,
+            neo4j_client=mock_neo4j,
+        )
+
+    @pytest.mark.asyncio
+    async def test_merge_flagged_duplicate(
         self, archivist: Archivist, mock_neo4j: Mock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Should only count merges where source was deleted."""
-        from datetime import datetime
-
-        from klabautermann.memory.entity_merge import DuplicateCandidate, MergeResult
-
-        mock_find = AsyncMock(
-            return_value=[
-                DuplicateCandidate(
-                    uuid1="person-001",
-                    uuid2="person-002",
-                    name1="John",
-                    name2="John",
-                    email1="john@test.com",
-                    email2="john@test.com",
-                    match_reason="both",
-                    similarity_score=1.0,
-                ),
-                DuplicateCandidate(
-                    uuid1="person-003",
-                    uuid2="person-004",
-                    name1="Jane",
-                    name2="Jane",
-                    email1="jane@test.com",
-                    email2="jane@test.com",
-                    match_reason="both",
-                    similarity_score=0.95,
-                ),
-            ]
-        )
-        # First merge succeeds, second fails (source_deleted=False)
-        mock_merge = AsyncMock(
-            side_effect=[
-                MergeResult(
-                    source_uuid="person-002",
-                    target_uuid="person-001",
-                    relationships_transferred=3,
-                    properties_merged=[],
-                    source_deleted=True,
-                    timestamp=datetime.now(),
-                ),
-                MergeResult(
-                    source_uuid="person-004",
-                    target_uuid="person-003",
-                    relationships_transferred=0,
-                    properties_merged=[],
-                    source_deleted=False,  # Failed to delete
-                    timestamp=datetime.now(),
-                ),
-            ]
-        )
-
-        monkeypatch.setattr("klabautermann.agents.archivist.find_duplicate_persons", mock_find)
+        """Should merge entities when merge=True."""
+        mock_neo4j.execute_query.return_value = [{"entity_type": "Person"}]
+        mock_merge = AsyncMock(return_value=True)
         monkeypatch.setattr("klabautermann.agents.archivist.merge_entities", mock_merge)
 
-        result = await archivist.detect_and_merge_duplicates(trace_id="test-trace-004")
+        result = await archivist.resolve_flagged_duplicate(
+            uuid1="person-001",
+            uuid2="person-002",
+            merge=True,
+            trace_id="test-trace-001",
+        )
 
-        assert result == 1  # Only one successful merge
+        assert result is True
+        mock_merge.assert_called_once_with(
+            mock_neo4j,
+            keep_uuid="person-001",
+            remove_uuid="person-002",
+            entity_type="Person",
+            trace_id="test-trace-001",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dismiss_flagged_duplicate(self, archivist: Archivist, mock_neo4j: Mock) -> None:
+        """Should mark as reviewed when merge=False."""
+        mock_neo4j.execute_query.return_value = [{"updated": 1}]
+
+        result = await archivist.resolve_flagged_duplicate(
+            uuid1="person-001",
+            uuid2="person-002",
+            merge=False,
+            trace_id="test-trace-002",
+        )
+
+        assert result is True
+        # Should have set reviewed=true
+        call_args = mock_neo4j.execute_query.call_args
+        assert "reviewed = true" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_neo4j(self) -> None:
+        """Should return False when Neo4j client not configured."""
+        archivist = Archivist(
+            name="archivist",
+            config={},
+            thread_manager=None,
+            neo4j_client=None,
+        )
+
+        result = await archivist.resolve_flagged_duplicate(
+            uuid1="person-001",
+            uuid2="person-002",
+            merge=True,
+            trace_id="test-trace-003",
+        )
+
+        assert result is False
 
 
 class TestProcessArchivalQueueWithDeduplication:
-    """Test suite for archival queue with deduplication integration (#191)."""
+    """Test suite for archival queue with deduplication integration (#35, #191)."""
 
     @pytest.fixture
     def mock_thread_manager(self) -> Mock:
@@ -815,7 +864,9 @@ class TestProcessArchivalQueueWithDeduplication:
             messages=[{"role": "user", "content": "Test"}],
         )
 
-        mock_dedup = AsyncMock(return_value=2)
+        mock_dedup = AsyncMock(
+            return_value={"auto_merged": 2, "flagged_for_review": 1, "ignored": 0}
+        )
         monkeypatch.setattr(archivist, "detect_and_merge_duplicates", mock_dedup)
 
         await archivist.process_archival_queue(trace_id="test-trace-001")
@@ -832,7 +883,9 @@ class TestProcessArchivalQueueWithDeduplication:
         """Should skip deduplication when no threads were archived."""
         mock_thread_manager.get_inactive_threads.return_value = []
 
-        mock_dedup = AsyncMock(return_value=0)
+        mock_dedup = AsyncMock(
+            return_value={"auto_merged": 0, "flagged_for_review": 0, "ignored": 0}
+        )
         monkeypatch.setattr(archivist, "detect_and_merge_duplicates", mock_dedup)
 
         await archivist.process_archival_queue(trace_id="test-trace-002")


### PR DESCRIPTION
## Summary
- Replace simple `entity_merge.py` module with sophisticated `deduplication.py` for the Archivist
- Use `rapidfuzz` library for fuzzy name similarity scoring
- Support both Person and Organization duplicate detection
- Auto-merge high-confidence duplicates (>= 0.9 similarity)
- Flag medium-confidence duplicates (0.7-0.9) for user review via `POTENTIAL_DUPLICATE` relationships

## Changes

### New/Modified Archivist Methods
- `detect_and_merge_duplicates()` - Now uses `process_duplicates()` pipeline with configurable thresholds
- `get_flagged_duplicates()` - Retrieve pending review items
- `resolve_flagged_duplicate()` - User can merge or dismiss flagged duplicates

### Tests
- Updated existing deduplication tests for new return type (`dict[str, int]` instead of `int`)
- Added tests for `get_flagged_duplicates()` and `resolve_flagged_duplicate()`
- All 32 Archivist tests pass

## Test plan
- [x] Unit tests pass (32/32)
- [x] Full test suite passes (1726 tests)
- [x] Ruff linter passes
- [x] Mypy type check passes

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)