### PR TITLE
feat(channels): Add auto-restart and cross-channel broadcast (#154, #156)

### DIFF
--- a/src/klabautermann/channels/__init__.py
+++ b/src/klabautermann/channels/__init__.py
@@ -18,6 +18,7 @@ from klabautermann.channels.base_channel import BaseChannel
 from klabautermann.channels.cli_driver import CLIDriver
 from klabautermann.channels.cli_renderer import CLIRenderer
 from klabautermann.channels.manager import (
+    BroadcastResult,
     ChannelConfig,
     ChannelInfo,
     ChannelManager,
@@ -53,6 +54,7 @@ __all__ = [
     "CLIRenderer",
     "TelegramDriver",
     # Manager
+    "BroadcastResult",
     "ChannelConfig",
     "ChannelInfo",
     "ChannelManager",

--- a/src/klabautermann/channels/manager.py
+++ b/src/klabautermann/channels/manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -23,7 +24,12 @@ from klabautermann.core.logger import logger
 
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
     from klabautermann.channels.base_channel import BaseChannel
+
+# Type alias for failure callback (sync or async)
+FailureCallback = Callable[[str, str], "Awaitable[None] | None"]
 
 
 # =============================================================================
@@ -94,6 +100,33 @@ class ChannelStatusReport:
     unhealthy_count: int
 
 
+@dataclass
+class BroadcastResult:
+    """Result of a broadcast operation."""
+
+    timestamp: datetime
+    content: str
+    results: dict[str, bool]  # channel_name -> success
+    errors: dict[str, str]  # channel_name -> error message
+    delivered_count: int
+    failed_count: int
+
+    @property
+    def all_delivered(self) -> bool:
+        """Check if message was delivered to all channels."""
+        return self.failed_count == 0
+
+    @property
+    def channels_delivered(self) -> list[str]:
+        """List of channels that received the message."""
+        return [name for name, success in self.results.items() if success]
+
+    @property
+    def channels_failed(self) -> list[str]:
+        """List of channels that failed to receive the message."""
+        return [name for name, success in self.results.items() if not success]
+
+
 # =============================================================================
 # Channel Configuration
 # =============================================================================
@@ -111,6 +144,9 @@ class ChannelConfig:
     discord_config: dict[str, Any] = field(default_factory=dict)
     health_check_interval: float = 30.0
     stale_threshold: float = 300.0  # 5 minutes
+    auto_restart: bool = True  # Auto-restart failed channels
+    max_restart_attempts: int = 3  # Max restart attempts before giving up
+    restart_backoff_seconds: float = 5.0  # Initial backoff between restarts
 
     @classmethod
     def from_env(cls) -> ChannelConfig:
@@ -128,6 +164,9 @@ class ChannelConfig:
             enable_discord=str_to_bool(os.getenv("ENABLE_DISCORD")),
             health_check_interval=float(os.getenv("HEALTH_CHECK_INTERVAL", "30.0")),
             stale_threshold=float(os.getenv("CHANNEL_STALE_THRESHOLD", "300.0")),
+            auto_restart=str_to_bool(os.getenv("CHANNEL_AUTO_RESTART", "true")),
+            max_restart_attempts=int(os.getenv("CHANNEL_MAX_RESTART_ATTEMPTS", "3")),
+            restart_backoff_seconds=float(os.getenv("CHANNEL_RESTART_BACKOFF", "5.0")),
         )
 
 
@@ -173,6 +212,11 @@ class ChannelManager:
         self._health_task: asyncio.Task[None] | None = None
         self._manager_started_at: datetime | None = None
         self._registration_order: list[str] = []
+        # Restart tracking
+        self._restart_attempts: dict[str, int] = {}
+        self._last_restart_at: dict[str, datetime | None] = {}
+        # Failure callbacks
+        self._failure_callbacks: list[FailureCallback] = []
 
     # =========================================================================
     # Registration
@@ -197,6 +241,8 @@ class ChannelManager:
         self._message_counts[name] = 0
         self._last_message_at[name] = None
         self._registration_order.append(name)
+        self._restart_attempts[name] = 0
+        self._last_restart_at[name] = None
 
         logger.debug(
             f"[WHISPER] Registered channel: {name}",
@@ -226,6 +272,8 @@ class ChannelManager:
         self._started_at.pop(name, None)
         self._health_status.pop(name, None)
         self._registration_order.remove(name)
+        self._restart_attempts.pop(name, None)
+        self._last_restart_at.pop(name, None)
 
         logger.debug(f"[WHISPER] Unregistered channel: {name}")
 
@@ -377,7 +425,11 @@ class ChannelManager:
 
         channel = self._channels[name]
 
-        logger.info(f"[CHART] Restarting channel: {name}")
+        # Track restart attempt
+        self._restart_attempts[name] = self._restart_attempts.get(name, 0) + 1
+        self._last_restart_at[name] = datetime.now()
+
+        logger.info(f"[CHART] Restarting channel: {name} (attempt {self._restart_attempts[name]})")
 
         # Stop if running
         if self._status[name] == ChannelStatus.RUNNING:
@@ -393,12 +445,47 @@ class ChannelManager:
             await channel.start()
             self._status[name] = ChannelStatus.RUNNING
             self._started_at[name] = datetime.now()
+            # Reset restart attempts on success
+            self._restart_attempts[name] = 0
             logger.info(f"[BEACON] Channel restarted: {name}")
             return True
         except Exception as e:
             self._status[name] = ChannelStatus.ERROR
-            logger.error(f"[STORM] Failed to restart channel {name}: {e}")
+            error_msg = str(e)
+            logger.error(f"[STORM] Failed to restart channel {name}: {error_msg}")
+            # Notify failure callbacks
+            await self._notify_failure(name, error_msg)
             return False
+
+    def on_failure(self, callback: FailureCallback) -> None:
+        """
+        Register a callback for channel failures.
+
+        The callback receives (channel_name, error_message).
+        Can be sync or async.
+
+        Args:
+            callback: Function to call on channel failure.
+        """
+        self._failure_callbacks.append(callback)
+
+    async def _notify_failure(self, channel_name: str, error: str) -> None:
+        """Notify all registered failure callbacks."""
+        for callback in self._failure_callbacks:
+            try:
+                result = callback(channel_name, error)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                logger.error(f"[STORM] Failure callback error: {e}")
+
+    def get_restart_attempts(self, name: str) -> int:
+        """Get number of restart attempts for a channel."""
+        return self._restart_attempts.get(name, 0)
+
+    def reset_restart_attempts(self, name: str) -> None:
+        """Reset restart attempt counter for a channel."""
+        self._restart_attempts[name] = 0
 
     # =========================================================================
     # Health Monitoring
@@ -494,6 +581,46 @@ class ChannelManager:
                     f"[SWELL] Channel unhealthy: {name}",
                     extra={"channel": name, "error": error},
                 )
+                # Auto-restart if enabled and under retry limit
+                if self._config.auto_restart:
+                    await self._attempt_auto_restart(name, error or "unhealthy")
+
+    async def _attempt_auto_restart(self, name: str, error: str) -> None:
+        """Attempt to auto-restart a failed channel with backoff."""
+        attempts = self._restart_attempts.get(name, 0)
+
+        if attempts >= self._config.max_restart_attempts:
+            logger.error(
+                f"[STORM] Channel {name} exceeded max restart attempts ({attempts}). "
+                "Manual intervention required.",
+                extra={"channel": name, "attempts": attempts},
+            )
+            await self._notify_failure(name, f"Max restarts exceeded: {error}")
+            return
+
+        # Exponential backoff
+        backoff = self._config.restart_backoff_seconds * (2**attempts)
+
+        # Check if enough time has passed since last restart
+        last_restart = self._last_restart_at.get(name)
+        if last_restart is not None:
+            elapsed = (datetime.now() - last_restart).total_seconds()
+            if elapsed < backoff:
+                logger.debug(f"[WHISPER] Waiting {backoff - elapsed:.1f}s before restart: {name}")
+                return
+
+        logger.info(
+            f"[CHART] Auto-restarting unhealthy channel: {name} "
+            f"(attempt {attempts + 1}/{self._config.max_restart_attempts})",
+            extra={"channel": name, "error": error},
+        )
+
+        success = await self.restart_channel(name)
+        if not success:
+            logger.error(
+                f"[STORM] Auto-restart failed for channel: {name}",
+                extra={"channel": name},
+            )
 
     def get_health(self, name: str) -> HealthStatus | None:
         """Get health status for a channel."""
@@ -522,6 +649,128 @@ class ChannelManager:
         if channel_name in self._message_counts:
             self._message_counts[channel_name] += 1
             self._last_message_at[channel_name] = datetime.now()
+
+    # =========================================================================
+    # Cross-Channel Messaging
+    # =========================================================================
+
+    async def broadcast(
+        self,
+        content: str,
+        thread_ids: dict[str, str] | None = None,
+        exclude_channels: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> BroadcastResult:
+        """
+        Broadcast a message to all active channels.
+
+        Each channel formats the message according to its capabilities
+        (e.g., Markdown for Telegram, Rich for CLI).
+
+        Args:
+            content: Message content to broadcast.
+            thread_ids: Optional dict mapping channel names to thread IDs.
+                       If not provided, uses a default broadcast thread.
+            exclude_channels: Channel names to exclude from broadcast.
+            metadata: Optional channel-specific metadata.
+
+        Returns:
+            BroadcastResult with delivery status per channel.
+        """
+        exclude = exclude_channels or []
+        results: dict[str, bool] = {}
+        errors: dict[str, str] = {}
+
+        logger.info(
+            f"[CHART] Broadcasting message to {len(self.active_channels)} channels",
+            extra={"content_length": len(content), "exclude": exclude},
+        )
+
+        for name in self.active_channels:
+            if name in exclude:
+                logger.debug(f"[WHISPER] Skipping excluded channel: {name}")
+                continue
+
+            channel = self._channels.get(name)
+            if channel is None:
+                continue
+
+            # Get thread ID for this channel
+            thread_id = (thread_ids or {}).get(name, f"broadcast-{name}")
+
+            try:
+                await channel.send_message(
+                    thread_id=thread_id,
+                    content=content,
+                    metadata=metadata,
+                )
+                results[name] = True
+                logger.debug(f"[WHISPER] Broadcast delivered to: {name}")
+            except Exception as e:
+                results[name] = False
+                errors[name] = str(e)
+                logger.error(
+                    f"[STORM] Broadcast failed for {name}: {e}",
+                    extra={"channel": name},
+                )
+
+        delivered = sum(1 for v in results.values() if v)
+        failed = len(results) - delivered
+
+        logger.info(
+            f"[BEACON] Broadcast complete: {delivered} delivered, {failed} failed",
+            extra={"results": results},
+        )
+
+        return BroadcastResult(
+            timestamp=datetime.now(),
+            content=content,
+            results=results,
+            errors=errors,
+            delivered_count=delivered,
+            failed_count=failed,
+        )
+
+    async def send_to_channel(
+        self,
+        channel_name: str,
+        content: str,
+        thread_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """
+        Send a message to a specific channel.
+
+        Args:
+            channel_name: Name of the channel to send to.
+            content: Message content.
+            thread_id: Optional thread ID. Defaults to default thread.
+            metadata: Optional channel-specific metadata.
+
+        Returns:
+            True if message was sent successfully.
+        """
+        channel = self._channels.get(channel_name)
+        if channel is None:
+            logger.error(f"[STORM] Channel not found: {channel_name}")
+            return False
+
+        if self._status.get(channel_name) != ChannelStatus.RUNNING:
+            logger.warning(f"[SWELL] Channel not running: {channel_name}")
+            return False
+
+        thread = thread_id or f"default-{channel_name}"
+
+        try:
+            await channel.send_message(
+                thread_id=thread,
+                content=content,
+                metadata=metadata,
+            )
+            return True
+        except Exception as e:
+            logger.error(f"[STORM] Failed to send to {channel_name}: {e}")
+            return False
 
     # =========================================================================
     # Status Reporting
@@ -613,6 +862,7 @@ def reset_channel_manager() -> None:
 # =============================================================================
 
 __all__ = [
+    "BroadcastResult",
     "ChannelConfig",
     "ChannelInfo",
     "ChannelManager",

--- a/tests/unit/test_channel_manager.py
+++ b/tests/unit/test_channel_manager.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from klabautermann.channels.manager import (
+    BroadcastResult,
     ChannelConfig,
     ChannelManager,
     ChannelStatus,
@@ -567,3 +568,306 @@ class TestGlobalInstance:
         reset_channel_manager()
         manager2 = get_channel_manager()
         assert manager1 is not manager2
+
+
+# =============================================================================
+# Test Auto-Restart (#154)
+# =============================================================================
+
+
+class TestAutoRestart:
+    """Tests for automatic channel restart on failure."""
+
+    def test_config_auto_restart_defaults(self) -> None:
+        """Test auto-restart configuration defaults."""
+        config = ChannelConfig()
+        assert config.auto_restart is True
+        assert config.max_restart_attempts == 3
+        assert config.restart_backoff_seconds == 5.0
+
+    def test_config_auto_restart_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test loading auto-restart config from environment."""
+        monkeypatch.setenv("CHANNEL_AUTO_RESTART", "false")
+        monkeypatch.setenv("CHANNEL_MAX_RESTART_ATTEMPTS", "5")
+        monkeypatch.setenv("CHANNEL_RESTART_BACKOFF", "10.0")
+
+        config = ChannelConfig.from_env()
+
+        assert config.auto_restart is False
+        assert config.max_restart_attempts == 5
+        assert config.restart_backoff_seconds == 10.0
+
+    @pytest.mark.asyncio
+    async def test_restart_tracks_attempts(
+        self, manager: ChannelManager, mock_channel: MagicMock
+    ) -> None:
+        """Test that restart tracks attempt count."""
+        manager.register("test", mock_channel)
+        await manager.start_all()
+
+        assert manager.get_restart_attempts("test") == 0
+
+        await manager.restart_channel("test")
+        # Attempt resets to 0 on success
+        assert manager.get_restart_attempts("test") == 0
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_restart_increments_on_failure(self, manager: ChannelManager) -> None:
+        """Test that failed restart increments attempt count."""
+        channel = MagicMock()
+        channel.channel_type = "failing"
+        channel.start = AsyncMock(side_effect=RuntimeError("Start failed"))
+        channel.stop = AsyncMock()
+
+        manager.register("failing", channel)
+
+        # First attempt
+        result = await manager.restart_channel("failing")
+        assert result is False
+        assert manager.get_restart_attempts("failing") == 1
+
+        # Second attempt
+        result = await manager.restart_channel("failing")
+        assert result is False
+        assert manager.get_restart_attempts("failing") == 2
+
+    def test_reset_restart_attempts(self, manager: ChannelManager, mock_channel: MagicMock) -> None:
+        """Test resetting restart attempt counter."""
+        manager.register("test", mock_channel)
+        manager._restart_attempts["test"] = 5
+
+        manager.reset_restart_attempts("test")
+
+        assert manager.get_restart_attempts("test") == 0
+
+    @pytest.mark.asyncio
+    async def test_failure_callback_called(self, manager: ChannelManager) -> None:
+        """Test that failure callbacks are called on restart failure."""
+        channel = MagicMock()
+        channel.channel_type = "failing"
+        channel.start = AsyncMock(side_effect=RuntimeError("Start failed"))
+        channel.stop = AsyncMock()
+
+        manager.register("failing", channel)
+
+        failures: list[tuple[str, str]] = []
+
+        def on_failure(name: str, error: str) -> None:
+            failures.append((name, error))
+
+        manager.on_failure(on_failure)
+
+        await manager.restart_channel("failing")
+
+        assert len(failures) == 1
+        assert failures[0][0] == "failing"
+        assert "Start failed" in failures[0][1]
+
+    @pytest.mark.asyncio
+    async def test_async_failure_callback(self, manager: ChannelManager) -> None:
+        """Test that async failure callbacks are awaited."""
+        channel = MagicMock()
+        channel.channel_type = "failing"
+        channel.start = AsyncMock(side_effect=RuntimeError("Start failed"))
+        channel.stop = AsyncMock()
+
+        manager.register("failing", channel)
+
+        failures: list[tuple[str, str]] = []
+
+        async def async_on_failure(name: str, error: str) -> None:
+            await asyncio.sleep(0.01)
+            failures.append((name, error))
+
+        manager.on_failure(async_on_failure)
+
+        await manager.restart_channel("failing")
+
+        assert len(failures) == 1
+
+
+# =============================================================================
+# Test Cross-Channel Messaging (#156)
+# =============================================================================
+
+
+class TestBroadcast:
+    """Tests for broadcast (cross-channel) messaging."""
+
+    @pytest.mark.asyncio
+    async def test_broadcast_to_all_channels(self, manager: ChannelManager) -> None:
+        """Test broadcasting to all active channels."""
+        channels = {}
+        for name in ["ch1", "ch2", "ch3"]:
+            ch = MagicMock()
+            ch.channel_type = name
+            ch.start = AsyncMock()
+            ch.stop = AsyncMock()
+            ch.send_message = AsyncMock()
+            channels[name] = ch
+            manager.register(name, ch)
+
+        await manager.start_all()
+
+        result = await manager.broadcast("Test broadcast message")
+
+        assert isinstance(result, BroadcastResult)
+        assert result.delivered_count == 3
+        assert result.failed_count == 0
+        assert result.all_delivered is True
+
+        for ch in channels.values():
+            ch.send_message.assert_called_once()
+            call_kwargs = ch.send_message.call_args.kwargs
+            assert call_kwargs["content"] == "Test broadcast message"
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_with_thread_ids(self, manager: ChannelManager) -> None:
+        """Test broadcasting with custom thread IDs."""
+        channel = MagicMock()
+        channel.channel_type = "test"
+        channel.start = AsyncMock()
+        channel.stop = AsyncMock()
+        channel.send_message = AsyncMock()
+
+        manager.register("test", channel)
+        await manager.start_all()
+
+        await manager.broadcast(
+            "Test message",
+            thread_ids={"test": "custom-thread-123"},
+        )
+
+        call_kwargs = channel.send_message.call_args.kwargs
+        assert call_kwargs["thread_id"] == "custom-thread-123"
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_exclude_channels(self, manager: ChannelManager) -> None:
+        """Test excluding channels from broadcast."""
+        for name in ["ch1", "ch2", "ch3"]:
+            ch = MagicMock()
+            ch.channel_type = name
+            ch.start = AsyncMock()
+            ch.stop = AsyncMock()
+            ch.send_message = AsyncMock()
+            manager.register(name, ch)
+
+        await manager.start_all()
+
+        result = await manager.broadcast(
+            "Test message",
+            exclude_channels=["ch2"],
+        )
+
+        assert result.delivered_count == 2
+        assert "ch1" in result.channels_delivered
+        assert "ch3" in result.channels_delivered
+        assert "ch2" not in result.channels_delivered
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_partial_failure(self, manager: ChannelManager) -> None:
+        """Test broadcast with some channels failing."""
+        good_channel = MagicMock()
+        good_channel.channel_type = "good"
+        good_channel.start = AsyncMock()
+        good_channel.stop = AsyncMock()
+        good_channel.send_message = AsyncMock()
+
+        bad_channel = MagicMock()
+        bad_channel.channel_type = "bad"
+        bad_channel.start = AsyncMock()
+        bad_channel.stop = AsyncMock()
+        bad_channel.send_message = AsyncMock(side_effect=RuntimeError("Send failed"))
+
+        manager.register("good", good_channel)
+        manager.register("bad", bad_channel)
+
+        await manager.start_all()
+
+        result = await manager.broadcast("Test message")
+
+        assert result.delivered_count == 1
+        assert result.failed_count == 1
+        assert result.all_delivered is False
+        assert "good" in result.channels_delivered
+        assert "bad" in result.channels_failed
+        assert "Send failed" in result.errors["bad"]
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_result_properties(self, manager: ChannelManager) -> None:
+        """Test BroadcastResult properties."""
+        for name in ["ch1", "ch2"]:
+            ch = MagicMock()
+            ch.channel_type = name
+            ch.start = AsyncMock()
+            ch.stop = AsyncMock()
+            ch.send_message = AsyncMock()
+            manager.register(name, ch)
+
+        await manager.start_all()
+
+        result = await manager.broadcast("Test")
+
+        assert isinstance(result.timestamp, datetime)
+        assert result.content == "Test"
+        assert set(result.channels_delivered) == {"ch1", "ch2"}
+        assert result.channels_failed == []
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_send_to_channel(self, manager: ChannelManager, mock_channel: MagicMock) -> None:
+        """Test sending to a specific channel."""
+        mock_channel.send_message = AsyncMock()
+        manager.register("test", mock_channel)
+        await manager.start_all()
+
+        result = await manager.send_to_channel(
+            channel_name="test",
+            content="Hello",
+            thread_id="thread-123",
+        )
+
+        assert result is True
+        mock_channel.send_message.assert_called_once()
+        call_kwargs = mock_channel.send_message.call_args.kwargs
+        assert call_kwargs["content"] == "Hello"
+        assert call_kwargs["thread_id"] == "thread-123"
+
+        await manager.stop_all()
+
+    @pytest.mark.asyncio
+    async def test_send_to_nonexistent_channel(self, manager: ChannelManager) -> None:
+        """Test sending to nonexistent channel."""
+        result = await manager.send_to_channel(
+            channel_name="nonexistent",
+            content="Hello",
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_to_stopped_channel(
+        self, manager: ChannelManager, mock_channel: MagicMock
+    ) -> None:
+        """Test sending to stopped channel."""
+        mock_channel.send_message = AsyncMock()
+        manager.register("test", mock_channel)
+        # Don't start the channel
+
+        result = await manager.send_to_channel(
+            channel_name="test",
+            content="Hello",
+        )
+
+        assert result is False
+        mock_channel.send_message.assert_not_called()


### PR DESCRIPTION
## Summary
- Add automatic channel restart on failure detection with exponential backoff
- Add cross-channel broadcast messaging with delivery tracking
- 15 new unit tests for the new functionality

## Changes

### Channel Restart with Auto-Recovery (#154)
- Track restart attempts per channel with exponential backoff
- Auto-restart unhealthy channels during health monitoring
- Failure callbacks for notifications (sync and async supported)
- `reset_restart_attempts()` and `get_restart_attempts()` methods
- Configurable via environment or `ChannelConfig`:
  - `CHANNEL_AUTO_RESTART` (default: true)
  - `CHANNEL_MAX_RESTART_ATTEMPTS` (default: 3)
  - `CHANNEL_RESTART_BACKOFF` (default: 5.0 seconds)

### Cross-Channel Messaging (#156)
- `broadcast()` method sends message to all active channels
- Support for custom `thread_ids` per channel
- `exclude_channels` parameter to skip specific channels
- `BroadcastResult` with delivery tracking and error details
- `send_to_channel()` for targeted messaging to specific channels

### Tests
- 15 new unit tests (56 total for channel manager)
- Full test suite passes (1741 tests)

## Test plan
- [x] New unit tests pass
- [x] Full test suite passes (1741 tests)
- [x] Ruff linter passes
- [x] Mypy type check passes

Closes #154, #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)