### PR TITLE
feat(memory): Add semantic query caching with TTL and LRU eviction (#197)

### DIFF
--- a/src/klabautermann/memory/__init__.py
+++ b/src/klabautermann/memory/__init__.py
@@ -15,6 +15,7 @@ Contains:
 - temporal_spine: Day-based temporal queries
 - relevance_scoring: Context relevance scoring for prioritization
 - summary_cache: Thread summary caching
+- semantic_cache: Semantic query result caching with TTL
 - weight_decay: Relationship weight decay for graph maintenance
 """
 
@@ -72,6 +73,22 @@ from klabautermann.memory.relevance_scoring import (
     score_and_truncate,
     score_context_items,
     truncate_by_relevance,
+)
+from klabautermann.memory.semantic_cache import (
+    DEFAULT_MAX_ENTRIES,
+    DEFAULT_TTL_SECONDS,
+    CacheEntry,
+    CacheStats,
+    SemanticCache,
+    cache_search_results,
+    clear_search_cache,
+    get_cached_search_results,
+    get_search_cache_stats,
+    get_semantic_cache,
+    hash_query,
+    hash_query_with_params,
+    invalidate_search_cache,
+    reset_semantic_cache,
 )
 from klabautermann.memory.summary_cache import (
     CachedSummary,
@@ -143,6 +160,21 @@ __all__ = [
     "AIZoomLevelSelector",
     # Summary Cache
     "CachedSummary",
+    # Semantic Cache
+    "CacheEntry",
+    "CacheStats",
+    "DEFAULT_MAX_ENTRIES",
+    "DEFAULT_TTL_SECONDS",
+    "SemanticCache",
+    "cache_search_results",
+    "clear_search_cache",
+    "get_cached_search_results",
+    "get_search_cache_stats",
+    "get_semantic_cache",
+    "hash_query",
+    "hash_query_with_params",
+    "invalidate_search_cache",
+    "reset_semantic_cache",
     # Context Statistics
     "ContextWindowMetrics",
     # Clients

--- a/src/klabautermann/memory/semantic_cache.py
+++ b/src/klabautermann/memory/semantic_cache.py
@@ -1,0 +1,458 @@
+"""
+Semantic query caching for Klabautermann.
+
+Caches search results based on query similarity to avoid redundant
+embedding computations and graph traversals. Uses hash-based lookup
+with TTL expiration.
+
+Features:
+- Hash query embeddings for fast lookup
+- TTL-based expiration (default 5 minutes)
+- LRU eviction when cache is full
+- Statistics tracking (hit/miss rates)
+
+Reference: specs/architecture/MEMORY.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+from klabautermann.core.logger import logger
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Default TTL for cached results (5 minutes)
+DEFAULT_TTL_SECONDS = float(os.getenv("SEMANTIC_CACHE_TTL", "300"))
+
+# Maximum number of cached entries
+DEFAULT_MAX_ENTRIES = int(os.getenv("SEMANTIC_CACHE_MAX_ENTRIES", "1000"))
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class CacheEntry:
+    """A cached search result with metadata."""
+
+    query_hash: str
+    query_text: str
+    results: list[dict[str, Any]]
+    cached_at: float
+    ttl_seconds: float
+    hit_count: int = 0
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if this cache entry has expired."""
+        return time.time() - self.cached_at > self.ttl_seconds
+
+    @property
+    def age_seconds(self) -> float:
+        """Time since this entry was cached."""
+        return time.time() - self.cached_at
+
+
+@dataclass
+class CacheStats:
+    """Statistics about cache performance."""
+
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    expirations: int = 0
+    current_size: int = 0
+    max_size: int = DEFAULT_MAX_ENTRIES
+
+    @property
+    def hit_rate(self) -> float:
+        """Calculate cache hit rate."""
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+    @property
+    def miss_rate(self) -> float:
+        """Calculate cache miss rate."""
+        return 1.0 - self.hit_rate
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to dictionary."""
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "evictions": self.evictions,
+            "expirations": self.expirations,
+            "current_size": self.current_size,
+            "max_size": self.max_size,
+            "hit_rate": round(self.hit_rate, 4),
+        }
+
+
+# =============================================================================
+# Query Hashing
+# =============================================================================
+
+
+def hash_query(query: str) -> str:
+    """
+    Generate a hash for a query string.
+
+    Uses SHA-256 truncated to 16 characters for compact storage
+    while maintaining collision resistance for practical use.
+
+    Args:
+        query: The query string to hash.
+
+    Returns:
+        16-character hex hash string.
+    """
+    # Normalize query: lowercase, strip whitespace
+    normalized = query.lower().strip()
+    # Generate SHA-256 hash and truncate
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def hash_query_with_params(
+    query: str,
+    params: dict[str, Any] | None = None,
+) -> str:
+    """
+    Generate a hash for a query with parameters.
+
+    Includes any search parameters (limit, filters, etc.) in the hash
+    to distinguish queries with different configurations.
+
+    Args:
+        query: The query string.
+        params: Optional dictionary of search parameters.
+
+    Returns:
+        16-character hex hash string.
+    """
+    # Normalize query
+    normalized = query.lower().strip()
+
+    # Add sorted params to hash input
+    if params:
+        param_str = "|".join(f"{k}={v}" for k, v in sorted(params.items()))
+        normalized = f"{normalized}|{param_str}"
+
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+# =============================================================================
+# Semantic Cache
+# =============================================================================
+
+
+class SemanticCache:
+    """
+    In-memory cache for semantic search results.
+
+    Provides hash-based lookup with TTL expiration and LRU eviction.
+    Thread-safe for single-threaded async use (no concurrent mutations).
+    """
+
+    def __init__(
+        self,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        default_ttl: float = DEFAULT_TTL_SECONDS,
+    ) -> None:
+        """
+        Initialize the semantic cache.
+
+        Args:
+            max_entries: Maximum number of entries to store.
+            default_ttl: Default TTL in seconds for cached entries.
+        """
+        self._cache: OrderedDict[str, CacheEntry] = OrderedDict()
+        self._max_entries = max_entries
+        self._default_ttl = default_ttl
+        self._stats = CacheStats(max_size=max_entries)
+
+    def get(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+    ) -> list[dict[str, Any]] | None:
+        """
+        Get cached results for a query.
+
+        Args:
+            query: The search query.
+            params: Optional search parameters.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Cached results if found and valid, None otherwise.
+        """
+        query_hash = hash_query_with_params(query, params)
+
+        entry = self._cache.get(query_hash)
+
+        if entry is None:
+            self._stats.misses += 1
+            logger.debug(
+                f"[WHISPER] Cache miss for query: {query[:50]}...",
+                extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+            )
+            return None
+
+        # Check expiration
+        if entry.is_expired:
+            self._stats.misses += 1
+            self._stats.expirations += 1
+            del self._cache[query_hash]
+            self._stats.current_size = len(self._cache)
+            logger.debug(
+                f"[WHISPER] Cache expired for query: {query[:50]}...",
+                extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+            )
+            return None
+
+        # Cache hit - move to end for LRU
+        self._cache.move_to_end(query_hash)
+        entry.hit_count += 1
+        self._stats.hits += 1
+
+        logger.debug(
+            f"[WHISPER] Cache hit for query: {query[:50]}... "
+            f"(age={entry.age_seconds:.1f}s, hits={entry.hit_count})",
+            extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+        )
+
+        return entry.results
+
+    def set(
+        self,
+        query: str,
+        results: list[dict[str, Any]],
+        params: dict[str, Any] | None = None,
+        ttl: float | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        """
+        Cache results for a query.
+
+        Args:
+            query: The search query.
+            results: Search results to cache.
+            params: Optional search parameters.
+            ttl: Optional TTL override in seconds.
+            trace_id: Optional trace ID for logging.
+        """
+        query_hash = hash_query_with_params(query, params)
+        ttl_seconds = ttl if ttl is not None else self._default_ttl
+
+        # Create entry
+        entry = CacheEntry(
+            query_hash=query_hash,
+            query_text=query,
+            results=results,
+            cached_at=time.time(),
+            ttl_seconds=ttl_seconds,
+        )
+
+        # Evict if at capacity
+        if len(self._cache) >= self._max_entries and query_hash not in self._cache:
+            # Remove oldest (first) entry
+            oldest_key = next(iter(self._cache))
+            del self._cache[oldest_key]
+            self._stats.evictions += 1
+
+        # Store entry
+        self._cache[query_hash] = entry
+        self._cache.move_to_end(query_hash)
+        self._stats.current_size = len(self._cache)
+
+        logger.debug(
+            f"[WHISPER] Cached results for query: {query[:50]}... "
+            f"(results={len(results)}, ttl={ttl_seconds}s)",
+            extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+        )
+
+    def invalidate(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+    ) -> bool:
+        """
+        Invalidate a specific cached query.
+
+        Args:
+            query: The search query.
+            params: Optional search parameters.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            True if entry was found and removed, False otherwise.
+        """
+        query_hash = hash_query_with_params(query, params)
+
+        if query_hash in self._cache:
+            del self._cache[query_hash]
+            self._stats.current_size = len(self._cache)
+            logger.debug(
+                f"[WHISPER] Invalidated cache for query: {query[:50]}...",
+                extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+            )
+            return True
+
+        return False
+
+    def clear(self, trace_id: str | None = None) -> int:
+        """
+        Clear all cached entries.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Number of entries cleared.
+        """
+        count = len(self._cache)
+        self._cache.clear()
+        self._stats.current_size = 0
+
+        logger.info(
+            f"[CHART] Cleared {count} cache entries",
+            extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+        )
+
+        return count
+
+    def cleanup_expired(self, trace_id: str | None = None) -> int:
+        """
+        Remove all expired entries.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Number of entries removed.
+        """
+        expired_keys = [k for k, v in self._cache.items() if v.is_expired]
+
+        for key in expired_keys:
+            del self._cache[key]
+            self._stats.expirations += 1
+
+        self._stats.current_size = len(self._cache)
+
+        if expired_keys:
+            logger.debug(
+                f"[WHISPER] Cleaned up {len(expired_keys)} expired cache entries",
+                extra={"trace_id": trace_id, "agent_name": "semantic_cache"},
+            )
+
+        return len(expired_keys)
+
+    def get_stats(self) -> CacheStats:
+        """Get cache statistics."""
+        self._stats.current_size = len(self._cache)
+        return self._stats
+
+    def reset_stats(self) -> None:
+        """Reset cache statistics (keeps entries)."""
+        self._stats = CacheStats(max_size=self._max_entries)
+        self._stats.current_size = len(self._cache)
+
+
+# =============================================================================
+# Global Cache Instance
+# =============================================================================
+
+_global_cache: SemanticCache | None = None
+
+
+def get_semantic_cache() -> SemanticCache:
+    """Get the global semantic cache instance."""
+    global _global_cache
+    if _global_cache is None:
+        _global_cache = SemanticCache()
+    return _global_cache
+
+
+def reset_semantic_cache() -> None:
+    """Reset the global semantic cache (for testing)."""
+    global _global_cache
+    _global_cache = None
+
+
+# =============================================================================
+# Convenience Functions
+# =============================================================================
+
+
+def cache_search_results(
+    query: str,
+    results: list[dict[str, Any]],
+    params: dict[str, Any] | None = None,
+    ttl: float | None = None,
+    trace_id: str | None = None,
+) -> None:
+    """Cache search results using global cache."""
+    get_semantic_cache().set(query, results, params, ttl, trace_id)
+
+
+def get_cached_search_results(
+    query: str,
+    params: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+) -> list[dict[str, Any]] | None:
+    """Get cached search results from global cache."""
+    return get_semantic_cache().get(query, params, trace_id)
+
+
+def invalidate_search_cache(
+    query: str,
+    params: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+) -> bool:
+    """Invalidate a specific query in global cache."""
+    return get_semantic_cache().invalidate(query, params, trace_id)
+
+
+def clear_search_cache(trace_id: str | None = None) -> int:
+    """Clear all entries from global cache."""
+    return get_semantic_cache().clear(trace_id)
+
+
+def get_search_cache_stats() -> CacheStats:
+    """Get statistics from global cache."""
+    return get_semantic_cache().get_stats()
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+__all__ = [
+    "DEFAULT_MAX_ENTRIES",
+    "DEFAULT_TTL_SECONDS",
+    "CacheEntry",
+    "CacheStats",
+    "SemanticCache",
+    "cache_search_results",
+    "clear_search_cache",
+    "get_cached_search_results",
+    "get_search_cache_stats",
+    "get_semantic_cache",
+    "hash_query",
+    "hash_query_with_params",
+    "invalidate_search_cache",
+    "reset_semantic_cache",
+]

--- a/tests/unit/test_semantic_cache.py
+++ b/tests/unit/test_semantic_cache.py
@@ -1,0 +1,428 @@
+"""Unit tests for semantic query caching."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from klabautermann.memory.semantic_cache import (
+    CacheEntry,
+    CacheStats,
+    SemanticCache,
+    cache_search_results,
+    clear_search_cache,
+    get_cached_search_results,
+    get_search_cache_stats,
+    get_semantic_cache,
+    hash_query,
+    hash_query_with_params,
+    invalidate_search_cache,
+    reset_semantic_cache,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_global_cache() -> None:
+    """Reset global cache before each test."""
+    reset_semantic_cache()
+
+
+@pytest.fixture
+def cache() -> SemanticCache:
+    """Create a fresh cache instance."""
+    return SemanticCache(max_entries=10, default_ttl=60.0)
+
+
+@pytest.fixture
+def sample_results() -> list[dict]:
+    """Sample search results."""
+    return [
+        {"uuid": "person-1", "name": "John Doe", "score": 0.95},
+        {"uuid": "person-2", "name": "Jane Smith", "score": 0.87},
+    ]
+
+
+# =============================================================================
+# Hash Function Tests
+# =============================================================================
+
+
+class TestHashQuery:
+    """Test query hashing functions."""
+
+    def test_hash_query_produces_consistent_hash(self) -> None:
+        """Test that same query produces same hash."""
+        query = "What is John's email?"
+        hash1 = hash_query(query)
+        hash2 = hash_query(query)
+
+        assert hash1 == hash2
+
+    def test_hash_query_normalizes_case(self) -> None:
+        """Test that queries are case-normalized."""
+        hash1 = hash_query("What is JOHN's email?")
+        hash2 = hash_query("what is john's email?")
+
+        assert hash1 == hash2
+
+    def test_hash_query_normalizes_whitespace(self) -> None:
+        """Test that queries are whitespace-normalized."""
+        hash1 = hash_query("  What is John's email?  ")
+        hash2 = hash_query("What is John's email?")
+
+        assert hash1 == hash2
+
+    def test_hash_query_returns_16_chars(self) -> None:
+        """Test that hash is 16 hex characters."""
+        query_hash = hash_query("Test query")
+
+        assert len(query_hash) == 16
+        assert all(c in "0123456789abcdef" for c in query_hash)
+
+    def test_different_queries_produce_different_hashes(self) -> None:
+        """Test that different queries produce different hashes."""
+        hash1 = hash_query("What is John's email?")
+        hash2 = hash_query("Who does John work for?")
+
+        assert hash1 != hash2
+
+    def test_hash_with_params_includes_params(self) -> None:
+        """Test that params affect the hash."""
+        query = "Find people"
+        hash1 = hash_query_with_params(query, {"limit": 10})
+        hash2 = hash_query_with_params(query, {"limit": 20})
+        hash3 = hash_query_with_params(query, None)
+
+        assert hash1 != hash2
+        assert hash1 != hash3
+        assert hash2 != hash3
+
+    def test_hash_with_params_sorted_consistently(self) -> None:
+        """Test that param order doesn't affect hash."""
+        query = "Find people"
+        hash1 = hash_query_with_params(query, {"limit": 10, "offset": 5})
+        hash2 = hash_query_with_params(query, {"offset": 5, "limit": 10})
+
+        assert hash1 == hash2
+
+
+# =============================================================================
+# CacheEntry Tests
+# =============================================================================
+
+
+class TestCacheEntry:
+    """Test CacheEntry dataclass."""
+
+    def test_entry_not_expired_when_fresh(self) -> None:
+        """Test fresh entry is not expired."""
+        entry = CacheEntry(
+            query_hash="abc123",
+            query_text="test query",
+            results=[],
+            cached_at=time.time(),
+            ttl_seconds=60.0,
+        )
+
+        assert not entry.is_expired
+
+    def test_entry_expired_after_ttl(self) -> None:
+        """Test entry expires after TTL."""
+        entry = CacheEntry(
+            query_hash="abc123",
+            query_text="test query",
+            results=[],
+            cached_at=time.time() - 120,  # 2 minutes ago
+            ttl_seconds=60.0,  # 1 minute TTL
+        )
+
+        assert entry.is_expired
+
+    def test_age_seconds_calculation(self) -> None:
+        """Test age calculation."""
+        entry = CacheEntry(
+            query_hash="abc123",
+            query_text="test query",
+            results=[],
+            cached_at=time.time() - 30,  # 30 seconds ago
+            ttl_seconds=60.0,
+        )
+
+        assert 29 <= entry.age_seconds <= 32
+
+
+# =============================================================================
+# CacheStats Tests
+# =============================================================================
+
+
+class TestCacheStats:
+    """Test CacheStats dataclass."""
+
+    def test_hit_rate_calculation(self) -> None:
+        """Test hit rate is calculated correctly."""
+        stats = CacheStats(hits=7, misses=3)
+
+        assert stats.hit_rate == 0.7
+
+    def test_hit_rate_zero_when_no_requests(self) -> None:
+        """Test hit rate is 0 when no requests."""
+        stats = CacheStats()
+
+        assert stats.hit_rate == 0.0
+
+    def test_miss_rate_calculation(self) -> None:
+        """Test miss rate is inverse of hit rate."""
+        stats = CacheStats(hits=7, misses=3)
+
+        assert abs(stats.miss_rate - 0.3) < 0.001
+
+    def test_to_dict(self) -> None:
+        """Test converting stats to dictionary."""
+        stats = CacheStats(
+            hits=10,
+            misses=5,
+            evictions=2,
+            expirations=1,
+            current_size=50,
+            max_size=100,
+        )
+
+        data = stats.to_dict()
+
+        assert data["hits"] == 10
+        assert data["misses"] == 5
+        assert data["evictions"] == 2
+        assert data["hit_rate"] == round(10 / 15, 4)
+
+
+# =============================================================================
+# SemanticCache Tests
+# =============================================================================
+
+
+class TestSemanticCache:
+    """Test SemanticCache class."""
+
+    def test_get_returns_none_for_miss(self, cache: SemanticCache) -> None:
+        """Test get returns None on cache miss."""
+        result = cache.get("unknown query")
+
+        assert result is None
+
+    def test_set_and_get_basic(self, cache: SemanticCache, sample_results: list[dict]) -> None:
+        """Test basic set and get."""
+        query = "Find John"
+
+        cache.set(query, sample_results)
+        result = cache.get(query)
+
+        assert result == sample_results
+
+    def test_get_returns_none_after_expiration(self, sample_results: list[dict]) -> None:
+        """Test that expired entries return None."""
+        cache = SemanticCache(default_ttl=0.1)  # 100ms TTL
+
+        cache.set("test query", sample_results)
+        time.sleep(0.15)  # Wait for expiration
+
+        result = cache.get("test query")
+
+        assert result is None
+
+    def test_stats_track_hits_and_misses(
+        self, cache: SemanticCache, sample_results: list[dict]
+    ) -> None:
+        """Test that stats track hits and misses."""
+        cache.set("query1", sample_results)
+
+        cache.get("query1")  # Hit
+        cache.get("query1")  # Hit
+        cache.get("query2")  # Miss
+
+        stats = cache.get_stats()
+
+        assert stats.hits == 2
+        assert stats.misses == 1
+
+    def test_lru_eviction_on_capacity(self, sample_results: list[dict]) -> None:
+        """Test LRU eviction when cache is full."""
+        cache = SemanticCache(max_entries=3)
+
+        cache.set("query1", sample_results)
+        cache.set("query2", sample_results)
+        cache.set("query3", sample_results)
+        cache.set("query4", sample_results)  # Should evict query1
+
+        assert cache.get("query1") is None  # Evicted
+        assert cache.get("query2") is not None
+        assert cache.get("query4") is not None
+
+    def test_lru_updates_on_access(self, sample_results: list[dict]) -> None:
+        """Test that accessing an entry updates its LRU position."""
+        cache = SemanticCache(max_entries=3)
+
+        cache.set("query1", sample_results)
+        cache.set("query2", sample_results)
+        cache.set("query3", sample_results)
+
+        # Access query1 to move it to end
+        cache.get("query1")
+
+        # Add new entry - should evict query2 (oldest unused)
+        cache.set("query4", sample_results)
+
+        assert cache.get("query1") is not None  # Still present
+        assert cache.get("query2") is None  # Evicted
+        assert cache.get("query3") is not None
+
+    def test_invalidate_removes_entry(
+        self, cache: SemanticCache, sample_results: list[dict]
+    ) -> None:
+        """Test invalidate removes specific entry."""
+        cache.set("query1", sample_results)
+        cache.set("query2", sample_results)
+
+        result = cache.invalidate("query1")
+
+        assert result is True
+        assert cache.get("query1") is None
+        assert cache.get("query2") is not None
+
+    def test_invalidate_returns_false_for_missing(self, cache: SemanticCache) -> None:
+        """Test invalidate returns False for missing entry."""
+        result = cache.invalidate("nonexistent")
+
+        assert result is False
+
+    def test_clear_removes_all_entries(
+        self, cache: SemanticCache, sample_results: list[dict]
+    ) -> None:
+        """Test clear removes all entries."""
+        cache.set("query1", sample_results)
+        cache.set("query2", sample_results)
+
+        count = cache.clear()
+
+        assert count == 2
+        assert cache.get("query1") is None
+        assert cache.get("query2") is None
+
+    def test_cleanup_expired_removes_old_entries(self, sample_results: list[dict]) -> None:
+        """Test cleanup_expired removes expired entries."""
+        cache = SemanticCache(default_ttl=0.1)
+
+        cache.set("query1", sample_results)
+        time.sleep(0.15)  # Let it expire
+        cache.set("query2", sample_results)  # Fresh entry
+
+        removed = cache.cleanup_expired()
+
+        assert removed == 1
+        assert cache.get("query2") is not None
+
+    def test_params_affect_cache_key(
+        self, cache: SemanticCache, sample_results: list[dict]
+    ) -> None:
+        """Test that different params create different cache entries."""
+        query = "Find people"
+
+        cache.set(query, sample_results, params={"limit": 10})
+        cache.set(query, [{"different": "results"}], params={"limit": 20})
+
+        result1 = cache.get(query, params={"limit": 10})
+        result2 = cache.get(query, params={"limit": 20})
+
+        assert result1 == sample_results
+        assert result2 == [{"different": "results"}]
+
+    def test_custom_ttl_per_entry(self, cache: SemanticCache, sample_results: list[dict]) -> None:
+        """Test that TTL can be customized per entry."""
+        cache.set("short", sample_results, ttl=0.1)
+        cache.set("long", sample_results, ttl=60.0)
+
+        time.sleep(0.15)
+
+        assert cache.get("short") is None
+        assert cache.get("long") is not None
+
+    def test_reset_stats_keeps_entries(
+        self, cache: SemanticCache, sample_results: list[dict]
+    ) -> None:
+        """Test reset_stats clears stats but keeps entries."""
+        cache.set("query", sample_results)
+        cache.get("query")  # Hit
+
+        stats_before = cache.get_stats()
+        assert stats_before.hits == 1
+
+        cache.reset_stats()
+
+        stats_after = cache.get_stats()
+        assert stats_after.hits == 0
+        assert cache.get("query") is not None  # Entry still there
+
+
+# =============================================================================
+# Global Cache Functions Tests
+# =============================================================================
+
+
+class TestGlobalCacheFunctions:
+    """Test convenience functions using global cache."""
+
+    def test_get_semantic_cache_returns_singleton(self) -> None:
+        """Test that get_semantic_cache returns singleton."""
+        cache1 = get_semantic_cache()
+        cache2 = get_semantic_cache()
+
+        assert cache1 is cache2
+
+    def test_cache_and_get_search_results(self, sample_results: list[dict]) -> None:
+        """Test convenience functions for caching."""
+        cache_search_results("test query", sample_results)
+        result = get_cached_search_results("test query")
+
+        assert result == sample_results
+
+    def test_invalidate_search_cache_function(self, sample_results: list[dict]) -> None:
+        """Test invalidate convenience function."""
+        cache_search_results("test query", sample_results)
+        invalidate_search_cache("test query")
+
+        assert get_cached_search_results("test query") is None
+
+    def test_clear_search_cache_function(self, sample_results: list[dict]) -> None:
+        """Test clear convenience function."""
+        cache_search_results("query1", sample_results)
+        cache_search_results("query2", sample_results)
+
+        count = clear_search_cache()
+
+        assert count == 2
+        assert get_cached_search_results("query1") is None
+
+    def test_get_search_cache_stats_function(self, sample_results: list[dict]) -> None:
+        """Test stats convenience function."""
+        cache_search_results("query", sample_results)
+        get_cached_search_results("query")
+        get_cached_search_results("missing")
+
+        stats = get_search_cache_stats()
+
+        assert stats.hits == 1
+        assert stats.misses == 1
+
+    def test_reset_semantic_cache_creates_new_instance(self, sample_results: list[dict]) -> None:
+        """Test reset creates new cache instance."""
+        cache_search_results("query", sample_results)
+
+        reset_semantic_cache()
+
+        assert get_cached_search_results("query") is None


### PR DESCRIPTION
## Summary

- Add `semantic_cache.py` module for caching search results
- Hash queries for fast lookup with TTL expiration
- LRU eviction when cache reaches capacity
- Track hit/miss statistics for monitoring

## Changes

### New Files
- `src/klabautermann/memory/semantic_cache.py` - Core caching functionality
- `tests/unit/test_semantic_cache.py` - 33 unit tests

### Modified Files
- `src/klabautermann/memory/__init__.py` - Export new classes and functions

## Features

**Query Hashing:**
- `hash_query()` - Normalize and hash query strings
- `hash_query_with_params()` - Include search parameters in hash
- Case and whitespace normalization for consistent keys

**Caching:**
- `SemanticCache` class with in-memory LRU cache
- TTL expiration (default 5 minutes, configurable)
- Max entries limit (default 1000, configurable)
- Per-entry TTL override support

**Statistics:**
- `CacheStats` tracks hits, misses, evictions, expirations
- Hit rate calculation for monitoring
- `get_search_cache_stats()` for global cache metrics

**Configuration:**
- `SEMANTIC_CACHE_TTL` - TTL in seconds (default: 300)
- `SEMANTIC_CACHE_MAX_ENTRIES` - Maximum cache size (default: 1000)

## Test Plan

- [x] Run `pytest tests/unit/test_semantic_cache.py` - 33 tests passing
- [x] Run `ruff check` - No linting errors
- [x] Run `mypy` - No type errors

## Issues Closed

- #197: [MEM-011] Implement semantic caching

---
Generated with [Claude Code](https://claude.com/claude-code)