### PR TITLE
feat(channels): Add channel metrics collection (#159)

### DIFF
--- a/src/klabautermann/channels/manager.py
+++ b/src/klabautermann/channels/manager.py
@@ -21,6 +21,16 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from klabautermann.core.logger import logger
+from klabautermann.core.metrics import (
+    record_channel_broadcast,
+    record_channel_broadcast_delivery,
+    record_channel_error,
+    record_channel_latency,
+    record_channel_message,
+    set_channel_active_count,
+    set_channel_healthy,
+    set_channel_status,
+)
 
 
 if TYPE_CHECKING:
@@ -353,6 +363,8 @@ class ChannelManager:
         await channel.start()
         self._status[name] = ChannelStatus.RUNNING
         self._started_at[name] = datetime.now()
+        set_channel_status(name, running=True)
+        set_channel_active_count(len(self.active_channels))
         logger.info(f"[CHART] Channel started: {name}")
 
     async def stop_all(self) -> dict[str, bool]:
@@ -390,10 +402,13 @@ class ChannelManager:
             try:
                 await channel.stop()
                 self._status[name] = ChannelStatus.STOPPED
+                set_channel_status(name, running=False)
                 results[name] = True
                 logger.debug(f"[WHISPER] Stopped channel: {name}")
             except Exception as e:
                 self._status[name] = ChannelStatus.ERROR
+                set_channel_status(name, running=False)
+                record_channel_error(name, "stop_failure")
                 results[name] = False
                 logger.error(
                     f"[STORM] Failed to stop channel {name}: {e}",
@@ -402,6 +417,7 @@ class ChannelManager:
                 )
 
         success_count = sum(results.values())
+        set_channel_active_count(len(self.active_channels))
         logger.info(
             f"[BEACON] Stopped {success_count}/{len(results)} channel(s)",
             extra={"results": results},
@@ -445,12 +461,16 @@ class ChannelManager:
             await channel.start()
             self._status[name] = ChannelStatus.RUNNING
             self._started_at[name] = datetime.now()
+            set_channel_status(name, running=True)
+            set_channel_active_count(len(self.active_channels))
             # Reset restart attempts on success
             self._restart_attempts[name] = 0
             logger.info(f"[BEACON] Channel restarted: {name}")
             return True
         except Exception as e:
             self._status[name] = ChannelStatus.ERROR
+            set_channel_status(name, running=False)
+            record_channel_error(name, "restart_failure")
             error_msg = str(e)
             logger.error(f"[STORM] Failed to restart channel {name}: {error_msg}")
             # Notify failure callbacks
@@ -575,6 +595,7 @@ class ChannelManager:
                 error=error,
                 message_count=self._message_counts.get(name, 0),
             )
+            set_channel_healthy(name, is_healthy)
 
             if not is_healthy:
                 logger.warning(
@@ -639,16 +660,20 @@ class ChannelManager:
     # Message Tracking
     # =========================================================================
 
-    def record_message(self, channel_name: str) -> None:
+    def record_message(self, channel_name: str, latency_ms: float | None = None) -> None:
         """
         Record that a message was processed.
 
         Args:
             channel_name: Name of the channel that processed the message.
+            latency_ms: Optional response latency in milliseconds.
         """
         if channel_name in self._message_counts:
             self._message_counts[channel_name] += 1
             self._last_message_at[channel_name] = datetime.now()
+            record_channel_message(channel_name)
+            if latency_ms is not None:
+                record_channel_latency(channel_name, latency_ms)
 
     # =========================================================================
     # Cross-Channel Messaging
@@ -685,6 +710,7 @@ class ChannelManager:
             f"[CHART] Broadcasting message to {len(self.active_channels)} channels",
             extra={"content_length": len(content), "exclude": exclude},
         )
+        record_channel_broadcast()
 
         for name in self.active_channels:
             if name in exclude:
@@ -705,10 +731,13 @@ class ChannelManager:
                     metadata=metadata,
                 )
                 results[name] = True
+                record_channel_broadcast_delivery(name, success=True)
                 logger.debug(f"[WHISPER] Broadcast delivered to: {name}")
             except Exception as e:
                 results[name] = False
                 errors[name] = str(e)
+                record_channel_broadcast_delivery(name, success=False)
+                record_channel_error(name, "broadcast_failure")
                 logger.error(
                     f"[STORM] Broadcast failed for {name}: {e}",
                     extra={"channel": name},

--- a/src/klabautermann/core/metrics.py
+++ b/src/klabautermann/core/metrics.py
@@ -95,6 +95,74 @@ AGENT_INBOX_SIZE = Gauge(
 
 
 # ===========================================================================
+# Channel Metrics
+# ===========================================================================
+
+# Messages processed per channel
+CHANNEL_MESSAGES_TOTAL = Counter(
+    "klabautermann_channel_messages_total",
+    "Total messages processed by channel",
+    ["channel_name"],
+    registry=REGISTRY,
+)
+
+# Channel response latency (in milliseconds)
+CHANNEL_RESPONSE_LATENCY_MS = Histogram(
+    "klabautermann_channel_response_latency_ms",
+    "Response latency in milliseconds by channel",
+    ["channel_name"],
+    buckets=[10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    registry=REGISTRY,
+)
+
+# Channel errors
+CHANNEL_ERRORS_TOTAL = Counter(
+    "klabautermann_channel_errors_total",
+    "Total errors by channel",
+    ["channel_name", "error_type"],
+    registry=REGISTRY,
+)
+
+# Channel status (1=running, 0=stopped)
+CHANNEL_STATUS = Gauge(
+    "klabautermann_channel_status",
+    "Channel status (1=running, 0=stopped)",
+    ["channel_name"],
+    registry=REGISTRY,
+)
+
+# Channel health (1=healthy, 0=unhealthy)
+CHANNEL_HEALTHY = Gauge(
+    "klabautermann_channel_healthy",
+    "Channel health status (1=healthy, 0=unhealthy)",
+    ["channel_name"],
+    registry=REGISTRY,
+)
+
+# Broadcast messages
+CHANNEL_BROADCASTS_TOTAL = Counter(
+    "klabautermann_channel_broadcasts_total",
+    "Total broadcast messages sent",
+    registry=REGISTRY,
+)
+
+# Broadcast delivery success/failure
+CHANNEL_BROADCAST_DELIVERIES_TOTAL = Counter(
+    "klabautermann_channel_broadcast_deliveries_total",
+    "Broadcast delivery results",
+    ["channel_name", "status"],  # status: success/failure
+    registry=REGISTRY,
+)
+
+# Active channels gauge
+CHANNEL_ACTIVE_COUNT = Gauge(
+    "klabautermann_channel_active_count",
+    "Number of active channels",
+    registry=REGISTRY,
+)
+
+
+# ===========================================================================
 # API Metrics
 # ===========================================================================
 
@@ -220,6 +288,47 @@ def set_agent_inbox_size(agent_name: str, size: int) -> None:
     AGENT_INBOX_SIZE.labels(agent_name=agent_name).set(size)
 
 
+def record_channel_message(channel_name: str) -> None:
+    """Record a channel message."""
+    CHANNEL_MESSAGES_TOTAL.labels(channel_name=channel_name).inc()
+
+
+def record_channel_latency(channel_name: str, latency_ms: float) -> None:
+    """Record channel response latency in milliseconds."""
+    CHANNEL_RESPONSE_LATENCY_MS.labels(channel_name=channel_name).observe(latency_ms)
+
+
+def record_channel_error(channel_name: str, error_type: str) -> None:
+    """Record a channel error."""
+    CHANNEL_ERRORS_TOTAL.labels(channel_name=channel_name, error_type=error_type).inc()
+
+
+def set_channel_status(channel_name: str, running: bool) -> None:
+    """Set channel running status."""
+    CHANNEL_STATUS.labels(channel_name=channel_name).set(1 if running else 0)
+
+
+def set_channel_healthy(channel_name: str, healthy: bool) -> None:
+    """Set channel health status."""
+    CHANNEL_HEALTHY.labels(channel_name=channel_name).set(1 if healthy else 0)
+
+
+def record_channel_broadcast() -> None:
+    """Record a broadcast message."""
+    CHANNEL_BROADCASTS_TOTAL.inc()
+
+
+def record_channel_broadcast_delivery(channel_name: str, success: bool) -> None:
+    """Record broadcast delivery result."""
+    status = "success" if success else "failure"
+    CHANNEL_BROADCAST_DELIVERIES_TOTAL.labels(channel_name=channel_name, status=status).inc()
+
+
+def set_channel_active_count(count: int) -> None:
+    """Set the number of active channels."""
+    CHANNEL_ACTIVE_COUNT.set(count)
+
+
 def record_api_request(method: str, endpoint: str, status_code: int) -> None:
     """Record an API request."""
     API_REQUESTS_TOTAL.labels(method=method, endpoint=endpoint, status_code=str(status_code)).inc()
@@ -318,9 +427,9 @@ def timed_operation(metric_func: Callable[[str, float], None], label: str) -> Ca
 # ===========================================================================
 
 __all__ = [
+    # Agent metrics
     "AGENT_ERRORS_TOTAL",
     "AGENT_INBOX_SIZE",
-    # Agent metrics
     "AGENT_REQUESTS_TOTAL",
     "AGENT_REQUEST_LATENCY_MS",
     "AGENT_RUNNING",
@@ -329,6 +438,15 @@ __all__ = [
     "API_REQUESTS_TOTAL",
     "API_REQUEST_LATENCY_SECONDS",
     "API_WEBSOCKET_CONNECTIONS",
+    # Channel metrics
+    "CHANNEL_ACTIVE_COUNT",
+    "CHANNEL_BROADCASTS_TOTAL",
+    "CHANNEL_BROADCAST_DELIVERIES_TOTAL",
+    "CHANNEL_ERRORS_TOTAL",
+    "CHANNEL_HEALTHY",
+    "CHANNEL_MESSAGES_TOTAL",
+    "CHANNEL_RESPONSE_LATENCY_MS",
+    "CHANNEL_STATUS",
     # Graph metrics
     "GRAPH_OPERATIONS_TOTAL",
     "GRAPH_OPERATION_LATENCY_SECONDS",
@@ -341,19 +459,31 @@ __all__ = [
     "decrement_websocket_connections",
     "get_metrics",
     "increment_websocket_connections",
+    # Agent helpers
     "record_agent_error",
     "record_agent_latency",
-    # Agent helpers
     "record_agent_request",
     "record_agent_success",
-    "record_api_latency",
     # API helpers
+    "record_api_latency",
     "record_api_request",
+    # Channel helpers
+    "record_channel_broadcast",
+    "record_channel_broadcast_delivery",
+    "record_channel_error",
+    "record_channel_latency",
+    "record_channel_message",
+    "set_channel_active_count",
+    "set_channel_healthy",
+    "set_channel_status",
+    # Graph helpers
     "record_graph_latency",
     "record_graph_operation",
+    # LLM helpers
     "record_llm_call",
     "record_llm_latency",
     "record_llm_tokens",
+    # Agent state
     "set_agent_inbox_size",
     "set_agent_running",
     "set_websocket_connections",

--- a/tests/unit/test_prometheus_metrics.py
+++ b/tests/unit/test_prometheus_metrics.py
@@ -22,6 +22,13 @@ from klabautermann.core.metrics import (
     AGENT_SUCCESSES_TOTAL,
     API_REQUESTS_TOTAL,
     API_WEBSOCKET_CONNECTIONS,
+    CHANNEL_ACTIVE_COUNT,
+    CHANNEL_BROADCAST_DELIVERIES_TOTAL,
+    CHANNEL_BROADCASTS_TOTAL,
+    CHANNEL_ERRORS_TOTAL,
+    CHANNEL_HEALTHY,
+    CHANNEL_MESSAGES_TOTAL,
+    CHANNEL_STATUS,
     GRAPH_OPERATIONS_TOTAL,
     LLM_CALLS_TOTAL,
     LLM_TOKENS_TOTAL,
@@ -35,6 +42,11 @@ from klabautermann.core.metrics import (
     record_agent_success,
     record_api_latency,
     record_api_request,
+    record_channel_broadcast,
+    record_channel_broadcast_delivery,
+    record_channel_error,
+    record_channel_latency,
+    record_channel_message,
     record_graph_latency,
     record_graph_operation,
     record_llm_call,
@@ -42,6 +54,9 @@ from klabautermann.core.metrics import (
     record_llm_tokens,
     set_agent_inbox_size,
     set_agent_running,
+    set_channel_active_count,
+    set_channel_healthy,
+    set_channel_status,
     set_websocket_connections,
     timed_operation,
 )
@@ -387,3 +402,135 @@ class TestIntegration:
         # Both should appear in output
         assert 'agent_name="agent_a"' in metrics
         assert 'agent_name="agent_b"' in metrics
+
+
+# ===========================================================================
+# Channel Metrics Tests
+# ===========================================================================
+
+
+class TestChannelMetrics:
+    """Tests for channel metrics recording."""
+
+    def test_record_channel_message(self):
+        """Should increment channel message counter."""
+        initial = CHANNEL_MESSAGES_TOTAL.labels(channel_name="test_channel")._value.get()
+        record_channel_message("test_channel")
+        after = CHANNEL_MESSAGES_TOTAL.labels(channel_name="test_channel")._value.get()
+        assert after == initial + 1
+
+    def test_record_channel_latency(self):
+        """Should record channel response latency."""
+        record_channel_latency("latency_channel", 150.0)
+        metrics = get_metrics().decode("utf-8")
+        assert 'channel_name="latency_channel"' in metrics
+        assert "klabautermann_channel_response_latency_ms" in metrics
+
+    def test_record_channel_error(self):
+        """Should increment channel error counter with error type."""
+        initial = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="error_channel", error_type="connection"
+        )._value.get()
+        record_channel_error("error_channel", "connection")
+        after = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="error_channel", error_type="connection"
+        )._value.get()
+        assert after == initial + 1
+
+    def test_record_channel_error_different_types(self):
+        """Should track different error types separately."""
+        initial_conn = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="multi_error_channel", error_type="connection"
+        )._value.get()
+        initial_timeout = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="multi_error_channel", error_type="timeout"
+        )._value.get()
+
+        record_channel_error("multi_error_channel", "connection")
+        record_channel_error("multi_error_channel", "timeout")
+
+        after_conn = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="multi_error_channel", error_type="connection"
+        )._value.get()
+        after_timeout = CHANNEL_ERRORS_TOTAL.labels(
+            channel_name="multi_error_channel", error_type="timeout"
+        )._value.get()
+
+        assert after_conn == initial_conn + 1
+        assert after_timeout == initial_timeout + 1
+
+    def test_set_channel_status_running(self):
+        """Should set channel status gauge to 1 when running."""
+        set_channel_status("status_channel", running=True)
+        value = CHANNEL_STATUS.labels(channel_name="status_channel")._value.get()
+        assert value == 1
+
+    def test_set_channel_status_stopped(self):
+        """Should set channel status gauge to 0 when stopped."""
+        set_channel_status("status_channel", running=False)
+        value = CHANNEL_STATUS.labels(channel_name="status_channel")._value.get()
+        assert value == 0
+
+    def test_set_channel_healthy_true(self):
+        """Should set channel health gauge to 1 when healthy."""
+        set_channel_healthy("health_channel", healthy=True)
+        value = CHANNEL_HEALTHY.labels(channel_name="health_channel")._value.get()
+        assert value == 1
+
+    def test_set_channel_healthy_false(self):
+        """Should set channel health gauge to 0 when unhealthy."""
+        set_channel_healthy("health_channel", healthy=False)
+        value = CHANNEL_HEALTHY.labels(channel_name="health_channel")._value.get()
+        assert value == 0
+
+    def test_record_channel_broadcast(self):
+        """Should increment broadcast counter."""
+        initial = CHANNEL_BROADCASTS_TOTAL._value.get()
+        record_channel_broadcast()
+        after = CHANNEL_BROADCASTS_TOTAL._value.get()
+        assert after == initial + 1
+
+    def test_record_channel_broadcast_delivery_success(self):
+        """Should track successful broadcast deliveries."""
+        initial = CHANNEL_BROADCAST_DELIVERIES_TOTAL.labels(
+            channel_name="delivery_channel", status="success"
+        )._value.get()
+        record_channel_broadcast_delivery("delivery_channel", success=True)
+        after = CHANNEL_BROADCAST_DELIVERIES_TOTAL.labels(
+            channel_name="delivery_channel", status="success"
+        )._value.get()
+        assert after == initial + 1
+
+    def test_record_channel_broadcast_delivery_failure(self):
+        """Should track failed broadcast deliveries."""
+        initial = CHANNEL_BROADCAST_DELIVERIES_TOTAL.labels(
+            channel_name="delivery_channel", status="failure"
+        )._value.get()
+        record_channel_broadcast_delivery("delivery_channel", success=False)
+        after = CHANNEL_BROADCAST_DELIVERIES_TOTAL.labels(
+            channel_name="delivery_channel", status="failure"
+        )._value.get()
+        assert after == initial + 1
+
+    def test_set_channel_active_count(self):
+        """Should set active channel count gauge."""
+        set_channel_active_count(3)
+        value = CHANNEL_ACTIVE_COUNT._value.get()
+        assert value == 3
+
+    def test_channel_metrics_in_output(self):
+        """Channel metrics should appear in Prometheus output."""
+        # Record some channel metrics
+        record_channel_message("output_test_channel")
+        record_channel_error("output_test_channel", "test_error")
+        set_channel_status("output_test_channel", running=True)
+
+        metrics = get_metrics().decode("utf-8")
+
+        # Verify channel metrics are present
+        assert "klabautermann_channel_messages_total" in metrics
+        assert "klabautermann_channel_errors_total" in metrics
+        assert "klabautermann_channel_status" in metrics
+        assert "klabautermann_channel_healthy" in metrics
+        assert "klabautermann_channel_broadcasts_total" in metrics
+        assert "klabautermann_channel_active_count" in metrics


### PR DESCRIPTION
## Summary
- Add 8 Prometheus metrics for channel monitoring
- Wire metrics into ChannelManager for automatic tracking
- Add 13 new unit tests for channel metrics

## Metrics Added
- `klabautermann_channel_messages_total`: Messages processed per channel
- `klabautermann_channel_response_latency_ms`: Response latency histogram
- `klabautermann_channel_errors_total`: Errors by channel and error type
- `klabautermann_channel_status`: Channel running status (1/0)
- `klabautermann_channel_healthy`: Channel health status (1/0)
- `klabautermann_channel_broadcasts_total`: Broadcast message count
- `klabautermann_channel_broadcast_deliveries_total`: Delivery results
- `klabautermann_channel_active_count`: Number of active channels

## Test plan
- [x] All 40 metrics tests pass
- [x] All 56 channel manager tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)