### PR TITLE
feat(memory): Add JSON-based backup and restore for knowledge graph (#203, #204)

### DIFF
--- a/src/klabautermann/memory/__init__.py
+++ b/src/klabautermann/memory/__init__.py
@@ -18,6 +18,17 @@ Contains:
 - weight_decay: Relationship weight decay for graph maintenance
 """
 
+from klabautermann.memory.backup import (
+    BackupMetadata,
+    BackupSnapshot,
+    RestoreResult,
+    clear_database,
+    create_backup,
+    load_backup_from_file,
+    restore_backup,
+    save_backup_to_file,
+    validate_backup,
+)
 from klabautermann.memory.context_statistics import (
     ContextWindowMetrics,
     GlobalContextMetrics,
@@ -113,6 +124,16 @@ from klabautermann.memory.zoom_search import (
 
 
 __all__ = [
+    # Backup/Restore
+    "BackupMetadata",
+    "BackupSnapshot",
+    "RestoreResult",
+    "clear_database",
+    "create_backup",
+    "load_backup_from_file",
+    "restore_backup",
+    "save_backup_to_file",
+    "validate_backup",
     # Weight Decay
     "DEFAULT_ACCESS_BOOST",
     "DEFAULT_HALF_LIFE_SECONDS",

--- a/src/klabautermann/memory/backup.py
+++ b/src/klabautermann/memory/backup.py
@@ -1,0 +1,601 @@
+"""
+Graph backup and restore functionality for Klabautermann.
+
+Provides JSON-based export/import of the Neo4j knowledge graph for
+backup, migration, and disaster recovery purposes.
+
+Features:
+- Export all nodes and relationships to JSON
+- Include all properties with timestamp metadata
+- Validate consistency after restore
+- Optionally clear existing data before restore
+
+Reference: specs/architecture/MEMORY.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from klabautermann.core.logger import logger
+from klabautermann.core.ontology import NodeLabel, RelationType
+
+
+if TYPE_CHECKING:
+    from klabautermann.memory.neo4j_client import Neo4jClient
+
+
+# =============================================================================
+# Data Models
+# =============================================================================
+
+
+@dataclass
+class BackupMetadata:
+    """Metadata about a backup snapshot."""
+
+    created_at: str
+    version: str = "1.0"
+    node_count: int = 0
+    relationship_count: int = 0
+    node_labels: list[str] = field(default_factory=list)
+    relationship_types: list[str] = field(default_factory=list)
+    source_database: str = "neo4j"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "created_at": self.created_at,
+            "version": self.version,
+            "node_count": self.node_count,
+            "relationship_count": self.relationship_count,
+            "node_labels": self.node_labels,
+            "relationship_types": self.relationship_types,
+            "source_database": self.source_database,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BackupMetadata:
+        """Create from dictionary."""
+        return cls(
+            created_at=data["created_at"],
+            version=data.get("version", "1.0"),
+            node_count=data.get("node_count", 0),
+            relationship_count=data.get("relationship_count", 0),
+            node_labels=data.get("node_labels", []),
+            relationship_types=data.get("relationship_types", []),
+            source_database=data.get("source_database", "neo4j"),
+        )
+
+
+@dataclass
+class BackupSnapshot:
+    """A complete snapshot of the graph database."""
+
+    metadata: BackupMetadata
+    nodes: list[dict[str, Any]]
+    relationships: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON export."""
+        return {
+            "metadata": self.metadata.to_dict(),
+            "nodes": self.nodes,
+            "relationships": self.relationships,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BackupSnapshot:
+        """Create from dictionary."""
+        return cls(
+            metadata=BackupMetadata.from_dict(data["metadata"]),
+            nodes=data.get("nodes", []),
+            relationships=data.get("relationships", []),
+        )
+
+
+@dataclass
+class RestoreResult:
+    """Result of a restore operation."""
+
+    success: bool
+    nodes_restored: int = 0
+    relationships_restored: int = 0
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+# =============================================================================
+# Backup Functions
+# =============================================================================
+
+
+async def create_backup(
+    client: Neo4jClient,
+    trace_id: str | None = None,
+) -> BackupSnapshot:
+    """
+    Create a backup snapshot of the entire graph database.
+
+    Exports all nodes and relationships with their properties to a
+    BackupSnapshot object that can be serialized to JSON.
+
+    Args:
+        client: Connected Neo4j client.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        BackupSnapshot containing all graph data.
+    """
+    logger.info(
+        "[CHART] Starting graph backup...",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Export all nodes with labels and properties
+    node_query = """
+    MATCH (n)
+    RETURN labels(n) as labels, properties(n) as props, elementId(n) as id
+    """
+    nodes_result = await client.execute_query(node_query, trace_id=trace_id, timeout_ms=120000)
+
+    nodes = []
+    node_labels_set: set[str] = set()
+
+    for record in nodes_result:
+        labels = record["labels"]
+        props = record["props"]
+        element_id = record["id"]
+
+        node_labels_set.update(labels)
+        nodes.append(
+            {
+                "element_id": element_id,
+                "labels": labels,
+                "properties": props,
+            }
+        )
+
+    logger.debug(
+        f"[WHISPER] Exported {len(nodes)} nodes",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Export all relationships with types and properties
+    rel_query = """
+    MATCH (a)-[r]->(b)
+    RETURN type(r) as type, properties(r) as props,
+           elementId(a) as from_id, elementId(b) as to_id,
+           labels(a) as from_labels, labels(b) as to_labels,
+           properties(a).uuid as from_uuid, properties(b).uuid as to_uuid
+    """
+    rels_result = await client.execute_query(rel_query, trace_id=trace_id, timeout_ms=120000)
+
+    relationships = []
+    rel_types_set: set[str] = set()
+
+    for record in rels_result:
+        rel_type = record["type"]
+        rel_types_set.add(rel_type)
+
+        relationships.append(
+            {
+                "type": rel_type,
+                "properties": record["props"],
+                "from_element_id": record["from_id"],
+                "to_element_id": record["to_id"],
+                "from_labels": record["from_labels"],
+                "to_labels": record["to_labels"],
+                "from_uuid": record["from_uuid"],
+                "to_uuid": record["to_uuid"],
+            }
+        )
+
+    logger.debug(
+        f"[WHISPER] Exported {len(relationships)} relationships",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Create metadata
+    metadata = BackupMetadata(
+        created_at=datetime.now(UTC).isoformat(),
+        node_count=len(nodes),
+        relationship_count=len(relationships),
+        node_labels=sorted(node_labels_set),
+        relationship_types=sorted(rel_types_set),
+    )
+
+    logger.info(
+        f"[BEACON] Backup complete: {metadata.node_count} nodes, "
+        f"{metadata.relationship_count} relationships",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    return BackupSnapshot(
+        metadata=metadata,
+        nodes=nodes,
+        relationships=relationships,
+    )
+
+
+async def save_backup_to_file(
+    snapshot: BackupSnapshot,
+    filepath: Path | str,
+    trace_id: str | None = None,
+) -> None:
+    """
+    Save a backup snapshot to a JSON file.
+
+    Args:
+        snapshot: Backup snapshot to save.
+        filepath: Path to the output JSON file.
+        trace_id: Optional trace ID for logging.
+    """
+    filepath = Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    with filepath.open("w", encoding="utf-8") as f:
+        json.dump(snapshot.to_dict(), f, indent=2, default=str)
+
+    file_size = filepath.stat().st_size
+    logger.info(
+        f"[BEACON] Backup saved to {filepath} ({file_size / 1024:.1f} KB)",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+
+async def load_backup_from_file(
+    filepath: Path | str,
+    trace_id: str | None = None,
+) -> BackupSnapshot:
+    """
+    Load a backup snapshot from a JSON file.
+
+    Args:
+        filepath: Path to the backup JSON file.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        BackupSnapshot loaded from the file.
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist.
+        json.JSONDecodeError: If the file isn't valid JSON.
+    """
+    filepath = Path(filepath)
+
+    if not filepath.exists():
+        raise FileNotFoundError(f"Backup file not found: {filepath}")
+
+    with filepath.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    snapshot = BackupSnapshot.from_dict(data)
+
+    logger.info(
+        f"[CHART] Loaded backup from {filepath}: "
+        f"{snapshot.metadata.node_count} nodes, "
+        f"{snapshot.metadata.relationship_count} relationships",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    return snapshot
+
+
+# =============================================================================
+# Restore Functions
+# =============================================================================
+
+
+async def clear_database(
+    client: Neo4jClient,
+    trace_id: str | None = None,
+) -> int:
+    """
+    Clear all data from the database.
+
+    WARNING: This permanently deletes all nodes and relationships!
+
+    Args:
+        client: Connected Neo4j client.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        Number of nodes deleted.
+    """
+    logger.warning(
+        "[STORM] Clearing database - all data will be deleted!",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Delete in batches to avoid memory issues
+    total_deleted = 0
+    batch_size = 1000
+
+    while True:
+        # Delete batch of nodes (relationships deleted automatically)
+        delete_query = """
+        MATCH (n)
+        WITH n LIMIT $batch_size
+        DETACH DELETE n
+        RETURN count(*) as deleted
+        """
+        result = await client.execute_query(
+            delete_query,
+            {"batch_size": batch_size},
+            trace_id=trace_id,
+            timeout_ms=60000,
+        )
+
+        deleted = result[0]["deleted"] if result else 0
+        total_deleted += deleted
+
+        if deleted < batch_size:
+            break
+
+    logger.info(
+        f"[BEACON] Database cleared: {total_deleted} nodes deleted",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    return total_deleted
+
+
+async def restore_backup(
+    client: Neo4jClient,
+    snapshot: BackupSnapshot,
+    clear_existing: bool = False,
+    trace_id: str | None = None,
+) -> RestoreResult:
+    """
+    Restore a backup snapshot to the database.
+
+    Args:
+        client: Connected Neo4j client.
+        snapshot: Backup snapshot to restore.
+        clear_existing: If True, clear all existing data first.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        RestoreResult with restore statistics.
+    """
+    logger.info(
+        f"[CHART] Starting restore: {snapshot.metadata.node_count} nodes, "
+        f"{snapshot.metadata.relationship_count} relationships",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Clear existing data if requested
+    if clear_existing:
+        await clear_database(client, trace_id)
+
+    # Map old element IDs to new UUIDs for relationship restoration
+    id_mapping: dict[str, str] = {}
+
+    # Restore nodes
+    nodes_restored = 0
+    for node in snapshot.nodes:
+        labels = node["labels"]
+        props = node["properties"]
+        old_id = node["element_id"]
+
+        # Validate labels exist in our ontology
+        valid_labels = []
+        for label in labels:
+            try:
+                NodeLabel(label)
+                valid_labels.append(label)
+            except ValueError:
+                # Allow labels not in enum (for Graphiti-managed nodes)
+                valid_labels.append(label)
+
+        if not valid_labels:
+            warnings.append(f"Node with no valid labels: {old_id}")
+            continue
+
+        # Create node with original properties
+        label_str = ":".join(valid_labels)
+        create_query = (
+            f"CREATE (n:{label_str} $props) RETURN n.uuid as uuid, elementId(n) as new_id"
+        )
+
+        try:
+            result = await client.execute_query(
+                create_query,
+                {"props": props},
+                trace_id=trace_id,
+            )
+
+            if result:
+                # Map old ID to new UUID for relationship creation
+                new_uuid = result[0].get("uuid") or props.get("uuid")
+                if new_uuid:
+                    id_mapping[old_id] = new_uuid
+                nodes_restored += 1
+
+        except Exception as e:
+            errors.append(f"Failed to restore node {old_id}: {e}")
+
+    logger.debug(
+        f"[WHISPER] Restored {nodes_restored}/{len(snapshot.nodes)} nodes",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Restore relationships
+    relationships_restored = 0
+    for rel in snapshot.relationships:
+        rel_type = rel["type"]
+        props = rel["properties"]
+        from_uuid = rel.get("from_uuid")
+        to_uuid = rel.get("to_uuid")
+        from_labels = rel.get("from_labels", [])
+        to_labels = rel.get("to_labels", [])
+
+        # Skip if we don't have UUIDs
+        if not from_uuid or not to_uuid:
+            warnings.append(f"Skipping relationship with missing UUIDs: {rel_type}")
+            continue
+
+        # Validate relationship type (allow types not in enum for Graphiti-managed)
+        with contextlib.suppress(ValueError):
+            RelationType(rel_type)
+
+        # Build label matches
+        from_label = from_labels[0] if from_labels else ""
+        to_label = to_labels[0] if to_labels else ""
+
+        # Create relationship using UUIDs
+        if from_label and to_label:
+            rel_query = f"""
+            MATCH (a:{from_label} {{uuid: $from_uuid}})
+            MATCH (b:{to_label} {{uuid: $to_uuid}})
+            CREATE (a)-[r:{rel_type} $props]->(b)
+            RETURN r
+            """
+        else:
+            rel_query = f"""
+            MATCH (a {{uuid: $from_uuid}})
+            MATCH (b {{uuid: $to_uuid}})
+            CREATE (a)-[r:{rel_type} $props]->(b)
+            RETURN r
+            """
+
+        try:
+            result = await client.execute_query(
+                rel_query,
+                {"from_uuid": from_uuid, "to_uuid": to_uuid, "props": props or {}},
+                trace_id=trace_id,
+            )
+
+            if result:
+                relationships_restored += 1
+
+        except Exception as e:
+            errors.append(f"Failed to restore relationship {rel_type}: {e}")
+
+    logger.debug(
+        f"[WHISPER] Restored {relationships_restored}/{len(snapshot.relationships)} relationships",
+        extra={"trace_id": trace_id, "agent_name": "backup"},
+    )
+
+    # Determine success
+    success = len(errors) == 0
+
+    if success:
+        logger.info(
+            f"[BEACON] Restore complete: {nodes_restored} nodes, "
+            f"{relationships_restored} relationships",
+            extra={"trace_id": trace_id, "agent_name": "backup"},
+        )
+    else:
+        logger.error(
+            f"[STORM] Restore completed with {len(errors)} errors",
+            extra={"trace_id": trace_id, "agent_name": "backup"},
+        )
+
+    return RestoreResult(
+        success=success,
+        nodes_restored=nodes_restored,
+        relationships_restored=relationships_restored,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+
+async def validate_backup(
+    snapshot: BackupSnapshot,
+    trace_id: str | None = None,
+) -> list[str]:
+    """
+    Validate a backup snapshot for consistency.
+
+    Checks:
+    - Metadata matches actual counts
+    - All relationships reference valid nodes
+    - No duplicate UUIDs within same label
+
+    Args:
+        snapshot: Backup snapshot to validate.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        List of validation errors (empty if valid).
+    """
+    errors: list[str] = []
+
+    # Check metadata counts
+    if snapshot.metadata.node_count != len(snapshot.nodes):
+        errors.append(
+            f"Node count mismatch: metadata says {snapshot.metadata.node_count}, "
+            f"actual is {len(snapshot.nodes)}"
+        )
+
+    if snapshot.metadata.relationship_count != len(snapshot.relationships):
+        errors.append(
+            f"Relationship count mismatch: metadata says {snapshot.metadata.relationship_count}, "
+            f"actual is {len(snapshot.relationships)}"
+        )
+
+    # Build set of node element IDs
+    node_ids = {node["element_id"] for node in snapshot.nodes}
+
+    # Check relationships reference valid nodes
+    for rel in snapshot.relationships:
+        from_id = rel.get("from_element_id")
+        to_id = rel.get("to_element_id")
+
+        if from_id and from_id not in node_ids:
+            errors.append(f"Relationship references non-existent from node: {from_id}")
+
+        if to_id and to_id not in node_ids:
+            errors.append(f"Relationship references non-existent to node: {to_id}")
+
+    # Check for duplicate UUIDs within same label
+    uuid_by_label: dict[str, set[str]] = {}
+    for node in snapshot.nodes:
+        props = node.get("properties", {})
+        uuid = props.get("uuid")
+        labels = node.get("labels", [])
+
+        if uuid:
+            for label in labels:
+                if label not in uuid_by_label:
+                    uuid_by_label[label] = set()
+
+                if uuid in uuid_by_label[label]:
+                    errors.append(f"Duplicate UUID in {label}: {uuid}")
+                else:
+                    uuid_by_label[label].add(uuid)
+
+    return errors
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+
+__all__ = [
+    "BackupMetadata",
+    "BackupSnapshot",
+    "RestoreResult",
+    "clear_database",
+    "create_backup",
+    "load_backup_from_file",
+    "restore_backup",
+    "save_backup_to_file",
+    "validate_backup",
+]

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,0 +1,558 @@
+"""Unit tests for backup and restore functionality."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from klabautermann.memory.backup import (
+    BackupMetadata,
+    BackupSnapshot,
+    RestoreResult,
+    clear_database,
+    create_backup,
+    load_backup_from_file,
+    restore_backup,
+    save_backup_to_file,
+    validate_backup,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_nodes() -> list[dict]:
+    """Sample nodes for testing."""
+    return [
+        {
+            "element_id": "4:abc:0",
+            "labels": ["Person"],
+            "properties": {
+                "uuid": "person-1",
+                "name": "John Doe",
+                "email": "john@example.com",
+            },
+        },
+        {
+            "element_id": "4:abc:1",
+            "labels": ["Organization"],
+            "properties": {
+                "uuid": "org-1",
+                "name": "Acme Corp",
+                "industry": "Technology",
+            },
+        },
+        {
+            "element_id": "4:abc:2",
+            "labels": ["Person"],
+            "properties": {
+                "uuid": "person-2",
+                "name": "Jane Smith",
+                "email": "jane@example.com",
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def sample_relationships() -> list[dict]:
+    """Sample relationships for testing."""
+    return [
+        {
+            "type": "WORKS_AT",
+            "properties": {"title": "Engineer"},
+            "from_element_id": "4:abc:0",
+            "to_element_id": "4:abc:1",
+            "from_labels": ["Person"],
+            "to_labels": ["Organization"],
+            "from_uuid": "person-1",
+            "to_uuid": "org-1",
+        },
+        {
+            "type": "KNOWS",
+            "properties": {},
+            "from_element_id": "4:abc:0",
+            "to_element_id": "4:abc:2",
+            "from_labels": ["Person"],
+            "to_labels": ["Person"],
+            "from_uuid": "person-1",
+            "to_uuid": "person-2",
+        },
+    ]
+
+
+@pytest.fixture
+def sample_metadata() -> BackupMetadata:
+    """Sample metadata for testing."""
+    return BackupMetadata(
+        created_at=datetime.now(UTC).isoformat(),
+        version="1.0",
+        node_count=3,
+        relationship_count=2,
+        node_labels=["Organization", "Person"],
+        relationship_types=["KNOWS", "WORKS_AT"],
+    )
+
+
+@pytest.fixture
+def sample_snapshot(
+    sample_metadata: BackupMetadata,
+    sample_nodes: list[dict],
+    sample_relationships: list[dict],
+) -> BackupSnapshot:
+    """Sample backup snapshot for testing."""
+    return BackupSnapshot(
+        metadata=sample_metadata,
+        nodes=sample_nodes,
+        relationships=sample_relationships,
+    )
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock Neo4j client."""
+    client = AsyncMock()
+    client.execute_query = AsyncMock()
+    return client
+
+
+# =============================================================================
+# BackupMetadata Tests
+# =============================================================================
+
+
+class TestBackupMetadata:
+    """Test BackupMetadata dataclass."""
+
+    def test_to_dict(self, sample_metadata: BackupMetadata) -> None:
+        """Test converting metadata to dictionary."""
+        data = sample_metadata.to_dict()
+
+        assert data["version"] == "1.0"
+        assert data["node_count"] == 3
+        assert data["relationship_count"] == 2
+        assert "Person" in data["node_labels"]
+        assert "WORKS_AT" in data["relationship_types"]
+
+    def test_from_dict(self) -> None:
+        """Test creating metadata from dictionary."""
+        data = {
+            "created_at": "2026-01-22T10:00:00+00:00",
+            "version": "1.0",
+            "node_count": 5,
+            "relationship_count": 3,
+            "node_labels": ["Person"],
+            "relationship_types": ["KNOWS"],
+        }
+
+        metadata = BackupMetadata.from_dict(data)
+
+        assert metadata.node_count == 5
+        assert metadata.relationship_count == 3
+        assert metadata.version == "1.0"
+
+    def test_from_dict_with_defaults(self) -> None:
+        """Test creating metadata with missing optional fields."""
+        data = {"created_at": "2026-01-22T10:00:00+00:00"}
+
+        metadata = BackupMetadata.from_dict(data)
+
+        assert metadata.node_count == 0
+        assert metadata.relationship_count == 0
+        assert metadata.version == "1.0"
+
+
+# =============================================================================
+# BackupSnapshot Tests
+# =============================================================================
+
+
+class TestBackupSnapshot:
+    """Test BackupSnapshot dataclass."""
+
+    def test_to_dict(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test converting snapshot to dictionary."""
+        data = sample_snapshot.to_dict()
+
+        assert "metadata" in data
+        assert "nodes" in data
+        assert "relationships" in data
+        assert len(data["nodes"]) == 3
+        assert len(data["relationships"]) == 2
+
+    def test_from_dict(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test creating snapshot from dictionary."""
+        data = sample_snapshot.to_dict()
+
+        restored = BackupSnapshot.from_dict(data)
+
+        assert restored.metadata.node_count == 3
+        assert len(restored.nodes) == 3
+        assert len(restored.relationships) == 2
+
+    def test_json_roundtrip(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test JSON serialization roundtrip."""
+        json_str = json.dumps(sample_snapshot.to_dict())
+        data = json.loads(json_str)
+
+        restored = BackupSnapshot.from_dict(data)
+
+        assert restored.metadata.node_count == sample_snapshot.metadata.node_count
+        assert len(restored.nodes) == len(sample_snapshot.nodes)
+
+
+# =============================================================================
+# Create Backup Tests
+# =============================================================================
+
+
+class TestCreateBackup:
+    """Test create_backup function."""
+
+    @pytest.mark.asyncio
+    async def test_create_backup_success(self, mock_client: AsyncMock) -> None:
+        """Test creating a backup snapshot."""
+        # Mock node query response
+        mock_client.execute_query.side_effect = [
+            # First call: nodes
+            [
+                {
+                    "labels": ["Person"],
+                    "props": {"uuid": "p1", "name": "Test"},
+                    "id": "4:abc:0",
+                },
+            ],
+            # Second call: relationships
+            [
+                {
+                    "type": "KNOWS",
+                    "props": {},
+                    "from_id": "4:abc:0",
+                    "to_id": "4:abc:1",
+                    "from_labels": ["Person"],
+                    "to_labels": ["Person"],
+                    "from_uuid": "p1",
+                    "to_uuid": "p2",
+                },
+            ],
+        ]
+
+        snapshot = await create_backup(mock_client)
+
+        assert snapshot.metadata.node_count == 1
+        assert snapshot.metadata.relationship_count == 1
+        assert "Person" in snapshot.metadata.node_labels
+        assert "KNOWS" in snapshot.metadata.relationship_types
+
+    @pytest.mark.asyncio
+    async def test_create_backup_empty_database(self, mock_client: AsyncMock) -> None:
+        """Test creating backup of empty database."""
+        mock_client.execute_query.side_effect = [[], []]
+
+        snapshot = await create_backup(mock_client)
+
+        assert snapshot.metadata.node_count == 0
+        assert snapshot.metadata.relationship_count == 0
+        assert len(snapshot.nodes) == 0
+        assert len(snapshot.relationships) == 0
+
+
+# =============================================================================
+# File Operations Tests
+# =============================================================================
+
+
+class TestFileOperations:
+    """Test file save/load operations."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_load_backup(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test saving and loading a backup file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "backup.json"
+
+            await save_backup_to_file(sample_snapshot, filepath)
+
+            assert filepath.exists()
+
+            loaded = await load_backup_from_file(filepath)
+
+            assert loaded.metadata.node_count == sample_snapshot.metadata.node_count
+            assert len(loaded.nodes) == len(sample_snapshot.nodes)
+            assert len(loaded.relationships) == len(sample_snapshot.relationships)
+
+    @pytest.mark.asyncio
+    async def test_save_creates_parent_directories(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test that save creates parent directories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "nested" / "path" / "backup.json"
+
+            await save_backup_to_file(sample_snapshot, filepath)
+
+            assert filepath.exists()
+
+    @pytest.mark.asyncio
+    async def test_load_nonexistent_file(self) -> None:
+        """Test loading a file that doesn't exist."""
+        with pytest.raises(FileNotFoundError):
+            await load_backup_from_file("/nonexistent/path/backup.json")
+
+
+# =============================================================================
+# Clear Database Tests
+# =============================================================================
+
+
+class TestClearDatabase:
+    """Test clear_database function."""
+
+    @pytest.mark.asyncio
+    async def test_clear_database(self, mock_client: AsyncMock) -> None:
+        """Test clearing all data from database."""
+        # First batch deletes 1000, second batch deletes 500 (under batch size)
+        mock_client.execute_query.side_effect = [
+            [{"deleted": 1000}],
+            [{"deleted": 500}],
+        ]
+
+        deleted = await clear_database(mock_client)
+
+        assert deleted == 1500
+        assert mock_client.execute_query.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_clear_empty_database(self, mock_client: AsyncMock) -> None:
+        """Test clearing an already empty database."""
+        mock_client.execute_query.return_value = [{"deleted": 0}]
+
+        deleted = await clear_database(mock_client)
+
+        assert deleted == 0
+
+
+# =============================================================================
+# Restore Backup Tests
+# =============================================================================
+
+
+class TestRestoreBackup:
+    """Test restore_backup function."""
+
+    @pytest.mark.asyncio
+    async def test_restore_backup_success(
+        self, mock_client: AsyncMock, sample_snapshot: BackupSnapshot
+    ) -> None:
+        """Test restoring a backup successfully."""
+        # Mock node creation
+        mock_client.execute_query.return_value = [{"uuid": "test-uuid", "new_id": "4:new:0"}]
+
+        result = await restore_backup(mock_client, sample_snapshot)
+
+        assert result.success
+        assert result.nodes_restored == 3
+        assert result.relationships_restored == 2
+        assert len(result.errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_restore_with_clear(
+        self, mock_client: AsyncMock, sample_snapshot: BackupSnapshot
+    ) -> None:
+        """Test restoring with clear_existing=True."""
+        # First call is clear_database batch delete
+        # Then node creations, then relationship creations
+        mock_client.execute_query.side_effect = [
+            [{"deleted": 0}],  # clear_database
+            *[[{"uuid": "test", "new_id": "4:new:0"}]] * 3,  # 3 nodes
+            *[[{"r": {}}]] * 2,  # 2 relationships
+        ]
+
+        result = await restore_backup(mock_client, sample_snapshot, clear_existing=True)
+
+        assert result.success
+        # First call is the clear operation
+        assert mock_client.execute_query.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_restore_with_missing_uuids(self, mock_client: AsyncMock) -> None:
+        """Test restoring relationships with missing UUIDs."""
+        snapshot = BackupSnapshot(
+            metadata=BackupMetadata(
+                created_at=datetime.now(UTC).isoformat(),
+                node_count=0,
+                relationship_count=1,
+            ),
+            nodes=[],
+            relationships=[
+                {
+                    "type": "KNOWS",
+                    "properties": {},
+                    "from_uuid": None,
+                    "to_uuid": None,
+                }
+            ],
+        )
+
+        mock_client.execute_query.return_value = []
+
+        result = await restore_backup(mock_client, snapshot)
+
+        assert result.success  # Should succeed but with warnings
+        assert result.relationships_restored == 0
+        assert len(result.warnings) > 0
+
+
+# =============================================================================
+# Validate Backup Tests
+# =============================================================================
+
+
+class TestValidateBackup:
+    """Test validate_backup function."""
+
+    @pytest.mark.asyncio
+    async def test_validate_valid_backup(self, sample_snapshot: BackupSnapshot) -> None:
+        """Test validating a valid backup."""
+        errors = await validate_backup(sample_snapshot)
+
+        assert len(errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_validate_count_mismatch(self) -> None:
+        """Test detecting node count mismatch."""
+        snapshot = BackupSnapshot(
+            metadata=BackupMetadata(
+                created_at=datetime.now(UTC).isoformat(),
+                node_count=5,  # Says 5 but only 1 node
+                relationship_count=0,
+            ),
+            nodes=[{"element_id": "1", "labels": ["Person"], "properties": {}}],
+            relationships=[],
+        )
+
+        errors = await validate_backup(snapshot)
+
+        assert len(errors) > 0
+        assert any("count mismatch" in e.lower() for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_validate_relationship_mismatch(self) -> None:
+        """Test detecting relationship count mismatch."""
+        snapshot = BackupSnapshot(
+            metadata=BackupMetadata(
+                created_at=datetime.now(UTC).isoformat(),
+                node_count=0,
+                relationship_count=10,  # Says 10 but empty
+            ),
+            nodes=[],
+            relationships=[],
+        )
+
+        errors = await validate_backup(snapshot)
+
+        assert len(errors) > 0
+
+    @pytest.mark.asyncio
+    async def test_validate_orphan_relationship(self) -> None:
+        """Test detecting relationships referencing non-existent nodes."""
+        snapshot = BackupSnapshot(
+            metadata=BackupMetadata(
+                created_at=datetime.now(UTC).isoformat(),
+                node_count=1,
+                relationship_count=1,
+            ),
+            nodes=[{"element_id": "4:abc:0", "labels": ["Person"], "properties": {}}],
+            relationships=[
+                {
+                    "type": "KNOWS",
+                    "from_element_id": "4:abc:0",
+                    "to_element_id": "4:abc:999",  # Does not exist
+                }
+            ],
+        )
+
+        errors = await validate_backup(snapshot)
+
+        assert len(errors) > 0
+        assert any("non-existent" in e.lower() for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_validate_duplicate_uuids(self) -> None:
+        """Test detecting duplicate UUIDs within same label."""
+        snapshot = BackupSnapshot(
+            metadata=BackupMetadata(
+                created_at=datetime.now(UTC).isoformat(),
+                node_count=2,
+                relationship_count=0,
+            ),
+            nodes=[
+                {
+                    "element_id": "4:abc:0",
+                    "labels": ["Person"],
+                    "properties": {"uuid": "duplicate-uuid"},
+                },
+                {
+                    "element_id": "4:abc:1",
+                    "labels": ["Person"],
+                    "properties": {"uuid": "duplicate-uuid"},  # Same UUID
+                },
+            ],
+            relationships=[],
+        )
+
+        errors = await validate_backup(snapshot)
+
+        assert len(errors) > 0
+        assert any("duplicate" in e.lower() for e in errors)
+
+
+# =============================================================================
+# RestoreResult Tests
+# =============================================================================
+
+
+class TestRestoreResult:
+    """Test RestoreResult dataclass."""
+
+    def test_successful_result(self) -> None:
+        """Test creating a successful result."""
+        result = RestoreResult(
+            success=True,
+            nodes_restored=10,
+            relationships_restored=5,
+        )
+
+        assert result.success
+        assert result.nodes_restored == 10
+        assert result.relationships_restored == 5
+        assert len(result.errors) == 0
+
+    def test_failed_result(self) -> None:
+        """Test creating a failed result."""
+        result = RestoreResult(
+            success=False,
+            nodes_restored=5,
+            relationships_restored=2,
+            errors=["Failed to create node X", "Failed to create relationship Y"],
+        )
+
+        assert not result.success
+        assert len(result.errors) == 2
+
+    def test_result_with_warnings(self) -> None:
+        """Test result with warnings but no errors."""
+        result = RestoreResult(
+            success=True,
+            nodes_restored=10,
+            warnings=["Skipped node without labels"],
+        )
+
+        assert result.success
+        assert len(result.warnings) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -724,9 +724,11 @@ dependencies = [
     { name = "google-auth-oauthlib" },
     { name = "graphiti-core" },
     { name = "neo4j" },
+    { name = "prometheus-client" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-telegram-bot" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "rich" },
@@ -762,6 +764,7 @@ requires-dist = [
     { name = "neo4j", specifier = ">=5.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "prometheus-client", specifier = ">=0.20" },
     { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -769,6 +772,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -1239,6 +1243,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1515,6 +1528,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/6b/400f88e5c29a270c1c519a3ca8ad0babc650ec63dbfbd1b73babf625ed54/python_telegram_bot-22.5.tar.gz", hash = "sha256:82d4efd891d04132f308f0369f5b5929e0b96957901f58bcef43911c5f6f92f8", size = 1488269, upload-time = "2025-09-27T13:50:27.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c3/340c7520095a8c79455fcf699cbb207225e5b36490d2b9ee557c16a7b21b/python_telegram_bot-22.5-py3-none-any.whl", hash = "sha256:4b7cd365344a7dce54312cc4520d7fa898b44d1a0e5f8c74b5bd9b540d035d16", size = 730976, upload-time = "2025-09-27T13:50:25.93Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `backup.py` module with Python-level JSON export/import for the knowledge graph
- Create backup snapshots with all nodes, relationships, and metadata
- Restore from backup with optional clear_existing mode
- Validate backup integrity before restore

## Changes

### New Files
- `src/klabautermann/memory/backup.py` - Core backup/restore functionality
- `tests/unit/test_backup.py` - 24 unit tests

### Modified Files  
- `src/klabautermann/memory/__init__.py` - Export new classes and functions

## Features

**Backup:**
- `create_backup()` - Export entire graph to BackupSnapshot
- `save_backup_to_file()` - Save snapshot to JSON file
- Captures all node labels, relationship types, and properties
- Includes metadata: timestamps, counts, version

**Restore:**
- `restore_backup()` - Import snapshot to database
- `clear_database()` - Optional clear before restore
- `load_backup_from_file()` - Load snapshot from JSON
- Handles UUID-based node matching for relationships

**Validation:**
- `validate_backup()` - Check snapshot consistency
- Detects count mismatches, orphan relationships, duplicate UUIDs

## Test Plan

- [x] Run `pytest tests/unit/test_backup.py` - 24 tests passing
- [x] Run `ruff check` - No linting errors
- [x] Run `mypy` - No type errors

## Issues Closed

- #203: [MEM-017] Implement backup snapshot
- #204: [MEM-018] Add restore from backup

---
Generated with [Claude Code](https://claude.com/claude-code)