### PR TITLE
feat(infra): Add resource limits to monitoring stack (#269)

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -41,6 +41,17 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    # Resource limits prevent runaway memory/CPU usage.
+    # If OOM occurs, Prometheus will restart (restart: unless-stopped).
+    # Consider increasing limits if scraping many targets or long retention.
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.25"
+          memory: 256M
 
   # ===========================================================================
   # Alertmanager - Alert Handling
@@ -65,6 +76,16 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    # Resource limits - Alertmanager is lightweight.
+    # If OOM occurs, it will restart (restart: unless-stopped).
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
 
   # ===========================================================================
   # Grafana - Metrics Visualization
@@ -94,6 +115,17 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+    # Resource limits - Grafana can use more memory with complex dashboards.
+    # If OOM occurs, it will restart (restart: unless-stopped).
+    # Increase limits if running many dashboards or heavy queries.
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          cpus: "0.25"
+          memory: 128M
 
 # ===========================================================================
 # Networks


### PR DESCRIPTION
## Summary
- Add CPU and memory limits to Prometheus, Alertmanager, and Grafana containers
- Document OOM handling behavior and tuning guidance
- Production docker-compose already has limits; this covers the monitoring stack

## Resource Allocations

| Service | CPU Limit | Memory Limit | Notes |
|---------|-----------|--------------|-------|
| Prometheus | 1.0 | 1G | Handles metrics storage and queries |
| Alertmanager | 0.5 | 256M | Lightweight alert routing |
| Grafana | 1.0 | 512M | Dashboard rendering |

## Test plan
- [ ] Verify docker-compose.monitoring.yml is valid YAML (pre-commit checked)
- [ ] Deploy monitoring stack and verify containers respect limits
- [ ] Confirm services restart correctly if OOM occurs

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)