### PR TITLE
feat(agents): Add orphan message detection and removal to HullCleaner (#82, #83)

### DIFF
--- a/src/klabautermann/agents/hull_cleaner.py
+++ b/src/klabautermann/agents/hull_cleaner.py
@@ -20,6 +20,11 @@ from typing import TYPE_CHECKING, Any
 from klabautermann.agents.base_agent import BaseAgent
 from klabautermann.core.logger import logger
 from klabautermann.core.models import AgentMessage
+from klabautermann.memory.orphan_cleanup import (
+    OrphanMessage,
+    delete_orphan_messages,
+    find_orphan_messages,
+)
 from klabautermann.memory.weight_decay import (
     RelationshipWeight,
     get_low_weight_relationships,
@@ -64,6 +69,10 @@ class HullCleanerConfig:
     prune_weak_relationships: bool = True
     weak_relationship_threshold: float = 0.2
     weak_relationship_age_days: int = 90
+
+    # Orphan cleanup settings
+    remove_orphan_messages: bool = True
+    orphan_batch_size: int = 50
 
     # Run limits
     max_deletions_per_run: int = 1000
@@ -208,6 +217,22 @@ class HullCleaner(BaseAgent):
         elif operation == "prune_weak_relationships":
             result = await self.prune_weak_relationships(dry_run=dry_run, trace_id=trace_id)
             result_payload = result.to_dict()
+        elif operation == "find_orphan_messages":
+            orphans = await self.find_orphan_messages(trace_id=trace_id)
+            result_payload = {
+                "orphan_messages": [
+                    {
+                        "uuid": o.uuid,
+                        "content": o.content[:100] if o.content else None,
+                        "role": o.role,
+                    }
+                    for o in orphans
+                ],
+                "count": len(orphans),
+            }
+        elif operation == "remove_orphan_messages":
+            result = await self.remove_orphan_messages(dry_run=dry_run, trace_id=trace_id)
+            result_payload = result.to_dict()
         else:
             result_payload = {"error": f"Unknown operation: {operation}"}
 
@@ -271,8 +296,24 @@ class HullCleaner(BaseAgent):
                 )
                 errors.append(error_msg)
 
+        # 2. Remove orphan messages
+        if self.hull_config.remove_orphan_messages:
+            try:
+                orphan_result = await self.remove_orphan_messages(
+                    dry_run=dry_run, trace_id=trace_id
+                )
+                total_nodes_found += orphan_result.nodes_found
+                total_nodes_removed += orphan_result.nodes_removed
+                self._audit_log.extend(orphan_result.audit_entries)
+            except Exception as e:
+                error_msg = f"Orphan message removal failed: {e}"
+                logger.error(
+                    f"[STORM] {error_msg}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+                errors.append(error_msg)
+
         # Future: Add more pruning operations here
-        # - Orphan message removal
         # - Duplicate entity detection
         # - Transitive path reduction
 
@@ -292,8 +333,8 @@ class HullCleaner(BaseAgent):
 
         logger.info(
             f"[BEACON] Barnacle scraping complete: "
-            f"found {total_rels_found} weak relationships, "
-            f"pruned {total_rels_pruned} "
+            f"found {total_rels_found} weak relationships (pruned {total_rels_pruned}), "
+            f"found {total_nodes_found} orphan messages (removed {total_nodes_removed}) "
             f"({'preview' if dry_run else 'actual'})",
             extra={"trace_id": trace_id, "agent_name": self.name},
         )
@@ -497,6 +538,130 @@ class HullCleaner(BaseAgent):
         )
 
         return deleted > 0
+
+    # =========================================================================
+    # Orphan Message Operations
+    # =========================================================================
+
+    async def find_orphan_messages(
+        self,
+        limit: int | None = None,
+        trace_id: str | None = None,
+    ) -> list[OrphanMessage]:
+        """
+        Find messages not linked to any thread.
+
+        These are candidates for cleanup - messages that were created but
+        never properly linked due to failed transactions or bugs.
+
+        Args:
+            limit: Maximum orphans to return (default from config).
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of OrphanMessage objects representing orphan messages.
+        """
+        limit = limit or self.hull_config.max_deletions_per_run
+
+        logger.debug(
+            f"[WHISPER] Finding orphan messages (limit={limit})",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        # Use existing orphan_cleanup infrastructure
+        orphans = await find_orphan_messages(
+            neo4j=self.neo4j,
+            limit=limit,
+            trace_id=trace_id,
+        )
+
+        logger.debug(
+            f"[WHISPER] Found {len(orphans)} orphan messages",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return orphans
+
+    async def remove_orphan_messages(
+        self,
+        dry_run: bool = True,
+        trace_id: str | None = None,
+    ) -> PruningResult:
+        """
+        Delete orphan messages from the graph.
+
+        Args:
+            dry_run: If True, only preview changes without deleting.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            PruningResult with operation statistics.
+        """
+        start_time = time.time()
+
+        logger.info(
+            f"[CHART] Removing orphan messages (dry_run={dry_run})",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        # Find orphans first
+        orphans = await self.find_orphan_messages(trace_id=trace_id)
+
+        audit_entries: list[AuditEntry] = []
+        removed_count = 0
+        errors: list[str] = []
+
+        for orphan in orphans:
+            # Create audit entry
+            entry = AuditEntry(
+                timestamp=datetime.now(),
+                action=PruningAction.PREVIEW if dry_run else PruningAction.DELETE_NODE,
+                entity_type="message",
+                entity_id=orphan.uuid,
+                reason="Message not linked to any thread",
+                metadata={
+                    "role": orphan.role,
+                    "content_preview": orphan.content[:50] if orphan.content else None,
+                },
+            )
+            audit_entries.append(entry)
+
+        if not dry_run:
+            # Use existing delete_orphan_messages for actual deletion
+            cleanup_result = await delete_orphan_messages(
+                neo4j=self.neo4j,
+                batch_size=self.hull_config.orphan_batch_size,
+                dry_run=False,
+                trace_id=trace_id,
+            )
+            removed_count = cleanup_result.deleted_count
+            if cleanup_result.failed_count > 0:
+                errors.append(f"Failed to delete {cleanup_result.failed_count} orphan batches")
+        else:
+            removed_count = len(orphans)  # Count as "would be removed" in dry run
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        result = PruningResult(
+            operation="remove_orphan_messages",
+            dry_run=dry_run,
+            relationships_found=0,
+            relationships_pruned=0,
+            nodes_found=len(orphans),
+            nodes_removed=removed_count,
+            errors=errors,
+            duration_ms=duration_ms,
+            audit_entries=audit_entries,
+        )
+
+        logger.info(
+            f"[BEACON] Orphan message removal complete: "
+            f"found {len(orphans)}, removed {removed_count} "
+            f"({'preview' if dry_run else 'actual'})",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return result
 
     # =========================================================================
     # Statistics

--- a/tests/unit/test_hull_cleaner.py
+++ b/tests/unit/test_hull_cleaner.py
@@ -541,6 +541,234 @@ class TestAuditLog:
 
 
 # =============================================================================
+# Orphan Message Tests
+# =============================================================================
+
+
+class TestFindOrphanMessages:
+    """Tests for find_orphan_messages method."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_find_orphans_empty(self, cleaner, mock_neo4j):
+        """Test finding orphans when none exist."""
+        mock_neo4j.execute_query = AsyncMock(return_value=[])
+
+        result = await cleaner.find_orphan_messages()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_find_orphans_with_results(self, cleaner, mock_neo4j):
+        """Test finding orphan messages."""
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "uuid": "orphan-1",
+                    "content": "Orphaned message content",
+                    "timestamp": 1234567890.0,
+                    "role": "user",
+                },
+                {
+                    "uuid": "orphan-2",
+                    "content": "Another orphan",
+                    "timestamp": 1234567891.0,
+                    "role": "assistant",
+                },
+            ]
+        )
+
+        result = await cleaner.find_orphan_messages()
+
+        assert len(result) == 2
+        assert result[0].uuid == "orphan-1"
+        assert result[1].role == "assistant"
+
+
+class TestRemoveOrphanMessages:
+    """Tests for remove_orphan_messages method."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_remove_orphans_dry_run(self, cleaner, mock_neo4j):
+        """Test removing orphans in dry run mode."""
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "uuid": "orphan-1",
+                    "content": "Test content",
+                    "timestamp": 1234567890.0,
+                    "role": "user",
+                },
+            ]
+        )
+
+        result = await cleaner.remove_orphan_messages(dry_run=True)
+
+        assert result.dry_run is True
+        assert result.nodes_found == 1
+        assert result.nodes_removed == 1  # Would be removed
+        assert len(result.audit_entries) == 1
+        assert result.audit_entries[0].action == PruningAction.PREVIEW
+
+    @pytest.mark.asyncio
+    async def test_remove_orphans_actual(self, cleaner, mock_neo4j):
+        """Test actual orphan removal."""
+        # First call returns orphans, second call is the count, third is delete
+        mock_neo4j.execute_query = AsyncMock(
+            side_effect=[
+                # find_orphan_messages
+                [
+                    {
+                        "uuid": "orphan-1",
+                        "content": "Test",
+                        "timestamp": 1234567890.0,
+                        "role": "user",
+                    },
+                ],
+                # count_orphan_messages (inside delete_orphan_messages)
+                [{"count": 1}],
+                # actual delete batch
+                [{"deleted": 1}],
+                # next delete batch (returns 0 to stop)
+                [{"deleted": 0}],
+            ]
+        )
+
+        result = await cleaner.remove_orphan_messages(dry_run=False)
+
+        assert result.dry_run is False
+        assert result.nodes_found == 1
+        assert result.nodes_removed == 1
+        assert result.audit_entries[0].action == PruningAction.DELETE_NODE
+
+
+class TestScrapeBarnaclesWithOrphans:
+    """Tests for scrape_barnacles with orphan cleanup enabled."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_scrape_includes_orphans(self, cleaner):
+        """Test that scrape_barnacles includes orphan cleanup."""
+        result = await cleaner.scrape_barnacles(dry_run=True)
+
+        # Should have processed both weak rels and orphans
+        assert result.operation == "scrape_barnacles"
+        # Both operations should complete without errors
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    async def test_scrape_with_orphans_disabled(self, mock_neo4j):
+        """Test scrape with orphan cleanup disabled."""
+        config = HullCleanerConfig(
+            prune_weak_relationships=False,
+            remove_orphan_messages=False,
+        )
+        cleaner = HullCleaner(neo4j_client=mock_neo4j, config=config)
+
+        result = await cleaner.scrape_barnacles(dry_run=True)
+
+        # No operations should be processed
+        assert result.relationships_found == 0
+        assert result.nodes_found == 0
+
+
+class TestProcessMessageOrphanOperations:
+    """Tests for process_message with orphan operations."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_process_find_orphan_messages(self, cleaner, mock_neo4j):
+        """Test processing find_orphan_messages operation."""
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "uuid": "orphan-1",
+                    "content": "Test content",
+                    "timestamp": 1234567890.0,
+                    "role": "user",
+                },
+            ]
+        )
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="hull_cleaner",
+            intent="maintenance",
+            payload={"operation": "find_orphan_messages"},
+            trace_id="test-trace",
+        )
+
+        response = await cleaner.process_message(msg)
+
+        assert response is not None
+        assert response.payload["count"] == 1
+        assert len(response.payload["orphan_messages"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_remove_orphan_messages(self, cleaner, mock_neo4j):
+        """Test processing remove_orphan_messages operation."""
+        mock_neo4j.execute_query = AsyncMock(return_value=[])
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="hull_cleaner",
+            intent="maintenance",
+            payload={"operation": "remove_orphan_messages", "dry_run": True},
+            trace_id="test-trace",
+        )
+
+        response = await cleaner.process_message(msg)
+
+        assert response is not None
+        assert response.payload["operation"] == "remove_orphan_messages"
+
+
+# =============================================================================
 # Module Export Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Extends HullCleaner agent with orphan message detection and removal capabilities
- Integrates with existing `orphan_cleanup.py` infrastructure
- Adds `find_orphan_messages()` and `remove_orphan_messages()` methods with dry-run support
- Updates `scrape_barnacles()` to include orphan cleanup in full maintenance runs
- Configurable via `remove_orphan_messages` and `orphan_batch_size` settings
- Full audit trail for all orphan operations

## Test plan

- [x] All 33 unit tests pass (8 new tests added)
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] Pre-commit hooks pass

## Issues Closed

Closes #82 - [AGT-S-046] Implement orphan message detection
Closes #83 - [AGT-S-047] Implement orphan removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)