### PR TITLE
feat(core): Add distributed tracing with W3C Trace Context (#273)

### DIFF
--- a/src/klabautermann/core/__init__.py
+++ b/src/klabautermann/core/__init__.py
@@ -7,6 +7,7 @@ Contains:
 - logger: Nautical logging system
 - exceptions: Custom exception types
 - workflow_inspector: Agent workflow inspection for debugging
+- tracing: Distributed tracing with W3C Trace Context support
 """
 
 from klabautermann.core.exceptions import (
@@ -15,6 +16,21 @@ from klabautermann.core.exceptions import (
     GraphConnectionError,
     KlabautermannError,
     ValidationError,
+)
+from klabautermann.core.tracing import (
+    Span,
+    SpanStatus,
+    TraceContext,
+    Tracer,
+    current_span_id,
+    current_trace_id,
+    generate_short_trace_id,
+    generate_span_id,
+    generate_trace_id,
+    get_tracer,
+    reset_tracer,
+    start_trace,
+    trace_span,
 )
 from klabautermann.core.workflow_inspector import (
     WorkflowEntry,
@@ -33,6 +49,21 @@ __all__ = [
     "GraphConnectionError",
     "KlabautermannError",
     "ValidationError",
+    # Tracing
+    "Span",
+    "SpanStatus",
+    "TraceContext",
+    "Tracer",
+    "current_span_id",
+    "current_trace_id",
+    "generate_short_trace_id",
+    "generate_span_id",
+    "generate_trace_id",
+    "get_tracer",
+    "reset_tracer",
+    "start_trace",
+    "trace_span",
+    # Workflow Inspector
     "WorkflowEntry",
     "WorkflowInspector",
     "WorkflowPhase",

--- a/src/klabautermann/core/tracing.py
+++ b/src/klabautermann/core/tracing.py
@@ -1,0 +1,478 @@
+"""
+Distributed tracing for Klabautermann.
+
+Provides trace context propagation for tracking requests across agents.
+Compatible with W3C Trace Context standard for interoperability.
+
+Features:
+- W3C Trace Context compatible trace IDs (128-bit) and span IDs (64-bit)
+- Context propagation via contextvars
+- Span tracking for nested operations
+- Export to stdout (development) or OpenTelemetry collector (production)
+
+Environment Variables:
+- TRACING_ENABLED: Enable distributed tracing (default: true)
+- TRACING_EXPORT: Export destination (none, stdout, otlp). Default: none
+- OTEL_EXPORTER_OTLP_ENDPOINT: OpenTelemetry collector endpoint
+- OTEL_SERVICE_NAME: Service name for traces (default: klabautermann)
+
+Reference: W3C Trace Context https://www.w3.org/TR/trace-context/
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+import secrets
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from klabautermann.core.logger import logger
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# =============================================================================
+# Context Variables
+# =============================================================================
+
+# Current trace context
+_trace_context: contextvars.ContextVar[TraceContext | None] = contextvars.ContextVar(
+    "trace_context", default=None
+)
+
+# Current span
+_current_span: contextvars.ContextVar[Span | None] = contextvars.ContextVar(
+    "current_span", default=None
+)
+
+
+# =============================================================================
+# Trace ID Generation (W3C Trace Context compatible)
+# =============================================================================
+
+
+def generate_trace_id() -> str:
+    """
+    Generate a W3C Trace Context compatible trace ID.
+
+    Format: 32 lowercase hex characters (128 bits)
+    Example: "4bf92f3577b34da6a3ce929d0e0e4736"
+    """
+    return secrets.token_hex(16)
+
+
+def generate_span_id() -> str:
+    """
+    Generate a W3C Trace Context compatible span ID.
+
+    Format: 16 lowercase hex characters (64 bits)
+    Example: "00f067aa0ba902b7"
+    """
+    return secrets.token_hex(8)
+
+
+def generate_short_trace_id() -> str:
+    """
+    Generate a short trace ID for display/logging.
+
+    Format: 8 lowercase hex characters (32 bits)
+    Example: "4bf92f35"
+
+    Note: Use full trace_id for actual tracing, this is just for display.
+    """
+    return secrets.token_hex(4)
+
+
+# =============================================================================
+# Span Status
+# =============================================================================
+
+
+class SpanStatus(Enum):
+    """Status of a span."""
+
+    UNSET = "unset"
+    OK = "ok"
+    ERROR = "error"
+
+
+# =============================================================================
+# Span
+# =============================================================================
+
+
+@dataclass
+class Span:
+    """
+    Represents a unit of work within a trace.
+
+    A span tracks a single operation with timing, status, and metadata.
+    Spans can be nested to represent operation hierarchy.
+    """
+
+    name: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+    start_time: float = field(default_factory=time.time)
+    end_time: float | None = None
+    status: SpanStatus = SpanStatus.UNSET
+    attributes: dict[str, Any] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def duration_ms(self) -> float | None:
+        """Duration in milliseconds, or None if not ended."""
+        if self.end_time is None:
+            return None
+        return (self.end_time - self.start_time) * 1000
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Set a span attribute."""
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
+        """Add an event to the span."""
+        self.events.append(
+            {
+                "name": name,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "attributes": attributes or {},
+            }
+        )
+
+    def end(self, status: SpanStatus = SpanStatus.OK) -> None:
+        """End the span."""
+        self.end_time = time.time()
+        if self.status == SpanStatus.UNSET:
+            self.status = status
+
+    def set_error(self, error: Exception) -> None:
+        """Record an error on the span."""
+        self.status = SpanStatus.ERROR
+        self.set_attribute("error.type", type(error).__name__)
+        self.set_attribute("error.message", str(error))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert span to dictionary for export."""
+        return {
+            "name": self.name,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "start_time": datetime.fromtimestamp(self.start_time, tz=UTC).isoformat(),
+            "end_time": (
+                datetime.fromtimestamp(self.end_time, tz=UTC).isoformat() if self.end_time else None
+            ),
+            "duration_ms": self.duration_ms,
+            "status": self.status.value,
+            "attributes": self.attributes,
+            "events": self.events,
+        }
+
+
+# =============================================================================
+# Trace Context
+# =============================================================================
+
+
+@dataclass
+class TraceContext:
+    """
+    W3C Trace Context for distributed tracing.
+
+    Contains the trace ID and optional parent span ID for propagation.
+    """
+
+    trace_id: str
+    parent_span_id: str | None = None
+
+    @classmethod
+    def new(cls) -> TraceContext:
+        """Create a new trace context with fresh trace ID."""
+        return cls(trace_id=generate_trace_id())
+
+    @classmethod
+    def from_traceparent(cls, traceparent: str) -> TraceContext | None:
+        """
+        Parse W3C traceparent header.
+
+        Format: version-trace_id-parent_id-trace_flags
+        Example: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        """
+        try:
+            parts = traceparent.split("-")
+            if len(parts) != 4:
+                return None
+
+            version, trace_id, parent_id, flags = parts
+
+            if version != "00":
+                return None  # Only version 00 supported
+
+            if len(trace_id) != 32 or len(parent_id) != 16:
+                return None
+
+            return cls(trace_id=trace_id, parent_span_id=parent_id)
+
+        except Exception:
+            return None
+
+    def to_traceparent(self, span_id: str) -> str:
+        """
+        Generate W3C traceparent header.
+
+        Args:
+            span_id: Current span ID to include.
+
+        Returns:
+            Traceparent header value.
+        """
+        return f"00-{self.trace_id}-{span_id}-01"
+
+
+# =============================================================================
+# Tracer
+# =============================================================================
+
+
+class Tracer:
+    """
+    Main tracer interface for creating and managing spans.
+
+    The tracer provides the API for starting spans, propagating context,
+    and exporting trace data.
+    """
+
+    def __init__(self, service_name: str | None = None) -> None:
+        """
+        Initialize the tracer.
+
+        Args:
+            service_name: Service name for traces. Defaults to OTEL_SERVICE_NAME
+                         or "klabautermann".
+        """
+        self.service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "klabautermann")
+        self.enabled = os.getenv("TRACING_ENABLED", "true").lower() in ("true", "1", "yes")
+        self.export_mode = os.getenv("TRACING_EXPORT", "none").lower()
+        self._spans: list[Span] = []  # Completed spans for export
+
+    def start_trace(self, name: str = "request") -> TraceContext:  # noqa: ARG002
+        """
+        Start a new trace.
+
+        Args:
+            name: Name for the root span.
+
+        Returns:
+            New trace context.
+        """
+        ctx = TraceContext.new()
+        _trace_context.set(ctx)
+        return ctx
+
+    def get_current_context(self) -> TraceContext | None:
+        """Get the current trace context."""
+        return _trace_context.get()
+
+    def get_current_span(self) -> Span | None:
+        """Get the current span."""
+        return _current_span.get()
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+    ) -> Iterator[Span]:
+        """
+        Create a span for tracking an operation.
+
+        Usage:
+            with tracer.span("database.query", {"db.system": "neo4j"}) as span:
+                result = await db.query(...)
+                span.set_attribute("db.rows", len(result))
+
+        Args:
+            name: Span name (e.g., "agent.process", "llm.call").
+            attributes: Initial span attributes.
+
+        Yields:
+            The span instance.
+        """
+        if not self.enabled:
+            # Return a dummy span when tracing is disabled
+            yield Span(
+                name=name,
+                trace_id="00000000000000000000000000000000",
+                span_id="0000000000000000",
+            )
+            return
+
+        # Get or create trace context
+        ctx = _trace_context.get()
+        if ctx is None:
+            ctx = TraceContext.new()
+            _trace_context.set(ctx)
+
+        # Get parent span
+        parent = _current_span.get()
+        parent_span_id = parent.span_id if parent else ctx.parent_span_id
+
+        # Create new span
+        span = Span(
+            name=name,
+            trace_id=ctx.trace_id,
+            span_id=generate_span_id(),
+            parent_span_id=parent_span_id,
+            attributes=attributes or {},
+        )
+
+        # Set as current span
+        token = _current_span.set(span)
+
+        try:
+            yield span
+            if span.status == SpanStatus.UNSET:
+                span.status = SpanStatus.OK
+
+        except Exception as e:
+            span.set_error(e)
+            raise
+
+        finally:
+            span.end()
+            _current_span.reset(token)
+
+            # Export span
+            self._export_span(span)
+
+    def _export_span(self, span: Span) -> None:
+        """Export a completed span."""
+        if self.export_mode == "none":
+            return
+
+        if self.export_mode == "stdout":
+            self._export_stdout(span)
+        elif self.export_mode == "otlp":
+            self._export_otlp(span)
+
+    def _export_stdout(self, span: Span) -> None:
+        """Export span to stdout (for development)."""
+        import json
+
+        data = span.to_dict()
+        data["service"] = self.service_name
+        logger.debug(
+            f"[TRACE] {span.name}",
+            extra={
+                "trace_id": span.trace_id,
+                "span_id": span.span_id,
+                "duration_ms": span.duration_ms,
+            },
+        )
+        if os.getenv("TRACE_VERBOSE", "").lower() in ("true", "1", "yes"):
+            print(f"SPAN: {json.dumps(data, indent=2)}")
+
+    def _export_otlp(self, span: Span) -> None:
+        """Export span to OpenTelemetry collector."""
+        # For now, just log - full OTLP integration would require
+        # opentelemetry-sdk dependency
+        logger.debug(
+            f"[TRACE-OTLP] {span.name}",
+            extra={
+                "trace_id": span.trace_id,
+                "span_id": span.span_id,
+                "duration_ms": span.duration_ms,
+            },
+        )
+
+
+# =============================================================================
+# Global Tracer Instance
+# =============================================================================
+
+_tracer: Tracer | None = None
+
+
+def get_tracer() -> Tracer:
+    """Get the global tracer instance."""
+    global _tracer
+    if _tracer is None:
+        _tracer = Tracer()
+    return _tracer
+
+
+def reset_tracer() -> None:
+    """Reset the global tracer (for testing)."""
+    global _tracer
+    _tracer = None
+    _trace_context.set(None)
+    _current_span.set(None)
+
+
+# =============================================================================
+# Convenience Functions
+# =============================================================================
+
+
+def start_trace(name: str = "request") -> TraceContext:
+    """Start a new trace and return the context."""
+    return get_tracer().start_trace(name)
+
+
+def current_trace_id() -> str | None:
+    """Get the current trace ID, or None if no trace active."""
+    ctx = _trace_context.get()
+    return ctx.trace_id if ctx else None
+
+
+def current_span_id() -> str | None:
+    """Get the current span ID, or None if no span active."""
+    span = _current_span.get()
+    return span.span_id if span else None
+
+
+@contextmanager
+def trace_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Iterator[Span]:
+    """
+    Create a traced span (convenience wrapper).
+
+    Usage:
+        with trace_span("orchestrator.process") as span:
+            span.set_attribute("intent", "search")
+            result = await process()
+    """
+    with get_tracer().span(name, attributes) as span:
+        yield span
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+__all__ = [
+    "Span",
+    "SpanStatus",
+    "TraceContext",
+    "Tracer",
+    "current_span_id",
+    "current_trace_id",
+    "generate_short_trace_id",
+    "generate_span_id",
+    "generate_trace_id",
+    "get_tracer",
+    "reset_tracer",
+    "start_trace",
+    "trace_span",
+]

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,377 @@
+"""Unit tests for distributed tracing."""
+
+from __future__ import annotations
+
+import pytest
+
+from klabautermann.core.tracing import (
+    Span,
+    SpanStatus,
+    TraceContext,
+    Tracer,
+    current_span_id,
+    current_trace_id,
+    generate_short_trace_id,
+    generate_span_id,
+    generate_trace_id,
+    get_tracer,
+    reset_tracer,
+    start_trace,
+    trace_span,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing() -> None:
+    """Reset tracing state before each test."""
+    reset_tracer()
+
+
+@pytest.fixture
+def tracer() -> Tracer:
+    """Create a tracer instance."""
+    return Tracer(service_name="test-service")
+
+
+# =============================================================================
+# Trace ID Generation
+# =============================================================================
+
+
+class TestTraceIdGeneration:
+    """Test trace ID generation functions."""
+
+    def test_generate_trace_id_format(self) -> None:
+        """Test trace ID is 32 hex characters."""
+        trace_id = generate_trace_id()
+
+        assert len(trace_id) == 32
+        assert all(c in "0123456789abcdef" for c in trace_id)
+
+    def test_generate_trace_id_uniqueness(self) -> None:
+        """Test trace IDs are unique."""
+        ids = {generate_trace_id() for _ in range(100)}
+        assert len(ids) == 100  # All unique
+
+    def test_generate_span_id_format(self) -> None:
+        """Test span ID is 16 hex characters."""
+        span_id = generate_span_id()
+
+        assert len(span_id) == 16
+        assert all(c in "0123456789abcdef" for c in span_id)
+
+    def test_generate_span_id_uniqueness(self) -> None:
+        """Test span IDs are unique."""
+        ids = {generate_span_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_generate_short_trace_id_format(self) -> None:
+        """Test short trace ID is 8 hex characters."""
+        short_id = generate_short_trace_id()
+
+        assert len(short_id) == 8
+        assert all(c in "0123456789abcdef" for c in short_id)
+
+
+# =============================================================================
+# TraceContext
+# =============================================================================
+
+
+class TestTraceContext:
+    """Test TraceContext class."""
+
+    def test_new_creates_trace_id(self) -> None:
+        """Test TraceContext.new() creates a trace ID."""
+        ctx = TraceContext.new()
+
+        assert len(ctx.trace_id) == 32
+        assert ctx.parent_span_id is None
+
+    def test_from_traceparent_valid(self) -> None:
+        """Test parsing valid traceparent header."""
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+        ctx = TraceContext.from_traceparent(traceparent)
+
+        assert ctx is not None
+        assert ctx.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+        assert ctx.parent_span_id == "00f067aa0ba902b7"
+
+    def test_from_traceparent_invalid_version(self) -> None:
+        """Test parsing traceparent with unsupported version."""
+        traceparent = "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+        ctx = TraceContext.from_traceparent(traceparent)
+
+        assert ctx is None
+
+    def test_from_traceparent_invalid_format(self) -> None:
+        """Test parsing invalid traceparent format."""
+        ctx = TraceContext.from_traceparent("invalid")
+        assert ctx is None
+
+        ctx = TraceContext.from_traceparent("00-abc-def-01")
+        assert ctx is None
+
+    def test_to_traceparent(self) -> None:
+        """Test generating traceparent header."""
+        ctx = TraceContext(trace_id="4bf92f3577b34da6a3ce929d0e0e4736")
+        span_id = "00f067aa0ba902b7"
+
+        traceparent = ctx.to_traceparent(span_id)
+
+        assert traceparent == "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+# =============================================================================
+# Span
+# =============================================================================
+
+
+class TestSpan:
+    """Test Span class."""
+
+    def test_span_creation(self) -> None:
+        """Test creating a span."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        assert span.name == "test.operation"
+        assert span.status == SpanStatus.UNSET
+        assert span.end_time is None
+        assert span.duration_ms is None
+
+    def test_span_end(self) -> None:
+        """Test ending a span."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        span.end()
+
+        assert span.end_time is not None
+        assert span.status == SpanStatus.OK
+        assert span.duration_ms is not None
+        assert span.duration_ms >= 0
+
+    def test_span_end_with_status(self) -> None:
+        """Test ending a span with specific status."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        span.end(SpanStatus.ERROR)
+
+        assert span.status == SpanStatus.ERROR
+
+    def test_span_set_attribute(self) -> None:
+        """Test setting span attributes."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        span.set_attribute("key1", "value1")
+        span.set_attribute("key2", 42)
+
+        assert span.attributes["key1"] == "value1"
+        assert span.attributes["key2"] == 42
+
+    def test_span_add_event(self) -> None:
+        """Test adding events to a span."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        span.add_event("cache.hit", {"cache_key": "user:123"})
+
+        assert len(span.events) == 1
+        assert span.events[0]["name"] == "cache.hit"
+        assert span.events[0]["attributes"]["cache_key"] == "user:123"
+        assert "timestamp" in span.events[0]
+
+    def test_span_set_error(self) -> None:
+        """Test recording an error on a span."""
+        span = Span(
+            name="test.operation",
+            trace_id=generate_trace_id(),
+            span_id=generate_span_id(),
+        )
+
+        span.set_error(ValueError("Test error"))
+
+        assert span.status == SpanStatus.ERROR
+        assert span.attributes["error.type"] == "ValueError"
+        assert span.attributes["error.message"] == "Test error"
+
+    def test_span_to_dict(self) -> None:
+        """Test converting span to dictionary."""
+        span = Span(
+            name="test.operation",
+            trace_id="abc123",
+            span_id="def456",
+            parent_span_id="parent789",
+        )
+        span.set_attribute("key", "value")
+        span.end()
+
+        data = span.to_dict()
+
+        assert data["name"] == "test.operation"
+        assert data["trace_id"] == "abc123"
+        assert data["span_id"] == "def456"
+        assert data["parent_span_id"] == "parent789"
+        assert data["status"] == "ok"
+        assert data["attributes"]["key"] == "value"
+        assert data["duration_ms"] is not None
+
+
+# =============================================================================
+# Tracer
+# =============================================================================
+
+
+class TestTracer:
+    """Test Tracer class."""
+
+    def test_tracer_service_name(self, tracer: Tracer) -> None:
+        """Test tracer has service name."""
+        assert tracer.service_name == "test-service"
+
+    def test_tracer_enabled_by_default(self, tracer: Tracer) -> None:
+        """Test tracing is enabled by default."""
+        assert tracer.enabled is True
+
+    def test_tracer_start_trace(self, tracer: Tracer) -> None:
+        """Test starting a new trace."""
+        ctx = tracer.start_trace()
+
+        assert ctx is not None
+        assert len(ctx.trace_id) == 32
+        assert tracer.get_current_context() == ctx
+
+    def test_tracer_span_context_manager(self, tracer: Tracer) -> None:
+        """Test span as context manager."""
+        tracer.start_trace()
+
+        with tracer.span("test.operation") as span:
+            assert span.name == "test.operation"
+            assert tracer.get_current_span() == span
+            span.set_attribute("key", "value")
+
+        # Span should be ended after context manager
+        assert span.end_time is not None
+        assert span.status == SpanStatus.OK
+
+    def test_tracer_span_error_handling(self, tracer: Tracer) -> None:
+        """Test span handles exceptions."""
+        tracer.start_trace()
+
+        with pytest.raises(ValueError), tracer.span("failing.operation") as span:
+            raise ValueError("Test error")
+
+        assert span.status == SpanStatus.ERROR
+        assert span.attributes["error.type"] == "ValueError"
+
+    def test_tracer_nested_spans(self, tracer: Tracer) -> None:
+        """Test nested spans have correct parent relationships."""
+        tracer.start_trace()
+
+        with (
+            tracer.span("parent.operation") as parent_span,
+            tracer.span("child.operation") as child_span,
+        ):
+            assert child_span.parent_span_id == parent_span.span_id
+
+    def test_tracer_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test tracing when disabled."""
+        monkeypatch.setenv("TRACING_ENABLED", "false")
+        tracer = Tracer()
+
+        assert tracer.enabled is False
+
+        with tracer.span("test.operation") as span:
+            # Should get a dummy span
+            assert span.trace_id == "00000000000000000000000000000000"
+
+
+# =============================================================================
+# Convenience Functions
+# =============================================================================
+
+
+class TestConvenienceFunctions:
+    """Test convenience functions."""
+
+    def test_start_trace_function(self) -> None:
+        """Test start_trace convenience function."""
+        ctx = start_trace()
+
+        assert ctx is not None
+        assert len(ctx.trace_id) == 32
+
+    def test_current_trace_id_none_when_no_trace(self) -> None:
+        """Test current_trace_id returns None when no trace."""
+        assert current_trace_id() is None
+
+    def test_current_trace_id_returns_id(self) -> None:
+        """Test current_trace_id returns trace ID."""
+        ctx = start_trace()
+
+        assert current_trace_id() == ctx.trace_id
+
+    def test_current_span_id_none_when_no_span(self) -> None:
+        """Test current_span_id returns None when no span."""
+        start_trace()
+
+        assert current_span_id() is None
+
+    def test_current_span_id_returns_id(self) -> None:
+        """Test current_span_id returns span ID."""
+        start_trace()
+
+        with trace_span("test.operation") as span:
+            assert current_span_id() == span.span_id
+
+    def test_trace_span_function(self) -> None:
+        """Test trace_span convenience function."""
+        start_trace()
+
+        with trace_span("test.operation", {"key": "value"}) as span:
+            assert span.name == "test.operation"
+            assert span.attributes["key"] == "value"
+
+    def test_get_tracer_singleton(self) -> None:
+        """Test get_tracer returns singleton."""
+        tracer1 = get_tracer()
+        tracer2 = get_tracer()
+
+        assert tracer1 is tracer2
+
+    def test_reset_tracer(self) -> None:
+        """Test reset_tracer clears state."""
+        start_trace()
+        assert current_trace_id() is not None
+
+        reset_tracer()
+
+        assert current_trace_id() is None
+        # New tracer instance
+        tracer = get_tracer()
+        assert tracer.get_current_context() is None


### PR DESCRIPTION
## Summary
- Implement distributed tracing for tracking requests across agents
- W3C Trace Context compatible trace IDs and span IDs
- Context propagation via contextvars
- Span tracking with timing, attributes, events, and error recording

## Key Features

| Feature | Description |
|---------|-------------|
| Trace IDs | 128-bit W3C compatible |
| Span IDs | 64-bit W3C compatible |
| Context Propagation | Via Python contextvars |
| Nested Spans | Parent-child relationships |
| Export | stdout (dev) or OTLP placeholder |

## Configuration

Environment variables:
- `TRACING_ENABLED` (default: true)
- `TRACING_EXPORT` (none, stdout, otlp)
- `OTEL_SERVICE_NAME` (default: klabautermann)
- `TRACE_VERBOSE` (print full span JSON)

## Test plan
- [x] Trace ID generation (5 tests)
- [x] TraceContext parsing/generation (5 tests)
- [x] Span operations (7 tests)
- [x] Tracer functionality (7 tests)
- [x] Convenience functions (8 tests)
- [x] 32 tests passing

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)