### PR TITLE
feat(infra): Add Prometheus alerting rules (#275)

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,6 +1,6 @@
 # Klabautermann Monitoring Stack
 #
-# Prometheus + Grafana for metrics visualization
+# Prometheus + Grafana + Alertmanager for metrics and alerting
 #
 # Usage:
 #   docker-compose -f docker-compose.monitoring.yml up -d
@@ -8,6 +8,7 @@
 # Access:
 #   - Grafana: http://localhost:3000 (admin/admin)
 #   - Prometheus: http://localhost:9090
+#   - Alertmanager: http://localhost:9093
 #
 # The Klabautermann app exposes metrics at /metrics endpoint.
 # Configure KLABAUTERMANN_HOST to point to your app instance.
@@ -24,6 +25,7 @@ services:
       - "9090:9090"
     volumes:
       - ./infrastructure/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infrastructure/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -36,6 +38,30 @@ services:
       - monitoring-net
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ===========================================================================
+  # Alertmanager - Alert Handling
+  # ===========================================================================
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: klabautermann-alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./infrastructure/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--web.external-url=http://localhost:9093'
+    networks:
+      - monitoring-net
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9093/-/healthy"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -85,3 +111,5 @@ volumes:
     name: klabautermann-prometheus-data
   grafana_data:
     name: klabautermann-grafana-data
+  alertmanager_data:
+    name: klabautermann-alertmanager-data

--- a/infrastructure/alertmanager/alertmanager.yml
+++ b/infrastructure/alertmanager/alertmanager.yml
@@ -1,0 +1,100 @@
+# Alertmanager Configuration for Klabautermann
+#
+# Reference: specs/infrastructure/DEPLOYMENT.md
+#
+# This is a minimal configuration that groups alerts and routes them
+# to a default receiver. Customize receivers for your notification channels
+# (Slack, PagerDuty, email, etc.).
+#
+# Documentation: https://prometheus.io/docs/alerting/latest/configuration/
+
+# Global configuration
+global:
+  # How long to wait before sending a notification again if it has already been sent
+  resolve_timeout: 5m
+
+# The root route for all alerts
+route:
+  # The default receiver
+  receiver: 'default-receiver'
+
+  # How long to initially wait before sending a notification for a group
+  group_wait: 30s
+
+  # How long to wait before sending a notification about new alerts
+  # that are added to a group of alerts that have already been sent
+  group_interval: 5m
+
+  # How long to wait before re-sending a notification
+  repeat_interval: 4h
+
+  # Group alerts by these labels
+  group_by: ['alertname', 'severity']
+
+  # Child routes for specific alert handling
+  routes:
+    # Critical alerts get sent immediately
+    - match:
+        severity: critical
+      receiver: 'critical-receiver'
+      group_wait: 10s
+      repeat_interval: 1h
+
+    # Warning alerts use default timing
+    - match:
+        severity: warning
+      receiver: 'warning-receiver'
+
+    # Info alerts are batched more aggressively
+    - match:
+        severity: info
+      receiver: 'info-receiver'
+      group_wait: 5m
+      repeat_interval: 24h
+
+# Inhibition rules to prevent redundant notifications
+inhibit_rules:
+  # If a critical alert is firing, inhibit warning alerts for the same alertname
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname']
+
+# Receiver definitions
+receivers:
+  # Default receiver - logs to stdout (visible in docker logs)
+  - name: 'default-receiver'
+    # No notification config = silent (for development)
+
+  # Critical alerts receiver
+  # Configure with your notification service (Slack, PagerDuty, etc.)
+  - name: 'critical-receiver'
+    # Example Slack configuration (uncomment and configure):
+    # slack_configs:
+    #   - api_url: 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL'
+    #     channel: '#alerts-critical'
+    #     title: '{{ .CommonAnnotations.summary }}'
+    #     text: '{{ .CommonAnnotations.description }}'
+    #     send_resolved: true
+    #
+    # Example PagerDuty configuration:
+    # pagerduty_configs:
+    #   - service_key: 'YOUR_PAGERDUTY_SERVICE_KEY'
+    #     description: '{{ .CommonAnnotations.summary }}'
+
+  # Warning alerts receiver
+  - name: 'warning-receiver'
+    # Example email configuration:
+    # email_configs:
+    #   - to: 'alerts@example.com'
+    #     from: 'alertmanager@example.com'
+    #     smarthost: 'smtp.example.com:587'
+    #     auth_username: 'alertmanager'
+    #     auth_password: 'password'
+    #     send_resolved: true
+
+  # Info alerts receiver
+  - name: 'info-receiver'
+    # Info alerts typically don't need notification
+    # Configure if you want a digest of informational alerts

--- a/infrastructure/prometheus/alerts.yml
+++ b/infrastructure/prometheus/alerts.yml
@@ -1,0 +1,280 @@
+# Prometheus Alerting Rules for Klabautermann
+#
+# Reference: specs/infrastructure/DEPLOYMENT.md
+#
+# Alert severity levels:
+#   - critical: Immediate action required, service degraded
+#   - warning: Investigation needed, potential issue
+#   - info: Informational, no action required
+
+groups:
+  # ===========================================================================
+  # Agent Alerts
+  # ===========================================================================
+  - name: agent_alerts
+    rules:
+      - alert: AgentHighErrorRate
+        expr: |
+          (
+            sum(rate(klabautermann_agent_errors_total[5m])) by (agent_name)
+            /
+            sum(rate(klabautermann_agent_requests_total[5m])) by (agent_name)
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate for agent {{ $labels.agent_name }}"
+          description: "Agent {{ $labels.agent_name }} has error rate > 10% for 5 minutes. Current value: {{ $value | humanizePercentage }}"
+
+      - alert: AgentCriticalErrorRate
+        expr: |
+          (
+            sum(rate(klabautermann_agent_errors_total[5m])) by (agent_name)
+            /
+            sum(rate(klabautermann_agent_requests_total[5m])) by (agent_name)
+          ) > 0.25
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical error rate for agent {{ $labels.agent_name }}"
+          description: "Agent {{ $labels.agent_name }} has error rate > 25% for 2 minutes. Current value: {{ $value | humanizePercentage }}"
+
+      - alert: AgentHighLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_agent_request_latency_ms_bucket[5m])) > 5000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High latency for agent {{ $labels.agent_name }}"
+          description: "Agent {{ $labels.agent_name }} P95 latency > 5 seconds for 5 minutes. Current P95: {{ $value | humanizeDuration }}"
+
+      - alert: AgentCriticalLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_agent_request_latency_ms_bucket[5m])) > 10000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical latency for agent {{ $labels.agent_name }}"
+          description: "Agent {{ $labels.agent_name }} P95 latency > 10 seconds for 2 minutes. Current P95: {{ $value | humanizeDuration }}"
+
+      - alert: AgentStopped
+        expr: klabautermann_agent_running == 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Agent {{ $labels.agent_name }} is stopped"
+          description: "Agent {{ $labels.agent_name }} has been stopped for 1 minute."
+
+  # ===========================================================================
+  # API Alerts
+  # ===========================================================================
+  - name: api_alerts
+    rules:
+      - alert: APIHighErrorRate
+        expr: |
+          (
+            sum(rate(klabautermann_api_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(klabautermann_api_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API error rate (5xx responses)"
+          description: "API 5xx error rate > 5% for 5 minutes. Current value: {{ $value | humanizePercentage }}"
+
+      - alert: APICriticalErrorRate
+        expr: |
+          (
+            sum(rate(klabautermann_api_requests_total{status_code=~"5.."}[5m]))
+            /
+            sum(rate(klabautermann_api_requests_total[5m]))
+          ) > 0.15
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical API error rate (5xx responses)"
+          description: "API 5xx error rate > 15% for 2 minutes. Current value: {{ $value | humanizePercentage }}"
+
+      - alert: APIHighLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_api_request_latency_seconds_bucket[5m])) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API latency on {{ $labels.endpoint }}"
+          description: "API endpoint {{ $labels.endpoint }} P95 latency > 2 seconds for 5 minutes. Current P95: {{ $value | humanizeDuration }}"
+
+  # ===========================================================================
+  # Channel Alerts
+  # ===========================================================================
+  - name: channel_alerts
+    rules:
+      - alert: ChannelDown
+        expr: klabautermann_channel_status == 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Channel {{ $labels.channel_name }} is down"
+          description: "Channel {{ $labels.channel_name }} has been down for 1 minute."
+
+      - alert: ChannelUnhealthy
+        expr: klabautermann_channel_healthy == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Channel {{ $labels.channel_name }} is unhealthy"
+          description: "Channel {{ $labels.channel_name }} has been unhealthy for 5 minutes."
+
+      - alert: ChannelHighErrorRate
+        expr: |
+          (
+            sum(rate(klabautermann_channel_errors_total[5m])) by (channel_name)
+            /
+            sum(rate(klabautermann_channel_messages_total[5m])) by (channel_name)
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate for channel {{ $labels.channel_name }}"
+          description: "Channel {{ $labels.channel_name }} has error rate > 10% for 5 minutes. Current value: {{ $value | humanizePercentage }}"
+
+      - alert: ChannelHighLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_channel_response_latency_ms_bucket[5m])) > 3000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High latency for channel {{ $labels.channel_name }}"
+          description: "Channel {{ $labels.channel_name }} P95 latency > 3 seconds for 5 minutes."
+
+      - alert: AllChannelsDown
+        expr: klabautermann_channel_active_count == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "All channels are down"
+          description: "No active channels for 1 minute. The system cannot receive user messages."
+
+      - alert: BroadcastFailures
+        expr: |
+          (
+            sum(rate(klabautermann_channel_broadcast_deliveries_total{status="failure"}[5m]))
+            /
+            sum(rate(klabautermann_channel_broadcast_deliveries_total[5m]))
+          ) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High broadcast failure rate"
+          description: "Broadcast delivery failure rate > 20% for 5 minutes."
+
+  # ===========================================================================
+  # Graph/Memory Alerts
+  # ===========================================================================
+  - name: graph_alerts
+    rules:
+      - alert: GraphHighLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_graph_operation_latency_seconds_bucket[5m])) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High graph operation latency"
+          description: "Graph {{ $labels.operation_type }} operation P95 latency > 1 second for 5 minutes."
+
+      - alert: GraphCriticalLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_graph_operation_latency_seconds_bucket[5m])) > 5
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical graph operation latency"
+          description: "Graph {{ $labels.operation_type }} operation P95 latency > 5 seconds for 2 minutes."
+
+  # ===========================================================================
+  # LLM Alerts
+  # ===========================================================================
+  - name: llm_alerts
+    rules:
+      - alert: LLMHighLatency
+        expr: |
+          histogram_quantile(0.95, rate(klabautermann_llm_call_latency_seconds_bucket[5m])) > 30
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High LLM latency for {{ $labels.model }}"
+          description: "LLM model {{ $labels.model }} P95 latency > 30 seconds for 5 minutes."
+
+      - alert: LLMHighTokenUsage
+        expr: |
+          sum(rate(klabautermann_llm_tokens_total[1h])) by (model) > 100000
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "High token usage for {{ $labels.model }}"
+          description: "LLM model {{ $labels.model }} using > 100k tokens/hour. Consider optimizing prompts."
+
+  # ===========================================================================
+  # WebSocket Alerts
+  # ===========================================================================
+  - name: websocket_alerts
+    rules:
+      - alert: NoWebSocketConnections
+        expr: klabautermann_api_websocket_connections == 0
+        for: 10m
+        labels:
+          severity: info
+        annotations:
+          summary: "No WebSocket connections"
+          description: "No WebSocket connections for 10 minutes. Is the TUI client running?"
+
+      - alert: HighWebSocketConnections
+        expr: klabautermann_api_websocket_connections > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusually high WebSocket connections"
+          description: "{{ $value }} WebSocket connections for 5 minutes. Possible connection leak."
+
+  # ===========================================================================
+  # Prometheus Self-Monitoring
+  # ===========================================================================
+  - name: prometheus_alerts
+    rules:
+      - alert: PrometheusTargetDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus target {{ $labels.job }} is down"
+          description: "Target {{ $labels.instance }} in job {{ $labels.job }} has been down for 1 minute."
+
+      - alert: PrometheusConfigReloadFailed
+        expr: prometheus_config_last_reload_successful == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus config reload failed"
+          description: "Prometheus configuration reload has failed. Check for syntax errors."

--- a/infrastructure/prometheus/prometheus.yml
+++ b/infrastructure/prometheus/prometheus.yml
@@ -7,6 +7,17 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Alerting configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+# Load alerting rules
+rule_files:
+  - /etc/prometheus/alerts.yml
+
 scrape_configs:
   # Prometheus self-monitoring
   - job_name: 'prometheus'


### PR DESCRIPTION
## Summary
- Add 22 Prometheus alerting rules covering agents, API, channels, graph, LLM, and WebSockets
- Add Alertmanager service to monitoring stack
- Configure severity-based alert routing

## Alerts Added

| Category | Alert | Severity | Threshold |
|----------|-------|----------|-----------|
| Agent | HighErrorRate | warning | >10% for 5m |
| Agent | CriticalErrorRate | critical | >25% for 2m |
| Agent | HighLatency | warning | P95 >5s for 5m |
| API | HighErrorRate | warning | >5% 5xx for 5m |
| API | CriticalErrorRate | critical | >15% 5xx for 2m |
| Channel | Down | warning | status=0 for 1m |
| Channel | AllChannelsDown | critical | active=0 for 1m |
| Graph | CriticalLatency | critical | P95 >5s for 2m |
| LLM | HighLatency | warning | P95 >30s for 5m |

## Test plan
- [x] All YAML files validated
- [x] Pre-commit hooks pass

## Access
After deployment:
- Alertmanager: http://localhost:9093
- Prometheus Alerts: http://localhost:9090/alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)