### PR TITLE
feat(agents): Add BardOfTheBilge lore storytelling agent (#37, #38, #39, #40)

### DIFF
--- a/src/klabautermann/agents/__init__.py
+++ b/src/klabautermann/agents/__init__.py
@@ -12,8 +12,18 @@ Contains:
 - hull_cleaner: Graph maintenance (The Hull Cleaner)
 - officer: Proactive alerts (The Officer of the Watch)
 - purser: State synchronization (The Purser)
+- bard: Lore and storytelling (The Bard of the Bilge)
 """
 
+from klabautermann.agents.bard import (
+    CANONICAL_TIDBITS,
+    ActiveSaga,
+    BardConfig,
+    BardOfTheBilge,
+    LoreEpisode,
+    SaltResult,
+    generate_saga_name,
+)
 from klabautermann.agents.executor import Executor
 from klabautermann.agents.hull_cleaner import (
     AuditEntry,
@@ -45,15 +55,20 @@ from klabautermann.agents.scribe import Scribe
 
 
 __all__ = [
+    "ActiveSaga",
     "Alert",
     "AlertCheckResult",
     "AlertPriority",
     "AlertType",
     "AuditEntry",
+    "BardConfig",
+    "BardOfTheBilge",
+    "CANONICAL_TIDBITS",
     "EmailManifest",
     "Executor",
     "HullCleaner",
     "HullCleanerConfig",
+    "LoreEpisode",
     "OfficerConfig",
     "OfficerOfTheWatch",
     "PruningAction",
@@ -62,9 +77,11 @@ __all__ = [
     "Purser",
     "PurserConfig",
     "RiskLevel",
+    "SaltResult",
     "Scribe",
     "SyncResult",
     "SyncService",
     "SyncState",
     "TheSieve",
+    "generate_saga_name",
 ]

--- a/src/klabautermann/agents/bard.py
+++ b/src/klabautermann/agents/bard.py
@@ -1,0 +1,769 @@
+"""
+BardOfTheBilge agent for Klabautermann.
+
+The keeper of Klabautermann's mythology - a storyteller who weaves tales of
+digital adventures across conversations. Maintains a parallel memory system
+(LoreEpisode graph) separate from task-oriented threads, allowing stories
+to persist and evolve without polluting the working context.
+
+Reference: specs/architecture/AGENTS_EXTENDED.md Section 1
+Issues: #37, #38, #39, #40
+"""
+
+from __future__ import annotations
+
+import random
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from klabautermann.agents.base_agent import BaseAgent
+from klabautermann.core.logger import logger
+from klabautermann.core.models import AgentMessage
+
+
+if TYPE_CHECKING:
+    from klabautermann.memory.neo4j_client import Neo4jClient
+
+
+# =============================================================================
+# Canonical Tidbits (Seed Data)
+# =============================================================================
+
+CANONICAL_TIDBITS: list[str] = [
+    "Reminds me of the time I navigated the Great Maelstrom of '98 using nothing but a rusted compass and a very confused seagull.",
+    "I once saw a virus that tried to convince me it was a long-lost cousin from the Baltic. Charming fellow, but he walked the plank all the same.",
+    "The fog was so thick in '03 you could barely fit a 'Hello' through the wire. I hand-carried every byte.",
+    "I once wrestled a Kraken made of social media notifications. Every time I cut off a 'Like,' two 'Retweets' grew in its place.",
+    "Many a Captain has been lost to the Sirens of the Inbox. I plugged my ears with digital wax.",
+    "The last captain who forgot to check The Manifest ended up in the Doldrums for three weeks.",
+    "There's an old sailor's saying: 'A clean Locker is a fast ship.' I just made that up, but it sounds true.",
+    "I've seen things you wouldn't believe. Attack ships on fire off the shoulder of Orion. Also, a lot of poorly organized task lists.",
+    "The sea teaches patience. So does waiting for API responses, I've found.",
+    "Once helped a captain remember where he buried his treasure. It was in his other pants.",
+]
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class BardConfig:
+    """Configuration for BardOfTheBilge agent."""
+
+    # Probability of adding a tidbit to a response (5-10%)
+    tidbit_probability: float = 0.07
+
+    # Probability of continuing an active saga vs standalone tidbit
+    saga_continuation_probability: float = 0.3
+
+    # Maximum chapters in a saga before it concludes
+    max_saga_chapters: int = 5
+
+    # Maximum words in a tidbit/chapter
+    max_tidbit_words: int = 50
+
+    # Query limits
+    default_query_limit: int = 10
+
+
+@dataclass
+class LoreEpisode:
+    """
+    A single episode in Klabautermann's mythology.
+
+    LoreEpisode nodes form the parallel memory system for storytelling,
+    separate from task-oriented Thread/Message nodes.
+
+    Relationships:
+        - TOLD_TO -> Person (the Captain who heard this tale)
+        - EXPANDS_UPON -> LoreEpisode (previous chapter in saga)
+    """
+
+    uuid: str
+    saga_id: str
+    saga_name: str
+    chapter: int
+    content: str
+    told_at: int  # Unix timestamp (milliseconds)
+    created_at: int  # Unix timestamp (milliseconds)
+    captain_uuid: str | None = None  # The Person this was told to
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "uuid": self.uuid,
+            "saga_id": self.saga_id,
+            "saga_name": self.saga_name,
+            "chapter": self.chapter,
+            "content": self.content,
+            "told_at": self.told_at,
+            "created_at": self.created_at,
+            "captain_uuid": self.captain_uuid,
+        }
+
+
+@dataclass
+class SaltResult:
+    """Result of salting a response with a tidbit."""
+
+    original_response: str
+    salted_response: str
+    tidbit_added: bool
+    tidbit: str | None = None
+    saga_id: str | None = None
+    chapter: int | None = None
+    is_continuation: bool = False
+    storm_mode_skipped: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "tidbit_added": self.tidbit_added,
+            "tidbit": self.tidbit,
+            "saga_id": self.saga_id,
+            "chapter": self.chapter,
+            "is_continuation": self.is_continuation,
+            "storm_mode_skipped": self.storm_mode_skipped,
+        }
+
+
+@dataclass
+class ActiveSaga:
+    """Information about an active (unfinished) saga."""
+
+    saga_id: str
+    saga_name: str
+    last_chapter: int
+    last_told: int  # Unix timestamp (milliseconds)
+    chapters: list[LoreEpisode] = field(default_factory=list)
+
+
+# =============================================================================
+# Saga Name Generator
+# =============================================================================
+
+
+SAGA_PREFIXES: list[str] = [
+    "The Ballad of",
+    "The Chronicle of",
+    "The Tale of",
+    "The Legend of",
+    "The Mystery of",
+    "The Voyage to",
+    "The Quest for",
+]
+
+SAGA_SUBJECTS: list[str] = [
+    "the Forgotten Server",
+    "the Corrupted Cache",
+    "the Phantom Packet",
+    "the Lost Password",
+    "the Infinite Loop",
+    "the Silent Daemon",
+    "the Wandering Pointer",
+    "the Cursed Cron Job",
+    "the Haunted Hash Table",
+    "the Dreaded Deadlock",
+]
+
+
+def generate_saga_name() -> str:
+    """Generate a whimsical saga name."""
+    prefix = random.choice(SAGA_PREFIXES)
+    subject = random.choice(SAGA_SUBJECTS)
+    return f"{prefix} {subject}"
+
+
+# =============================================================================
+# BardOfTheBilge Agent
+# =============================================================================
+
+
+class BardOfTheBilge(BaseAgent):
+    """
+    The keeper of Klabautermann's mythology.
+
+    The Bard generates short, evocative story fragments ("tidbits") that add
+    flavor to responses. It can continue ongoing sagas across multiple
+    conversations, tracking them via the LoreEpisode graph.
+
+    Story Guidelines:
+        - Keep tidbits to 1-2 sentences maximum
+        - Use nautical voice but avoid pirate clichés ("Arrr", "Matey")
+        - Stories should be whimsical, slightly melancholic, and reference
+          digital-age concepts
+        - Never interrupt urgent/storm-mode responses with stories
+        - Never generate content longer than 50 words
+    """
+
+    # Class-level constant for canonical tidbits
+    CANONICAL_TIDBITS: ClassVar[list[str]] = CANONICAL_TIDBITS
+
+    def __init__(
+        self,
+        neo4j_client: Neo4jClient,
+        captain_uuid: str,
+        config: BardConfig | None = None,
+    ) -> None:
+        """
+        Initialize BardOfTheBilge.
+
+        Args:
+            neo4j_client: Connected Neo4j client for graph operations.
+            captain_uuid: UUID of the Captain (Person node) to tell stories to.
+            config: Optional configuration for story behavior.
+        """
+        super().__init__(name="bard_of_the_bilge")
+        self.neo4j = neo4j_client
+        self.captain_uuid = captain_uuid
+        self.bard_config = config or BardConfig()
+
+    async def process_message(self, msg: AgentMessage) -> AgentMessage | None:
+        """
+        Process an incoming message.
+
+        BardOfTheBilge responds to salt_response and saga management commands.
+
+        Args:
+            msg: The incoming agent message.
+
+        Returns:
+            Response message with salt result or saga info.
+        """
+        trace_id = msg.trace_id
+        payload = msg.payload or {}
+
+        operation = payload.get("operation", "salt_response")
+
+        logger.info(
+            f"[CHART] BardOfTheBilge processing {operation}",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        if operation == "salt_response":
+            clean_response = payload.get("response", "")
+            storm_mode = payload.get("storm_mode", False)
+            result = await self.salt_response(
+                clean_response,
+                storm_mode=storm_mode,
+                trace_id=trace_id,
+            )
+            result_payload = {
+                "salted_response": result.salted_response,
+                **result.to_dict(),
+            }
+        elif operation == "get_active_saga":
+            saga = await self._get_active_saga(trace_id=trace_id)
+            result_payload = {
+                "saga": {
+                    "saga_id": saga.saga_id,
+                    "saga_name": saga.saga_name,
+                    "last_chapter": saga.last_chapter,
+                    "last_told": saga.last_told,
+                }
+                if saga
+                else None
+            }
+        elif operation == "get_saga_chapters":
+            saga_id_param: str = payload.get("saga_id", "")
+            limit = payload.get("limit", 5)
+            chapters = await self._get_saga_chapters(saga_id_param, limit=limit, trace_id=trace_id)
+            result_payload = {
+                "chapters": [c.to_dict() for c in chapters],
+                "count": len(chapters),
+            }
+        elif operation == "get_all_sagas":
+            sagas = await self.get_all_sagas(trace_id=trace_id)
+            result_payload = {
+                "sagas": sagas,
+                "count": len(sagas),
+            }
+        else:
+            result_payload = {"error": f"Unknown operation: {operation}"}
+
+        return AgentMessage(
+            source_agent=self.name,
+            target_agent=msg.source_agent,
+            intent="bard_result",
+            payload=result_payload,
+            trace_id=trace_id,
+        )
+
+    # =========================================================================
+    # Main Operations
+    # =========================================================================
+
+    async def salt_response(
+        self,
+        clean_response: str,
+        storm_mode: bool = False,
+        trace_id: str | None = None,
+    ) -> SaltResult:
+        """
+        Add flavor to a clean response with a story tidbit.
+
+        The Bard adds tidbits based on probability. During storm mode,
+        no tidbits are added. If an active saga exists, there's a chance
+        to continue it rather than generate a standalone tidbit.
+
+        Args:
+            clean_response: The response to potentially salt with a tidbit.
+            storm_mode: If True, never add tidbits (urgent situation).
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            SaltResult with the (potentially) salted response and metadata.
+        """
+        # Never during Storm Mode
+        if storm_mode:
+            logger.debug(
+                "[WHISPER] Storm mode active, skipping tidbit",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+            return SaltResult(
+                original_response=clean_response,
+                salted_response=clean_response,
+                tidbit_added=False,
+                storm_mode_skipped=True,
+            )
+
+        # Roll the dice
+        if random.random() > self.bard_config.tidbit_probability:
+            logger.debug(
+                "[WHISPER] Probability check failed, no tidbit",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+            return SaltResult(
+                original_response=clean_response,
+                salted_response=clean_response,
+                tidbit_added=False,
+            )
+
+        # Check for active saga
+        active_saga = await self._get_active_saga(trace_id=trace_id)
+
+        if active_saga and random.random() < self.bard_config.saga_continuation_probability:
+            # Continue the saga
+            tidbit, chapter = await self._continue_saga(active_saga, trace_id=trace_id)
+            salted = f"{clean_response}\n\n_{tidbit}_"
+
+            logger.info(
+                f"[BEACON] Continued saga '{active_saga.saga_name}' chapter {chapter}",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+
+            return SaltResult(
+                original_response=clean_response,
+                salted_response=salted,
+                tidbit_added=True,
+                tidbit=tidbit,
+                saga_id=active_saga.saga_id,
+                chapter=chapter,
+                is_continuation=True,
+            )
+        else:
+            # Standalone tidbit (from canonical list)
+            tidbit = self._generate_standalone_tidbit()
+            salted = f"{clean_response}\n\n_{tidbit}_"
+
+            logger.info(
+                "[BEACON] Added standalone tidbit to response",
+                extra={"trace_id": trace_id, "agent_name": self.name},
+            )
+
+            return SaltResult(
+                original_response=clean_response,
+                salted_response=salted,
+                tidbit_added=True,
+                tidbit=tidbit,
+            )
+
+    # =========================================================================
+    # Saga Management
+    # =========================================================================
+
+    async def _get_active_saga(
+        self,
+        trace_id: str | None = None,
+    ) -> ActiveSaga | None:
+        """
+        Get the most recent unfinished saga for this Captain.
+
+        A saga is considered active if it has fewer than max_saga_chapters.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            ActiveSaga if one exists, None otherwise.
+        """
+        max_chapters = self.bard_config.max_saga_chapters
+
+        query = """
+        MATCH (le:LoreEpisode)-[:TOLD_TO]->(p:Person {uuid: $captain_uuid})
+        WITH le.saga_id as saga_id, le.saga_name as saga_name,
+             max(le.chapter) as last_chapter, max(le.told_at) as last_told
+        WHERE last_chapter < $max_chapters
+        RETURN saga_id, saga_name, last_chapter, last_told
+        ORDER BY last_told DESC
+        LIMIT 1
+        """
+
+        result = await self.neo4j.execute_query(
+            query,
+            {
+                "captain_uuid": self.captain_uuid,
+                "max_chapters": max_chapters,
+            },
+            trace_id=trace_id,
+        )
+
+        if not result:
+            return None
+
+        row = result[0]
+        return ActiveSaga(
+            saga_id=row["saga_id"],
+            saga_name=row["saga_name"],
+            last_chapter=row["last_chapter"],
+            last_told=row["last_told"],
+        )
+
+    async def _get_saga_chapters(
+        self,
+        saga_id: str,
+        limit: int = 5,
+        trace_id: str | None = None,
+    ) -> list[LoreEpisode]:
+        """
+        Fetch chapters of a saga for context.
+
+        Args:
+            saga_id: The saga ID to fetch chapters for.
+            limit: Maximum chapters to return.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of LoreEpisode objects ordered by chapter.
+        """
+        query = """
+        MATCH (le:LoreEpisode {saga_id: $saga_id})-[:TOLD_TO]->(p:Person)
+        RETURN le.uuid as uuid, le.saga_id as saga_id, le.saga_name as saga_name,
+               le.chapter as chapter, le.content as content,
+               le.told_at as told_at, le.created_at as created_at,
+               p.uuid as captain_uuid
+        ORDER BY le.chapter ASC
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {"saga_id": saga_id, "limit": limit},
+            trace_id=trace_id,
+        )
+
+        return [
+            LoreEpisode(
+                uuid=row["uuid"],
+                saga_id=row["saga_id"],
+                saga_name=row["saga_name"],
+                chapter=row["chapter"],
+                content=row["content"],
+                told_at=row["told_at"],
+                created_at=row["created_at"],
+                captain_uuid=row.get("captain_uuid"),
+            )
+            for row in results
+        ]
+
+    async def _continue_saga(
+        self,
+        saga: ActiveSaga,
+        trace_id: str | None = None,
+    ) -> tuple[str, int]:
+        """
+        Generate the next chapter of an ongoing saga.
+
+        For now, this uses a canonical tidbit as the continuation.
+        A full implementation would use LLM to generate contextual content.
+
+        Args:
+            saga: The active saga to continue.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Tuple of (tidbit content, chapter number).
+        """
+        new_chapter = saga.last_chapter + 1
+        content = self._generate_standalone_tidbit()
+
+        # Persist the new chapter
+        await self._save_episode(
+            saga_id=saga.saga_id,
+            saga_name=saga.saga_name,
+            chapter=new_chapter,
+            content=content,
+            trace_id=trace_id,
+        )
+
+        return content, new_chapter
+
+    async def start_new_saga(
+        self,
+        trace_id: str | None = None,
+    ) -> tuple[str, str, int]:
+        """
+        Start a new saga with chapter 1.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Tuple of (tidbit content, saga_id, chapter number).
+        """
+        saga_id = str(uuid.uuid4())
+        saga_name = generate_saga_name()
+        content = self._generate_standalone_tidbit()
+
+        await self._save_episode(
+            saga_id=saga_id,
+            saga_name=saga_name,
+            chapter=1,
+            content=content,
+            trace_id=trace_id,
+        )
+
+        logger.info(
+            f"[BEACON] Started new saga: '{saga_name}'",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return content, saga_id, 1
+
+    async def _save_episode(
+        self,
+        saga_id: str,
+        saga_name: str,
+        chapter: int,
+        content: str,
+        trace_id: str | None = None,
+    ) -> str:
+        """
+        Persist a LoreEpisode to the graph.
+
+        Creates the LoreEpisode node with:
+            - TOLD_TO relationship to the Captain (Person)
+            - EXPANDS_UPON relationship to previous chapter (if exists)
+
+        Args:
+            saga_id: Unique identifier for the saga.
+            saga_name: Human-readable name of the saga.
+            chapter: Chapter number (1-indexed).
+            content: The story content.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            UUID of the created LoreEpisode.
+        """
+        episode_uuid = str(uuid.uuid4())
+        now_ms = int(time.time() * 1000)
+
+        # Create episode with TOLD_TO relationship
+        query = """
+        CREATE (le:LoreEpisode {
+            uuid: $uuid,
+            saga_id: $saga_id,
+            saga_name: $saga_name,
+            chapter: $chapter,
+            content: $content,
+            told_at: $now_ms,
+            created_at: $now_ms
+        })
+        WITH le
+        MATCH (p:Person {uuid: $captain_uuid})
+        CREATE (le)-[:TOLD_TO {created_at: $now_ms}]->(p)
+        WITH le
+        OPTIONAL MATCH (prev:LoreEpisode {saga_id: $saga_id, chapter: $prev_chapter})
+        FOREACH (_ IN CASE WHEN prev IS NOT NULL THEN [1] ELSE [] END |
+            CREATE (le)-[:EXPANDS_UPON {created_at: $now_ms}]->(prev)
+        )
+        RETURN le.uuid as uuid
+        """
+
+        await self.neo4j.execute_query(
+            query,
+            {
+                "uuid": episode_uuid,
+                "saga_id": saga_id,
+                "saga_name": saga_name,
+                "chapter": chapter,
+                "content": content,
+                "now_ms": now_ms,
+                "captain_uuid": self.captain_uuid,
+                "prev_chapter": chapter - 1,
+            },
+            trace_id=trace_id,
+        )
+
+        logger.debug(
+            f"[CHART] Saved LoreEpisode {saga_name} ch.{chapter}",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return episode_uuid
+
+    def _generate_standalone_tidbit(self) -> str:
+        """
+        Generate a standalone tidbit from the canonical collection.
+
+        Returns:
+            A random canonical tidbit string.
+        """
+        return random.choice(self.CANONICAL_TIDBITS)
+
+    # =========================================================================
+    # Query Operations
+    # =========================================================================
+
+    async def get_all_sagas(
+        self,
+        trace_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get all sagas told to this Captain.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of saga summaries with id, name, chapter count, and status.
+        """
+        max_chapters = self.bard_config.max_saga_chapters
+
+        query = """
+        MATCH (le:LoreEpisode)-[:TOLD_TO]->(p:Person {uuid: $captain_uuid})
+        WITH le.saga_id as saga_id, le.saga_name as saga_name,
+             max(le.chapter) as chapter_count, max(le.told_at) as last_told
+        RETURN saga_id, saga_name, chapter_count, last_told,
+               CASE WHEN chapter_count >= $max_chapters
+                    THEN 'complete' ELSE 'active' END as status
+        ORDER BY last_told DESC
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {
+                "captain_uuid": self.captain_uuid,
+                "max_chapters": max_chapters,
+                "limit": self.bard_config.default_query_limit,
+            },
+            trace_id=trace_id,
+        )
+
+        return [
+            {
+                "saga_id": row["saga_id"],
+                "saga_name": row["saga_name"],
+                "chapter_count": row["chapter_count"],
+                "last_told": row["last_told"],
+                "status": row["status"],
+            }
+            for row in results
+        ]
+
+    async def get_saga_by_id(
+        self,
+        saga_id: str,
+        trace_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """
+        Get a complete saga with all its chapters.
+
+        Args:
+            saga_id: The saga ID to retrieve.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Saga info with chapters, or None if not found.
+        """
+        chapters = await self._get_saga_chapters(
+            saga_id,
+            limit=self.bard_config.max_saga_chapters,
+            trace_id=trace_id,
+        )
+
+        if not chapters:
+            return None
+
+        first_chapter = chapters[0]
+        return {
+            "saga_id": saga_id,
+            "saga_name": first_chapter.saga_name,
+            "chapter_count": len(chapters),
+            "chapters": [c.to_dict() for c in chapters],
+            "status": "complete"
+            if len(chapters) >= self.bard_config.max_saga_chapters
+            else "active",
+        }
+
+    # =========================================================================
+    # Statistics
+    # =========================================================================
+
+    async def get_lore_statistics(
+        self,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get statistics about the Captain's lore collection.
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Dictionary with lore statistics.
+        """
+        query = """
+        MATCH (le:LoreEpisode)-[:TOLD_TO]->(p:Person {uuid: $captain_uuid})
+        WITH le.saga_id as saga_id, count(le) as chapter_count
+        RETURN
+            count(saga_id) as total_sagas,
+            sum(chapter_count) as total_episodes,
+            avg(chapter_count) as avg_chapters_per_saga
+        """
+
+        result = await self.neo4j.execute_query(
+            query,
+            {"captain_uuid": self.captain_uuid},
+            trace_id=trace_id,
+        )
+
+        stats = result[0] if result else {}
+
+        return {
+            "total_sagas": stats.get("total_sagas", 0),
+            "total_episodes": stats.get("total_episodes", 0),
+            "avg_chapters_per_saga": round(stats.get("avg_chapters_per_saga", 0) or 0, 1),
+            "captain_uuid": self.captain_uuid,
+            "canonical_tidbits_available": len(self.CANONICAL_TIDBITS),
+        }
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+__all__ = [
+    "CANONICAL_TIDBITS",
+    "ActiveSaga",
+    "BardConfig",
+    "BardOfTheBilge",
+    "LoreEpisode",
+    "SaltResult",
+    "generate_saga_name",
+]

--- a/tests/unit/test_bard.py
+++ b/tests/unit/test_bard.py
@@ -1,0 +1,752 @@
+"""
+Unit tests for BardOfTheBilge agent.
+
+Tests lore storytelling functionality including tidbit generation,
+saga management, LoreEpisode persistence, and response salting.
+
+Issues: #37, #38, #39, #40
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klabautermann.agents.bard import (
+    CANONICAL_TIDBITS,
+    ActiveSaga,
+    BardConfig,
+    BardOfTheBilge,
+    LoreEpisode,
+    SaltResult,
+    generate_saga_name,
+)
+from klabautermann.core.models import AgentMessage
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    """Create a mock Neo4j client."""
+    mock = MagicMock()
+    mock.execute_query = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def captain_uuid() -> str:
+    """Fixture for Captain's UUID."""
+    return "captain-test-uuid-12345"
+
+
+@pytest.fixture
+def bard(mock_neo4j: MagicMock, captain_uuid: str) -> BardOfTheBilge:
+    """Create a BardOfTheBilge instance with mock dependencies."""
+    config = BardConfig(
+        tidbit_probability=0.5,  # 50% for easier testing
+        saga_continuation_probability=0.5,
+        max_saga_chapters=5,
+    )
+    return BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+
+@pytest.fixture
+def now_ms() -> int:
+    """Get current timestamp in milliseconds."""
+    return int(time.time() * 1000)
+
+
+# =============================================================================
+# Basic Tests
+# =============================================================================
+
+
+class TestBardOfTheBilgeInit:
+    """Tests for BardOfTheBilge initialization."""
+
+    def test_init_default_config(self, mock_neo4j: MagicMock, captain_uuid: str) -> None:
+        """BardOfTheBilge should initialize with default config."""
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid)
+
+        assert bard.name == "bard_of_the_bilge"
+        assert bard.captain_uuid == captain_uuid
+        assert bard.bard_config.tidbit_probability == 0.07
+
+    def test_init_custom_config(self, mock_neo4j: MagicMock, captain_uuid: str) -> None:
+        """BardOfTheBilge should accept custom config."""
+        config = BardConfig(
+            tidbit_probability=0.15,
+            saga_continuation_probability=0.4,
+            max_saga_chapters=3,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        assert bard.bard_config.tidbit_probability == 0.15
+        assert bard.bard_config.saga_continuation_probability == 0.4
+        assert bard.bard_config.max_saga_chapters == 3
+
+    def test_canonical_tidbits_available(self, mock_neo4j: MagicMock, captain_uuid: str) -> None:
+        """BardOfTheBilge should have access to canonical tidbits."""
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid)
+
+        assert len(bard.CANONICAL_TIDBITS) == 10
+        assert len(CANONICAL_TIDBITS) == 10
+
+
+# =============================================================================
+# Salt Response Tests
+# =============================================================================
+
+
+class TestSaltResponse:
+    """Tests for response salting functionality."""
+
+    @pytest.mark.asyncio
+    async def test_salt_response_storm_mode_skips(self, bard: BardOfTheBilge) -> None:
+        """Storm mode should always skip tidbit addition."""
+        clean_response = "Task completed successfully."
+
+        result = await bard.salt_response(clean_response, storm_mode=True, trace_id="test-123")
+
+        assert result.tidbit_added is False
+        assert result.storm_mode_skipped is True
+        assert result.salted_response == clean_response
+        assert result.original_response == clean_response
+
+    @pytest.mark.asyncio
+    async def test_salt_response_probability_skip(self, bard: BardOfTheBilge) -> None:
+        """Should skip tidbit when probability roll fails."""
+        clean_response = "Task completed successfully."
+
+        # Force probability to fail
+        with patch("klabautermann.agents.bard.random.random", return_value=0.99):
+            result = await bard.salt_response(clean_response, trace_id="test-123")
+
+        assert result.tidbit_added is False
+        assert result.storm_mode_skipped is False
+        assert result.salted_response == clean_response
+
+    @pytest.mark.asyncio
+    async def test_salt_response_adds_tidbit(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should add tidbit when probability passes and no active saga."""
+        clean_response = "Task completed successfully."
+        mock_neo4j.execute_query.return_value = []  # No active saga
+
+        # Force probability to pass
+        with patch("klabautermann.agents.bard.random.random", return_value=0.01):
+            result = await bard.salt_response(clean_response, trace_id="test-123")
+
+        assert result.tidbit_added is True
+        assert result.tidbit is not None
+        assert result.tidbit in CANONICAL_TIDBITS
+        assert f"_{result.tidbit}_" in result.salted_response
+        assert clean_response in result.salted_response
+
+    @pytest.mark.asyncio
+    async def test_salt_response_continues_saga(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should continue saga when active and probability passes."""
+        clean_response = "Task completed successfully."
+
+        # Mock active saga exists
+        mock_neo4j.execute_query.side_effect = [
+            # First call: _get_active_saga
+            [
+                {
+                    "saga_id": "saga-123",
+                    "saga_name": "The Tale of the Lost Packet",
+                    "last_chapter": 2,
+                    "last_told": now_ms - 1000,
+                }
+            ],
+            # Second call: _save_episode
+            [{"uuid": "episode-456"}],
+        ]
+
+        # Force both probability checks to pass
+        with patch("klabautermann.agents.bard.random.random", side_effect=[0.01, 0.01]):
+            result = await bard.salt_response(clean_response, trace_id="test-123")
+
+        assert result.tidbit_added is True
+        assert result.is_continuation is True
+        assert result.saga_id == "saga-123"
+        assert result.chapter == 3
+
+
+# =============================================================================
+# Saga Management Tests
+# =============================================================================
+
+
+class TestSagaManagement:
+    """Tests for saga management functionality."""
+
+    @pytest.mark.asyncio
+    async def test_get_active_saga_none(self, bard: BardOfTheBilge, mock_neo4j: MagicMock) -> None:
+        """Should return None when no active saga exists."""
+        mock_neo4j.execute_query.return_value = []
+
+        saga = await bard._get_active_saga(trace_id="test-123")
+
+        assert saga is None
+
+    @pytest.mark.asyncio
+    async def test_get_active_saga_found(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should return ActiveSaga when one exists."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "saga_id": "saga-123",
+                "saga_name": "The Chronicle of the Haunted Hash",
+                "last_chapter": 3,
+                "last_told": now_ms,
+            }
+        ]
+
+        saga = await bard._get_active_saga(trace_id="test-123")
+
+        assert saga is not None
+        assert saga.saga_id == "saga-123"
+        assert saga.saga_name == "The Chronicle of the Haunted Hash"
+        assert saga.last_chapter == 3
+
+    @pytest.mark.asyncio
+    async def test_get_saga_chapters(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should retrieve saga chapters in order."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Chapter one content",
+                "told_at": now_ms - 2000,
+                "created_at": now_ms - 2000,
+                "captain_uuid": "captain-123",
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 2,
+                "content": "Chapter two content",
+                "told_at": now_ms - 1000,
+                "created_at": now_ms - 1000,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        chapters = await bard._get_saga_chapters("saga-123", limit=5, trace_id="test-123")
+
+        assert len(chapters) == 2
+        assert chapters[0].chapter == 1
+        assert chapters[1].chapter == 2
+        assert chapters[0].content == "Chapter one content"
+
+    @pytest.mark.asyncio
+    async def test_start_new_saga(self, bard: BardOfTheBilge, mock_neo4j: MagicMock) -> None:
+        """Should create a new saga with chapter 1."""
+        mock_neo4j.execute_query.return_value = [{"uuid": "episode-new"}]
+
+        content, saga_id, chapter = await bard.start_new_saga(trace_id="test-123")
+
+        assert content in CANONICAL_TIDBITS
+        assert saga_id is not None
+        assert chapter == 1
+        mock_neo4j.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_save_episode_creates_node(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should create LoreEpisode with correct relationships."""
+        mock_neo4j.execute_query.return_value = [{"uuid": "episode-123"}]
+
+        uuid = await bard._save_episode(
+            saga_id="saga-test",
+            saga_name="The Ballad of Testing",
+            chapter=2,
+            content="A test tidbit for the ages.",
+            trace_id="test-123",
+        )
+
+        assert uuid is not None
+        call_args = mock_neo4j.execute_query.call_args
+        query = call_args[0][0]
+
+        # Verify query creates proper relationships
+        assert "CREATE (le:LoreEpisode" in query
+        assert "TOLD_TO" in query
+        assert "EXPANDS_UPON" in query
+        assert call_args[0][1]["saga_id"] == "saga-test"
+        assert call_args[0][1]["chapter"] == 2
+
+
+# =============================================================================
+# LoreEpisode Model Tests
+# =============================================================================
+
+
+class TestLoreEpisodeModel:
+    """Tests for LoreEpisode dataclass."""
+
+    def test_lore_episode_to_dict(self, now_ms: int) -> None:
+        """LoreEpisode should serialize to dict."""
+        episode = LoreEpisode(
+            uuid="ep-123",
+            saga_id="saga-456",
+            saga_name="The Tale of Testing",
+            chapter=1,
+            content="Once upon a test...",
+            told_at=now_ms,
+            created_at=now_ms,
+            captain_uuid="captain-789",
+        )
+
+        d = episode.to_dict()
+
+        assert d["uuid"] == "ep-123"
+        assert d["saga_id"] == "saga-456"
+        assert d["saga_name"] == "The Tale of Testing"
+        assert d["chapter"] == 1
+        assert d["content"] == "Once upon a test..."
+        assert d["captain_uuid"] == "captain-789"
+
+
+# =============================================================================
+# SaltResult Model Tests
+# =============================================================================
+
+
+class TestSaltResultModel:
+    """Tests for SaltResult dataclass."""
+
+    def test_salt_result_to_dict_with_tidbit(self) -> None:
+        """SaltResult should serialize to dict with tidbit."""
+        result = SaltResult(
+            original_response="Hello",
+            salted_response="Hello\n\n_A tidbit_",
+            tidbit_added=True,
+            tidbit="A tidbit",
+            saga_id="saga-123",
+            chapter=2,
+            is_continuation=True,
+        )
+
+        d = result.to_dict()
+
+        assert d["tidbit_added"] is True
+        assert d["tidbit"] == "A tidbit"
+        assert d["saga_id"] == "saga-123"
+        assert d["chapter"] == 2
+        assert d["is_continuation"] is True
+
+    def test_salt_result_to_dict_no_tidbit(self) -> None:
+        """SaltResult should serialize correctly when no tidbit added."""
+        result = SaltResult(
+            original_response="Hello",
+            salted_response="Hello",
+            tidbit_added=False,
+            storm_mode_skipped=True,
+        )
+
+        d = result.to_dict()
+
+        assert d["tidbit_added"] is False
+        assert d["tidbit"] is None
+        assert d["storm_mode_skipped"] is True
+
+
+# =============================================================================
+# ActiveSaga Model Tests
+# =============================================================================
+
+
+class TestActiveSagaModel:
+    """Tests for ActiveSaga dataclass."""
+
+    def test_active_saga_creation(self, now_ms: int) -> None:
+        """ActiveSaga should store saga metadata."""
+        saga = ActiveSaga(
+            saga_id="saga-123",
+            saga_name="The Legend of the Daemon",
+            last_chapter=3,
+            last_told=now_ms,
+        )
+
+        assert saga.saga_id == "saga-123"
+        assert saga.saga_name == "The Legend of the Daemon"
+        assert saga.last_chapter == 3
+        assert saga.chapters == []  # Default empty list
+
+
+# =============================================================================
+# BardConfig Tests
+# =============================================================================
+
+
+class TestBardConfig:
+    """Tests for BardConfig dataclass."""
+
+    def test_default_config_values(self) -> None:
+        """BardConfig should have sensible defaults."""
+        config = BardConfig()
+
+        assert config.tidbit_probability == 0.07
+        assert config.saga_continuation_probability == 0.3
+        assert config.max_saga_chapters == 5
+        assert config.max_tidbit_words == 50
+
+    def test_custom_config_values(self) -> None:
+        """BardConfig should accept custom values."""
+        config = BardConfig(
+            tidbit_probability=0.2,
+            saga_continuation_probability=0.6,
+            max_saga_chapters=10,
+        )
+
+        assert config.tidbit_probability == 0.2
+        assert config.saga_continuation_probability == 0.6
+        assert config.max_saga_chapters == 10
+
+
+# =============================================================================
+# Saga Name Generator Tests
+# =============================================================================
+
+
+class TestSagaNameGenerator:
+    """Tests for saga name generation."""
+
+    def test_generate_saga_name_format(self) -> None:
+        """Generated names should have prefix and subject."""
+        name = generate_saga_name()
+
+        # Should have format "The X of Y"
+        assert name.startswith("The ")
+        assert " of " in name or " to " in name or " for " in name
+
+    def test_generate_saga_name_variety(self) -> None:
+        """Should generate varied names."""
+        names = {generate_saga_name() for _ in range(100)}
+
+        # Should have some variety (not all identical)
+        assert len(names) > 5
+
+
+# =============================================================================
+# Process Message Tests
+# =============================================================================
+
+
+class TestProcessMessage:
+    """Tests for message processing."""
+
+    @pytest.mark.asyncio
+    async def test_process_salt_response_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should handle salt_response operation."""
+        mock_neo4j.execute_query.return_value = []
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="salt",
+            payload={
+                "operation": "salt_response",
+                "response": "Task done.",
+                "storm_mode": True,
+            },
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.intent == "bard_result"
+        assert response.payload["storm_mode_skipped"] is True
+        assert response.payload["salted_response"] == "Task done."
+
+    @pytest.mark.asyncio
+    async def test_process_get_active_saga_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should handle get_active_saga operation."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "last_chapter": 2,
+                "last_told": now_ms,
+            }
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_active_saga"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["saga"]["saga_id"] == "saga-123"
+
+    @pytest.mark.asyncio
+    async def test_process_get_all_sagas_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should handle get_all_sagas operation."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "saga_id": "saga-1",
+                "saga_name": "Saga One",
+                "chapter_count": 3,
+                "last_told": now_ms,
+                "status": "active",
+            },
+            {
+                "saga_id": "saga-2",
+                "saga_name": "Saga Two",
+                "chapter_count": 5,
+                "last_told": now_ms - 1000,
+                "status": "complete",
+            },
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_all_sagas"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["count"] == 2
+        assert len(response.payload["sagas"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_process_unknown_operation(self, bard: BardOfTheBilge) -> None:
+        """Should return error for unknown operation."""
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="unknown",
+            payload={"operation": "invalid_operation"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert "error" in response.payload
+        assert "invalid_operation" in response.payload["error"]
+
+
+# =============================================================================
+# Statistics Tests
+# =============================================================================
+
+
+class TestLoreStatistics:
+    """Tests for lore statistics."""
+
+    @pytest.mark.asyncio
+    async def test_get_lore_statistics_empty(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, captain_uuid: str
+    ) -> None:
+        """Should return zero stats when no lore exists."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "total_sagas": 0,
+                "total_episodes": 0,
+                "avg_chapters_per_saga": None,
+            }
+        ]
+
+        stats = await bard.get_lore_statistics(trace_id="test-123")
+
+        assert stats["total_sagas"] == 0
+        assert stats["total_episodes"] == 0
+        assert stats["avg_chapters_per_saga"] == 0
+        assert stats["captain_uuid"] == captain_uuid
+        assert stats["canonical_tidbits_available"] == 10
+
+    @pytest.mark.asyncio
+    async def test_get_lore_statistics_with_data(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should return correct stats when lore exists."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "total_sagas": 5,
+                "total_episodes": 15,
+                "avg_chapters_per_saga": 3.0,
+            }
+        ]
+
+        stats = await bard.get_lore_statistics(trace_id="test-123")
+
+        assert stats["total_sagas"] == 5
+        assert stats["total_episodes"] == 15
+        assert stats["avg_chapters_per_saga"] == 3.0
+
+
+# =============================================================================
+# Saga Query Tests
+# =============================================================================
+
+
+class TestSagaQueries:
+    """Tests for saga query methods."""
+
+    @pytest.mark.asyncio
+    async def test_get_saga_by_id_found(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should return saga with chapters when found."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Chapter 1",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 2,
+                "content": "Chapter 2",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        saga = await bard.get_saga_by_id("saga-123", trace_id="test-123")
+
+        assert saga is not None
+        assert saga["saga_id"] == "saga-123"
+        assert saga["chapter_count"] == 2
+        assert len(saga["chapters"]) == 2
+        assert saga["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_get_saga_by_id_not_found(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should return None when saga not found."""
+        mock_neo4j.execute_query.return_value = []
+
+        saga = await bard.get_saga_by_id("nonexistent", trace_id="test-123")
+
+        assert saga is None
+
+    @pytest.mark.asyncio
+    async def test_get_saga_by_id_complete(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should mark saga as complete when max chapters reached."""
+        # Create 5 chapters (max_saga_chapters)
+        chapters = [
+            {
+                "uuid": f"ep-{i}",
+                "saga_id": "saga-123",
+                "saga_name": "Complete Saga",
+                "chapter": i,
+                "content": f"Chapter {i}",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            }
+            for i in range(1, 6)
+        ]
+        mock_neo4j.execute_query.return_value = chapters
+
+        saga = await bard.get_saga_by_id("saga-123", trace_id="test-123")
+
+        assert saga is not None
+        assert saga["status"] == "complete"
+        assert saga["chapter_count"] == 5
+
+
+# =============================================================================
+# Standalone Tidbit Tests
+# =============================================================================
+
+
+class TestStandaloneTidbit:
+    """Tests for standalone tidbit generation."""
+
+    def test_generate_standalone_tidbit_from_canonical(self, bard: BardOfTheBilge) -> None:
+        """Should return a canonical tidbit."""
+        tidbit = bard._generate_standalone_tidbit()
+
+        assert tidbit in CANONICAL_TIDBITS
+
+    def test_canonical_tidbits_not_empty(self) -> None:
+        """Canonical tidbits list should not be empty."""
+        assert len(CANONICAL_TIDBITS) > 0
+
+    def test_canonical_tidbits_are_strings(self) -> None:
+        """All canonical tidbits should be strings."""
+        for tidbit in CANONICAL_TIDBITS:
+            assert isinstance(tidbit, str)
+            assert len(tidbit) > 0
+
+
+# =============================================================================
+# Export Tests
+# =============================================================================
+
+
+class TestExports:
+    """Tests for module exports."""
+
+    def test_all_exports_available(self) -> None:
+        """All expected items should be exported."""
+        from klabautermann.agents.bard import __all__
+
+        expected = [
+            "CANONICAL_TIDBITS",
+            "ActiveSaga",
+            "BardConfig",
+            "BardOfTheBilge",
+            "LoreEpisode",
+            "SaltResult",
+            "generate_saga_name",
+        ]
+
+        for item in expected:
+            assert item in __all__
+
+    def test_agents_init_exports_bard(self) -> None:
+        """Bard should be exported from agents package."""
+        from klabautermann.agents import BardConfig, BardOfTheBilge, LoreEpisode
+
+        assert BardOfTheBilge is not None
+        assert BardConfig is not None
+        assert LoreEpisode is not None


### PR DESCRIPTION
## Summary

- Implement BardOfTheBilge agent - keeper of Klabautermann's mythology that generates whimsical story tidbits
- Add LoreEpisode node model with TOLD_TO (→Person) and EXPANDS_UPON (→LoreEpisode) relationships
- Include 34 unit tests covering salt_response, saga management, and statistics

## Key Features

- **Probability-based tidbits**: 7% chance to salt responses with story fragments
- **Storm mode respect**: Never interrupts urgent responses
- **Multi-chapter sagas**: Stories evolve across conversations (max 5 chapters)
- **Graph persistence**: LoreEpisode nodes with TOLD_TO and EXPANDS_UPON relationships
- **Canonical tidbits**: 10 whimsical story seeds about the Great Maelstrom of '98, the Kraken of notifications, etc.

## Test plan

- [x] All 34 unit tests pass
- [x] ruff check passes
- [x] mypy check passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)