### PR TITLE
feat(core): Add ontology validation and LLM pre-extraction (#11, #13)

### DIFF
--- a/src/klabautermann/agents/__init__.py
+++ b/src/klabautermann/agents/__init__.py
@@ -53,6 +53,11 @@ from klabautermann.agents.officer import (
     OfficerConfig,
     OfficerOfTheWatch,
 )
+from klabautermann.agents.pre_extraction import (
+    PreExtractionConfig,
+    PreExtractionEngine,
+    pre_extract_entities,
+)
 from klabautermann.agents.purser import (
     EmailManifest,
     Purser,
@@ -91,6 +96,8 @@ __all__ = [
     "MergeResult",
     "OfficerConfig",
     "OfficerOfTheWatch",
+    "PreExtractionConfig",
+    "PreExtractionEngine",
     "PruningAction",
     "PruningResult",
     "PruningRule",
@@ -105,4 +112,5 @@ __all__ = [
     "TheSieve",
     "classify_theme",
     "generate_saga_name",
+    "pre_extract_entities",
 ]

--- a/src/klabautermann/agents/ingestor.py
+++ b/src/klabautermann/agents/ingestor.py
@@ -1,9 +1,14 @@
 """
 Ingestor Agent for Klabautermann.
 
-Cleans user input and passes it to Graphiti for entity/relationship extraction.
-Graphiti handles the actual extraction using its internal LLM - this agent
-only preprocesses input to remove role prefixes, roleplay, and system mentions.
+Cleans user input, performs LLM-based pre-extraction to validate entities
+against the ontology, then passes to Graphiti for final extraction.
+
+Pre-extraction (#11, #13):
+- Uses Haiku for fast entity/relationship extraction BEFORE Graphiti
+- Validates entities against ontology schema (NodeLabel, RelationType)
+- Logs validation issues for audit trail
+- Falls back gracefully if pre-extraction fails
 
 Runs asynchronously (fire-and-forget) to avoid blocking user responses.
 
@@ -12,6 +17,7 @@ MENTIONED_IN relationships (Bug #350 fix).
 
 Reference: specs/architecture/AGENTS.md Section 1.2
 Task: T023 - Ingestor Agent
+Issues: #11 LLM-based pre-extraction, #13 Ontology validation
 """
 
 from __future__ import annotations
@@ -20,11 +26,17 @@ import re
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from klabautermann.agents.base_agent import BaseAgent
+from klabautermann.agents.pre_extraction import (
+    PreExtractionConfig,
+    PreExtractionEngine,
+)
 from klabautermann.core.logger import logger
 from klabautermann.core.workflow_inspector import log_thinking
 
 
 if TYPE_CHECKING:
+    from anthropic import AsyncAnthropic
+
     from klabautermann.core.models import AgentMessage
     from klabautermann.memory.graphiti_client import GraphitiClient
     from klabautermann.memory.neo4j_client import Neo4jClient
@@ -32,18 +44,25 @@ if TYPE_CHECKING:
 
 class Ingestor(BaseAgent):
     """
-    The Ingestor Agent: cleans input and passes to Graphiti for extraction.
+    The Ingestor Agent: cleans input, pre-extracts entities, and passes to Graphiti.
 
     Responsibilities:
     - Clean input text (remove role prefixes, roleplay markers, system mentions)
+    - Pre-extract entities using Haiku for ontology validation (#11, #13)
     - Log original vs cleaned text for audit trail
     - Pass cleaned text to Graphiti for entity/relationship extraction
     - Never block user responses (fire-and-forget)
 
+    Pre-extraction validates:
+    - Entity types match NodeLabel enum
+    - Relationship types match RelationType enum
+    - Relationship source/target types are compatible
+    - Property types and enum values are valid
+
     Graphiti handles:
-    - Entity extraction (Person, Organization, Project, etc.)
-    - Relationship extraction with semantic naming
-    - Entity resolution and deduplication
+    - Final entity extraction and resolution
+    - Semantic relationship naming
+    - Entity deduplication
     - Temporal handling (valid_at, invalid_at, expired_at)
     """
 
@@ -63,6 +82,8 @@ class Ingestor(BaseAgent):
         config: dict[str, Any] | None = None,
         graphiti_client: GraphitiClient | None = None,
         neo4j_client: Neo4jClient | None = None,
+        anthropic_client: AsyncAnthropic | None = None,
+        pre_extraction_config: PreExtractionConfig | None = None,
     ) -> None:
         """
         Initialize the Ingestor agent.
@@ -72,10 +93,21 @@ class Ingestor(BaseAgent):
             config: Agent configuration dict.
             graphiti_client: GraphitiClient instance for graph storage.
             neo4j_client: Neo4jClient for entity linking (Bug #350).
+            anthropic_client: Anthropic client for pre-extraction (#11).
+            pre_extraction_config: Configuration for pre-extraction (#13).
         """
         super().__init__(name, config)
         self.graphiti = graphiti_client
         self.neo4j = neo4j_client
+        self.anthropic = anthropic_client
+
+        # Initialize pre-extraction engine if client provided
+        self.pre_extraction: PreExtractionEngine | None = None
+        if anthropic_client:
+            self.pre_extraction = PreExtractionEngine(
+                anthropic_client=anthropic_client,
+                config=pre_extraction_config or PreExtractionConfig(),
+            )
 
     async def process_message(self, msg: AgentMessage) -> AgentMessage | None:
         """
@@ -143,6 +175,54 @@ class Ingestor(BaseAgent):
         )
 
         try:
+            # Pre-extract entities for validation (#11, #13)
+            pre_extraction_result = None
+            validation_result = None
+            if self.pre_extraction:
+                log_thinking(
+                    trace_id=msg.trace_id,
+                    agent_name=self.name,
+                    data={
+                        "step": "pre_extraction",
+                        "decision": "running LLM pre-extraction for ontology validation",
+                        "content_length": len(cleaned),
+                    },
+                )
+
+                pre_extraction_result, validation_result = await self.pre_extraction.extract(
+                    text=cleaned,
+                    trace_id=msg.trace_id,
+                )
+
+                # Log pre-extraction results
+                if pre_extraction_result:
+                    log_thinking(
+                        trace_id=msg.trace_id,
+                        agent_name=self.name,
+                        data={
+                            "step": "pre_extraction_complete",
+                            "entities_found": len(pre_extraction_result.entities),
+                            "relationships_found": len(pre_extraction_result.relationships),
+                            "validation_valid": validation_result.is_valid
+                            if validation_result
+                            else None,
+                            "validation_errors": validation_result.error_count
+                            if validation_result
+                            else 0,
+                            "validation_warnings": validation_result.warning_count
+                            if validation_result
+                            else 0,
+                        },
+                    )
+
+                    # Log entity details at debug level
+                    for entity in pre_extraction_result.entities:
+                        logger.debug(
+                            f"[WHISPER] Pre-extracted: {entity.entity_type} '{entity.name}' "
+                            f"(confidence: {entity.confidence:.0%})",
+                            extra={"trace_id": msg.trace_id, "agent_name": self.name},
+                        )
+
             # Log THINKING phase: Graphiti ingestion decision
             log_thinking(
                 trace_id=msg.trace_id,
@@ -153,6 +233,9 @@ class Ingestor(BaseAgent):
                     "content_length": len(cleaned),
                     "captain_uuid": captain_uuid,
                     "will_link_entities": bool(message_uuid and self.neo4j and self.graphiti),
+                    "pre_extracted_entities": len(pre_extraction_result.entities)
+                    if pre_extraction_result
+                    else 0,
                 },
             )
 

--- a/src/klabautermann/agents/pre_extraction.py
+++ b/src/klabautermann/agents/pre_extraction.py
@@ -1,0 +1,380 @@
+"""
+LLM-based entity pre-extraction for Klabautermann Ingestor.
+
+Uses Claude Haiku to extract entities and relationships from text BEFORE
+passing to Graphiti. Validates extractions against the ontology schema.
+
+This provides:
+1. Early validation - catch schema violations before Graphiti
+2. Transparency - see what entities were detected
+3. Quality control - filter low-confidence extractions
+
+Reference: specs/architecture/AGENTS.md Section 2.1
+Issues: #11, #13
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+from klabautermann.core.logger import logger
+from klabautermann.core.validation import (
+    VALID_ENTITY_TYPES,
+    VALID_RELATIONSHIP_TYPES,
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractionResult,
+    OntologyValidator,
+    ValidationResult,
+)
+from klabautermann.core.workflow_inspector import log_thinking
+
+
+if TYPE_CHECKING:
+    from anthropic import AsyncAnthropic
+
+
+# ===========================================================================
+# Pre-Extraction Configuration
+# ===========================================================================
+
+
+@dataclass
+class PreExtractionConfig:
+    """Configuration for LLM-based pre-extraction."""
+
+    enabled: bool = True
+    model: str = "claude-3-5-haiku-latest"  # Fast model for extraction
+    min_confidence: float = 0.5  # Minimum confidence to include entity
+    max_tokens: int = 2048
+    temperature: float = 0.0  # Deterministic extraction
+    validate_ontology: bool = True  # Validate against ontology before return
+    strict_validation: bool = False  # Treat warnings as errors
+
+
+# ===========================================================================
+# Extraction Response Model
+# ===========================================================================
+
+
+class LLMExtractionResponse(BaseModel):
+    """Schema for LLM extraction response."""
+
+    entities: list[dict[str, Any]] = Field(default_factory=list, description="Extracted entities")
+    relationships: list[dict[str, Any]] = Field(
+        default_factory=list, description="Extracted relationships"
+    )
+
+
+# ===========================================================================
+# Pre-Extraction Prompt
+# ===========================================================================
+
+EXTRACTION_SYSTEM_PROMPT = """You are an entity extraction specialist for a personal knowledge management system.
+Your task is to extract entities and relationships from user text according to a strict ontology.
+
+VALID ENTITY TYPES (use exact casing):
+{entity_types}
+
+VALID RELATIONSHIP TYPES (use exact casing):
+{relationship_types}
+
+EXTRACTION RULES:
+1. Only extract entities that are explicitly mentioned
+2. Assign confidence scores (0.0-1.0) based on how clearly the entity is identified
+3. For relationships, both source and target entities must be extracted
+4. Use WORKS_AT for employment (not "employed_by")
+5. Use REPORTS_TO for management hierarchy
+6. Use KNOWS for general interpersonal connections
+7. Family relationships use specific types: SPOUSE_OF, PARENT_OF, CHILD_OF, SIBLING_OF, FRIEND_OF
+8. Names should be title-cased ("John Smith" not "john smith")
+9. Email addresses should be lowercase
+
+PROPERTY GUIDELINES:
+- Person: Extract email, title (job title), phone if mentioned
+- Organization: Extract industry, domain (website) if mentioned
+- Task: Extract status (todo/in_progress/done), priority (high/medium/low), due_date
+- Project: Extract status (active/on_hold/completed), deadline
+- Event: Extract start_time, location if mentioned
+
+OUTPUT FORMAT:
+Return a JSON object with "entities" and "relationships" arrays:
+{{
+  "entities": [
+    {{"name": "John Smith", "entity_type": "Person", "properties": {{"email": "john@acme.com", "title": "PM"}}, "confidence": 0.95}}
+  ],
+  "relationships": [
+    {{"source_name": "John Smith", "source_type": "Person", "relationship_type": "WORKS_AT", "target_name": "Acme Corp", "target_type": "Organization", "properties": {{}}, "confidence": 0.9}}
+  ]
+}}
+
+IMPORTANT:
+- Only return the JSON object, no markdown or explanation
+- If no entities found, return {{"entities": [], "relationships": []}}
+- Do not invent entities not mentioned in the text"""
+
+EXTRACTION_USER_PROMPT = """Extract entities and relationships from this text:
+
+{text}
+
+Return ONLY a valid JSON object."""
+
+
+def _build_system_prompt() -> str:
+    """Build the system prompt with valid entity/relationship types."""
+    entity_types = ", ".join(sorted(VALID_ENTITY_TYPES))
+    relationship_types = ", ".join(sorted(VALID_RELATIONSHIP_TYPES)[:30]) + "..."
+
+    return EXTRACTION_SYSTEM_PROMPT.format(
+        entity_types=entity_types,
+        relationship_types=relationship_types,
+    )
+
+
+# ===========================================================================
+# Pre-Extraction Engine
+# ===========================================================================
+
+
+class PreExtractionEngine:
+    """
+    LLM-based entity pre-extraction engine.
+
+    Uses Claude Haiku to extract entities and relationships from text,
+    validates against the ontology, and returns structured results.
+    """
+
+    def __init__(
+        self,
+        anthropic_client: AsyncAnthropic,
+        config: PreExtractionConfig | None = None,
+    ) -> None:
+        """
+        Initialize the pre-extraction engine.
+
+        Args:
+            anthropic_client: Anthropic API client for LLM calls.
+            config: Pre-extraction configuration.
+        """
+        self.client = anthropic_client
+        self.config = config or PreExtractionConfig()
+        self.validator = OntologyValidator(strict=self.config.strict_validation)
+
+    async def extract(
+        self,
+        text: str,
+        trace_id: str | None = None,
+    ) -> tuple[ExtractionResult, ValidationResult | None]:
+        """
+        Extract entities and relationships from text using LLM.
+
+        Args:
+            text: The text to extract from.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            Tuple of (ExtractionResult, ValidationResult or None).
+            ValidationResult is None if validation is disabled.
+        """
+        if not self.config.enabled:
+            return ExtractionResult(source_text=text), None
+
+        if not text or len(text.strip()) < 10:
+            logger.debug(
+                "[WHISPER] Text too short for pre-extraction",
+                extra={"trace_id": trace_id, "text_length": len(text)},
+            )
+            return ExtractionResult(source_text=text), None
+
+        # Log thinking phase
+        if trace_id:
+            log_thinking(
+                trace_id=trace_id,
+                agent_name="pre_extraction",
+                data={
+                    "step": "llm_extraction_start",
+                    "text_length": len(text),
+                    "model": self.config.model,
+                },
+            )
+
+        try:
+            # Call LLM for extraction
+            extraction = await self._call_llm(text, trace_id)
+
+            # Filter by confidence
+            extraction = self._filter_by_confidence(extraction)
+
+            # Validate against ontology
+            validation_result = None
+            if self.config.validate_ontology:
+                validation_result = self.validator.validate_extraction(
+                    extraction, trace_id=trace_id
+                )
+
+                # Log validation result
+                if trace_id:
+                    log_thinking(
+                        trace_id=trace_id,
+                        agent_name="pre_extraction",
+                        data={
+                            "step": "ontology_validation",
+                            "is_valid": validation_result.is_valid,
+                            "error_count": validation_result.error_count,
+                            "warning_count": validation_result.warning_count,
+                        },
+                    )
+
+            logger.info(
+                f"[BEACON] Pre-extraction complete: {len(extraction.entities)} entities, "
+                f"{len(extraction.relationships)} relationships",
+                extra={
+                    "trace_id": trace_id,
+                    "entity_count": len(extraction.entities),
+                    "relationship_count": len(extraction.relationships),
+                    "validation_valid": validation_result.is_valid if validation_result else None,
+                },
+            )
+
+            return extraction, validation_result
+
+        except Exception as e:
+            logger.error(
+                f"[STORM] Pre-extraction failed: {e}",
+                extra={"trace_id": trace_id},
+                exc_info=True,
+            )
+            # Return empty result on failure - don't block ingestion
+            return ExtractionResult(source_text=text), None
+
+    async def _call_llm(
+        self,
+        text: str,
+        trace_id: str | None = None,
+    ) -> ExtractionResult:
+        """Call the LLM to extract entities and relationships."""
+        system_prompt = _build_system_prompt()
+        user_prompt = EXTRACTION_USER_PROMPT.format(text=text)
+
+        response = await self.client.messages.create(
+            model=self.config.model,
+            max_tokens=self.config.max_tokens,
+            temperature=self.config.temperature,
+            system=system_prompt,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        # Extract text content from response
+        content = response.content[0].text if response.content else "{}"
+
+        # Parse JSON response
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as parse_error:
+            logger.warning(
+                f"[SWELL] Failed to parse LLM extraction response: {parse_error}",
+                extra={"trace_id": trace_id, "response_preview": content[:200]},
+            )
+            return ExtractionResult(source_text=text)
+
+        # Convert to structured result
+        entities = []
+        for entity_data in data.get("entities", []):
+            try:
+                entities.append(
+                    ExtractedEntity(
+                        name=entity_data.get("name", ""),
+                        entity_type=entity_data.get("entity_type", ""),
+                        properties=entity_data.get("properties", {}),
+                        confidence=float(entity_data.get("confidence", 1.0)),
+                    )
+                )
+            except Exception as ex:
+                logger.debug(
+                    f"[WHISPER] Skipping malformed entity: {ex}",
+                    extra={"trace_id": trace_id},
+                )
+
+        relationships = []
+        for r in data.get("relationships", []):
+            try:
+                relationships.append(
+                    ExtractedRelationship(
+                        source_name=r.get("source_name", ""),
+                        source_type=r.get("source_type", ""),
+                        relationship_type=r.get("relationship_type", ""),
+                        target_name=r.get("target_name", ""),
+                        target_type=r.get("target_type", ""),
+                        properties=r.get("properties", {}),
+                        confidence=float(r.get("confidence", 1.0)),
+                    )
+                )
+            except Exception as ex:
+                logger.debug(
+                    f"[WHISPER] Skipping malformed relationship: {ex}",
+                    extra={"trace_id": trace_id},
+                )
+
+        return ExtractionResult(
+            entities=entities,
+            relationships=relationships,
+            source_text=text,
+        )
+
+    def _filter_by_confidence(
+        self,
+        extraction: ExtractionResult,
+    ) -> ExtractionResult:
+        """Filter out low-confidence extractions."""
+        min_conf = self.config.min_confidence
+
+        filtered_entities = [e for e in extraction.entities if e.confidence >= min_conf]
+        filtered_relationships = [r for r in extraction.relationships if r.confidence >= min_conf]
+
+        return ExtractionResult(
+            entities=filtered_entities,
+            relationships=filtered_relationships,
+            source_text=extraction.source_text,
+        )
+
+
+# ===========================================================================
+# Convenience Function
+# ===========================================================================
+
+
+async def pre_extract_entities(
+    text: str,
+    anthropic_client: AsyncAnthropic,
+    config: PreExtractionConfig | None = None,
+    trace_id: str | None = None,
+) -> tuple[ExtractionResult, ValidationResult | None]:
+    """
+    Convenience function to extract entities from text.
+
+    Args:
+        text: Text to extract from.
+        anthropic_client: Anthropic API client.
+        config: Optional configuration.
+        trace_id: Optional trace ID.
+
+    Returns:
+        Tuple of (ExtractionResult, ValidationResult or None).
+    """
+    engine = PreExtractionEngine(anthropic_client, config)
+    return await engine.extract(text, trace_id)
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "PreExtractionConfig",
+    "PreExtractionEngine",
+    "pre_extract_entities",
+]

--- a/src/klabautermann/core/__init__.py
+++ b/src/klabautermann/core/__init__.py
@@ -4,6 +4,7 @@ Core module - Foundation components for Klabautermann.
 Contains:
 - models: Pydantic data models
 - ontology: Graph schema constants
+- validation: Ontology validation for entity/relationship extraction
 - logger: Nautical logging system
 - exceptions: Custom exception types
 - workflow_inspector: Agent workflow inspection for debugging
@@ -31,6 +32,18 @@ from klabautermann.core.tracing import (
     reset_tracer,
     start_trace,
     trace_span,
+)
+from klabautermann.core.validation import (
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractionResult,
+    OntologyValidator,
+    ValidationIssue,
+    ValidationResult,
+    ValidationSeverity,
+    is_valid_entity_type,
+    is_valid_relationship_type,
+    validate_extraction,
 )
 from klabautermann.core.workflow_inspector import (
     WorkflowEntry,
@@ -63,6 +76,17 @@ __all__ = [
     "reset_tracer",
     "start_trace",
     "trace_span",
+    # Ontology Validation
+    "ExtractionResult",
+    "ExtractedEntity",
+    "ExtractedRelationship",
+    "OntologyValidator",
+    "ValidationIssue",
+    "ValidationResult",
+    "ValidationSeverity",
+    "is_valid_entity_type",
+    "is_valid_relationship_type",
+    "validate_extraction",
     # Workflow Inspector
     "WorkflowEntry",
     "WorkflowInspector",

--- a/src/klabautermann/core/validation.py
+++ b/src/klabautermann/core/validation.py
@@ -1,0 +1,693 @@
+"""
+Ontology validation for Klabautermann.
+
+Validates extracted entities and relationships against the Klabautermann ontology
+before ingestion. Ensures type safety and property constraints are met.
+
+Reference: specs/architecture/ONTOLOGY.md Section 7
+Issues: #11, #13
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from klabautermann.core.logger import logger
+from klabautermann.core.ontology import (
+    ENTITY_TYPES,
+    NodeLabel,
+    RelationType,
+)
+
+
+# ===========================================================================
+# Validation Result Types
+# ===========================================================================
+
+
+class ValidationSeverity(str, Enum):
+    """Severity levels for validation issues."""
+
+    ERROR = "error"  # Blocks ingestion
+    WARNING = "warning"  # Logged but allows ingestion
+    INFO = "info"  # Informational only
+
+
+@dataclass
+class ValidationIssue:
+    """A single validation issue found during entity/relationship validation."""
+
+    severity: ValidationSeverity
+    code: str  # Machine-readable code (e.g., "INVALID_ENTITY_TYPE")
+    message: str  # Human-readable description
+    entity_name: str | None = None
+    entity_type: str | None = None
+    property_name: str | None = None
+    expected: str | None = None
+    actual: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for logging/serialization."""
+        return {
+            "severity": self.severity.value,
+            "code": self.code,
+            "message": self.message,
+            "entity_name": self.entity_name,
+            "entity_type": self.entity_type,
+            "property_name": self.property_name,
+            "expected": self.expected,
+            "actual": self.actual,
+        }
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating an extraction against the ontology."""
+
+    is_valid: bool
+    issues: list[ValidationIssue] = field(default_factory=list)
+    entities_validated: int = 0
+    relationships_validated: int = 0
+
+    @property
+    def error_count(self) -> int:
+        """Count of ERROR severity issues."""
+        return sum(1 for i in self.issues if i.severity == ValidationSeverity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        """Count of WARNING severity issues."""
+        return sum(1 for i in self.issues if i.severity == ValidationSeverity.WARNING)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for logging/serialization."""
+        return {
+            "is_valid": self.is_valid,
+            "error_count": self.error_count,
+            "warning_count": self.warning_count,
+            "entities_validated": self.entities_validated,
+            "relationships_validated": self.relationships_validated,
+            "issues": [i.to_dict() for i in self.issues],
+        }
+
+
+# ===========================================================================
+# Pre-Extraction Entity Models
+# ===========================================================================
+
+
+class ExtractedEntity(BaseModel):
+    """An entity extracted by the LLM before Graphiti ingestion."""
+
+    name: str = Field(..., min_length=1, description="Entity name")
+    entity_type: str = Field(..., description="Entity type from ontology")
+    properties: dict[str, Any] = Field(default_factory=dict, description="Entity properties")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Extraction confidence")
+
+    @field_validator("entity_type")
+    @classmethod
+    def validate_entity_type(cls, v: str) -> str:
+        """Ensure entity type uses proper casing."""
+        # Allow both "Person" and "person" - normalize to title case
+        return v.title() if v.islower() else v
+
+
+class ExtractedRelationship(BaseModel):
+    """A relationship extracted by the LLM before Graphiti ingestion."""
+
+    source_name: str = Field(..., min_length=1, description="Source entity name")
+    source_type: str = Field(..., description="Source entity type")
+    relationship_type: str = Field(..., description="Relationship type from ontology")
+    target_name: str = Field(..., min_length=1, description="Target entity name")
+    target_type: str = Field(..., description="Target entity type")
+    properties: dict[str, Any] = Field(default_factory=dict, description="Relationship properties")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Extraction confidence")
+
+    @field_validator("relationship_type")
+    @classmethod
+    def validate_relationship_type(cls, v: str) -> str:
+        """Ensure relationship type uses proper casing (UPPER_SNAKE)."""
+        return v.upper()
+
+
+class ExtractionResult(BaseModel):
+    """Complete extraction result from LLM pre-extraction."""
+
+    entities: list[ExtractedEntity] = Field(default_factory=list)
+    relationships: list[ExtractedRelationship] = Field(default_factory=list)
+    source_text: str = Field(default="", description="Original text that was analyzed")
+
+
+# ===========================================================================
+# Ontology Validator
+# ===========================================================================
+
+
+# Valid entity types from the ontology (NodeLabel enum values)
+VALID_ENTITY_TYPES: set[str] = {label.value for label in NodeLabel}
+
+# Valid relationship types from the ontology (RelationType enum values)
+VALID_RELATIONSHIP_TYPES: set[str] = {rel.value for rel in RelationType}
+
+# Relationship source/target constraints
+# Maps relationship type to allowed (source_types, target_types)
+RELATIONSHIP_CONSTRAINTS: dict[str, tuple[set[str], set[str]]] = {
+    # Professional Context
+    "WORKS_AT": ({"Person"}, {"Organization"}),
+    "REPORTS_TO": ({"Person"}, {"Person"}),
+    "AFFILIATED_WITH": ({"Person"}, {"Organization"}),
+    # Action Hierarchy
+    "CONTRIBUTES_TO": ({"Project"}, {"Goal"}),
+    "PART_OF": ({"Task", "Project"}, {"Project"}),
+    "SUBTASK_OF": ({"Task"}, {"Task"}),
+    "BLOCKS": ({"Task"}, {"Task"}),
+    "DEPENDS_ON": ({"Task"}, {"Task"}),
+    "ASSIGNED_TO": ({"Task"}, {"Person"}),
+    # Spatial Context
+    "HELD_AT": ({"Event"}, {"Location"}),
+    "LOCATED_IN": ({"Person", "Organization"}, {"Location"}),
+    "CREATED_AT_LOCATION": ({"Note"}, {"Location"}),
+    # Knowledge Linking
+    "REFERENCES": ({"Note", "Resource"}, {"Resource"}),
+    "SUMMARIZES": ({"Note"}, {"Event", "Thread"}),
+    "SUMMARY_OF": ({"Note"}, {"Thread"}),
+    "MENTIONED_IN": (
+        {"Person", "Organization", "Project", "Task"},
+        {"Note", "Event", "Message"},
+    ),
+    "DISCUSSED": ({"Event"}, {"Project", "Task", "Goal"}),
+    # Event Context
+    "ATTENDED": ({"Person"}, {"Event"}),
+    "ORGANIZED_BY": ({"Event"}, {"Person", "Organization"}),
+    # Email Context
+    "SENT_BY": ({"Email"}, {"Person"}),
+    "SENT_TO": ({"Email"}, {"Person"}),
+    "PART_OF_EMAIL_THREAD": ({"Email"}, {"Thread"}),
+    # Calendar Context
+    "ATTENDED_BY": ({"CalendarEvent"}, {"Person"}),
+    "HELD_AT_LOCATION": ({"CalendarEvent"}, {"Location"}),
+    # Information Lineage
+    "VERSION_OF": ({"Resource"}, {"Resource"}),
+    "REPLIES_TO": ({"Note", "Message"}, {"Note", "Message"}),
+    "ATTACHED_TO": ({"Resource"}, {"Event", "Note", "Email"}),
+    # Interpersonal Context
+    "KNOWS": ({"Person"}, {"Person"}),
+    "INTRODUCED_BY": ({"Person"}, {"Person"}),
+    # Family & Personal Relationships
+    "FAMILY_OF": ({"Person"}, {"Person"}),
+    "SPOUSE_OF": ({"Person"}, {"Person"}),
+    "PARENT_OF": ({"Person"}, {"Person"}),
+    "CHILD_OF": ({"Person"}, {"Person"}),
+    "SIBLING_OF": ({"Person"}, {"Person"}),
+    "FRIEND_OF": ({"Person"}, {"Person"}),
+    # Personal Life
+    "PRACTICES": ({"Person"}, {"Hobby"}),
+    "INTERESTED_IN": ({"Person"}, {"Hobby", "Note", "Project"}),
+    "PREFERS": ({"Person"}, {"Preference"}),
+    "OWNS": ({"Person"}, {"Pet"}),
+    "CARES_FOR": ({"Person"}, {"Pet"}),
+    "RECORDED": ({"Person"}, {"HealthMetric"}),
+    "ACHIEVES": ({"Person"}, {"Milestone"}),
+    "FOLLOWS_ROUTINE": ({"Person"}, {"Routine"}),
+    # Community (Knowledge Islands)
+    "PART_OF_ISLAND": (
+        {"Person", "Project", "Note", "Hobby", "Organization", "Task"},
+        {"Community"},
+    ),
+    # Lore System
+    "EXPANDS_UPON": ({"LoreEpisode"}, {"LoreEpisode"}),
+    "TOLD_TO": ({"LoreEpisode"}, {"Person"}),
+    "SAGA_STARTED_BY": ({"LoreEpisode"}, {"Person"}),
+    # Thread Management
+    "CONTAINS": ({"Thread"}, {"Message"}),
+    "PRECEDES": ({"Message"}, {"Message"}),
+    # Temporal Spine
+    "OCCURRED_ON": ({"Event", "JournalEntry", "Note"}, {"Day"}),
+    # Categorization
+    "TAGGED_WITH": ({"Note", "Project", "Resource"}, {"Tag"}),
+}
+
+# Property type constraints for entity types
+# Maps entity_type -> property_name -> expected Python type
+PROPERTY_TYPE_CONSTRAINTS: dict[str, dict[str, type]] = {
+    "Person": {
+        "email": str,
+        "title": str,
+        "phone": str,
+    },
+    "Organization": {
+        "industry": str,
+        "domain": str,
+    },
+    "Project": {
+        "status": str,
+        "deadline": str,
+    },
+    "Task": {
+        "status": str,
+        "priority": str,
+        "due_date": str,
+    },
+    "Event": {
+        "start_time": str,
+        "event_location": str,
+    },
+    "Location": {
+        "address": str,
+        "location_type": str,
+    },
+    "Hobby": {
+        "category": str,
+        "skill_level": str,
+        "frequency": str,
+    },
+    "HealthMetric": {
+        "metric_type": str,
+        "unit": str,
+    },
+    "Pet": {
+        "species": str,
+        "breed": str,
+    },
+    "Milestone": {
+        "category": str,
+        "significance": str,
+    },
+    "Routine": {
+        "frequency": str,
+        "time_of_day": str,
+        "duration_minutes": int,
+        "is_active": bool,
+    },
+    "Preference": {
+        "category": str,
+        "sentiment": str,
+        "strength": float,
+    },
+}
+
+# Valid enum values for status fields
+STATUS_CONSTRAINTS: dict[str, dict[str, set[str]]] = {
+    "Project": {
+        "status": {"active", "on_hold", "completed", "cancelled"},
+    },
+    "Task": {
+        "status": {"todo", "in_progress", "done", "cancelled"},
+        "priority": {"urgent", "high", "medium", "low"},
+    },
+    "Goal": {
+        "status": {"active", "achieved", "abandoned"},
+    },
+    "Thread": {
+        "status": {"active", "archiving", "archived"},
+    },
+    "Routine": {
+        "frequency": {"daily", "weekly", "monthly", "weekdays", "weekends"},
+        "time_of_day": {"morning", "afternoon", "evening", "night"},
+    },
+    "Preference": {
+        "sentiment": {"likes", "dislikes", "love", "hate", "neutral", "prefers", "avoids"},
+    },
+    "Milestone": {
+        "significance": {"minor", "moderate", "major", "life_changing"},
+    },
+    "Hobby": {
+        "skill_level": {"beginner", "intermediate", "advanced", "expert"},
+        "frequency": {"daily", "weekly", "monthly", "occasional"},
+    },
+}
+
+
+class OntologyValidator:
+    """
+    Validates extracted entities and relationships against the Klabautermann ontology.
+
+    Performs the following validations:
+    1. Entity type validation (must be in NodeLabel enum)
+    2. Relationship type validation (must be in RelationType enum)
+    3. Relationship constraint validation (source/target type compatibility)
+    4. Property type validation
+    5. Enum value validation (status fields, etc.)
+    """
+
+    def __init__(self, strict: bool = False) -> None:
+        """
+        Initialize the validator.
+
+        Args:
+            strict: If True, warnings are treated as errors.
+        """
+        self.strict = strict
+
+    def validate_extraction(
+        self, extraction: ExtractionResult, trace_id: str | None = None
+    ) -> ValidationResult:
+        """
+        Validate a complete extraction result against the ontology.
+
+        Args:
+            extraction: The extraction result to validate.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            ValidationResult with any issues found.
+        """
+        issues: list[ValidationIssue] = []
+        entities_validated = 0
+        relationships_validated = 0
+
+        # Validate each entity
+        for entity in extraction.entities:
+            entity_issues = self._validate_entity(entity)
+            issues.extend(entity_issues)
+            entities_validated += 1
+
+        # Validate each relationship
+        for relationship in extraction.relationships:
+            rel_issues = self._validate_relationship(relationship)
+            issues.extend(rel_issues)
+            relationships_validated += 1
+
+        # Determine overall validity
+        has_errors = any(i.severity == ValidationSeverity.ERROR for i in issues)
+        has_warnings = any(i.severity == ValidationSeverity.WARNING for i in issues)
+        is_valid = not has_errors and (not self.strict or not has_warnings)
+
+        # Log validation result
+        if issues:
+            log_level = "warning" if is_valid else "error"
+            getattr(logger, log_level)(
+                f"[SWELL] Ontology validation completed with {len(issues)} issues",
+                extra={
+                    "trace_id": trace_id,
+                    "is_valid": is_valid,
+                    "error_count": sum(1 for i in issues if i.severity == ValidationSeverity.ERROR),
+                    "warning_count": sum(
+                        1 for i in issues if i.severity == ValidationSeverity.WARNING
+                    ),
+                    "entities_validated": entities_validated,
+                    "relationships_validated": relationships_validated,
+                },
+            )
+
+        return ValidationResult(
+            is_valid=is_valid,
+            issues=issues,
+            entities_validated=entities_validated,
+            relationships_validated=relationships_validated,
+        )
+
+    def validate_entity(self, entity: ExtractedEntity) -> ValidationResult:
+        """
+        Validate a single entity against the ontology.
+
+        Args:
+            entity: The entity to validate.
+
+        Returns:
+            ValidationResult with any issues found.
+        """
+        issues = self._validate_entity(entity)
+        has_errors = any(i.severity == ValidationSeverity.ERROR for i in issues)
+        has_warnings = any(i.severity == ValidationSeverity.WARNING for i in issues)
+        is_valid = not has_errors and (not self.strict or not has_warnings)
+        return ValidationResult(
+            is_valid=is_valid,
+            issues=issues,
+            entities_validated=1,
+        )
+
+    def validate_relationship(self, relationship: ExtractedRelationship) -> ValidationResult:
+        """
+        Validate a single relationship against the ontology.
+
+        Args:
+            relationship: The relationship to validate.
+
+        Returns:
+            ValidationResult with any issues found.
+        """
+        issues = self._validate_relationship(relationship)
+        has_errors = any(i.severity == ValidationSeverity.ERROR for i in issues)
+        return ValidationResult(
+            is_valid=not has_errors,
+            issues=issues,
+            relationships_validated=1,
+        )
+
+    def _validate_entity(self, entity: ExtractedEntity) -> list[ValidationIssue]:
+        """Validate a single entity and return any issues."""
+        issues: list[ValidationIssue] = []
+
+        # 1. Validate entity type
+        if entity.entity_type not in VALID_ENTITY_TYPES:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    code="INVALID_ENTITY_TYPE",
+                    message=f"Unknown entity type: {entity.entity_type}",
+                    entity_name=entity.name,
+                    entity_type=entity.entity_type,
+                    expected=", ".join(sorted(VALID_ENTITY_TYPES)[:10]) + "...",
+                    actual=entity.entity_type,
+                )
+            )
+            # Can't validate properties if type is invalid
+            return issues
+
+        # 2. Validate property types
+        type_constraints = PROPERTY_TYPE_CONSTRAINTS.get(entity.entity_type, {})
+        for prop_name, prop_value in entity.properties.items():
+            if prop_name in type_constraints:
+                expected_type = type_constraints[prop_name]
+                if isinstance(expected_type, tuple):
+                    if not isinstance(prop_value, expected_type):
+                        issues.append(
+                            ValidationIssue(
+                                severity=ValidationSeverity.WARNING,
+                                code="INVALID_PROPERTY_TYPE",
+                                message=f"Property '{prop_name}' has wrong type",
+                                entity_name=entity.name,
+                                entity_type=entity.entity_type,
+                                property_name=prop_name,
+                                expected=str(expected_type),
+                                actual=type(prop_value).__name__,
+                            )
+                        )
+                elif not isinstance(prop_value, expected_type):
+                    issues.append(
+                        ValidationIssue(
+                            severity=ValidationSeverity.WARNING,
+                            code="INVALID_PROPERTY_TYPE",
+                            message=f"Property '{prop_name}' has wrong type",
+                            entity_name=entity.name,
+                            entity_type=entity.entity_type,
+                            property_name=prop_name,
+                            expected=expected_type.__name__,
+                            actual=type(prop_value).__name__,
+                        )
+                    )
+
+        # 3. Validate enum values (status, priority, etc.)
+        enum_constraints = STATUS_CONSTRAINTS.get(entity.entity_type, {})
+        for prop_name, valid_values in enum_constraints.items():
+            if prop_name in entity.properties:
+                prop_value = entity.properties[prop_name]
+                if isinstance(prop_value, str):
+                    # Normalize to lowercase for comparison
+                    normalized = prop_value.lower()
+                    if normalized not in valid_values:
+                        issues.append(
+                            ValidationIssue(
+                                severity=ValidationSeverity.WARNING,
+                                code="INVALID_ENUM_VALUE",
+                                message=f"Property '{prop_name}' has invalid value",
+                                entity_name=entity.name,
+                                entity_type=entity.entity_type,
+                                property_name=prop_name,
+                                expected=", ".join(sorted(valid_values)),
+                                actual=prop_value,
+                            )
+                        )
+
+        # 4. Validate low confidence extractions
+        if entity.confidence < 0.5:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.INFO,
+                    code="LOW_CONFIDENCE",
+                    message=f"Entity extraction has low confidence: {entity.confidence:.0%}",
+                    entity_name=entity.name,
+                    entity_type=entity.entity_type,
+                )
+            )
+
+        return issues
+
+    def _validate_relationship(self, relationship: ExtractedRelationship) -> list[ValidationIssue]:
+        """Validate a single relationship and return any issues."""
+        issues: list[ValidationIssue] = []
+        rel_type = relationship.relationship_type
+
+        # 1. Validate relationship type
+        if rel_type not in VALID_RELATIONSHIP_TYPES:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    code="INVALID_RELATIONSHIP_TYPE",
+                    message=f"Unknown relationship type: {rel_type}",
+                    entity_name=f"{relationship.source_name} -> {relationship.target_name}",
+                    expected=", ".join(sorted(VALID_RELATIONSHIP_TYPES)[:10]) + "...",
+                    actual=rel_type,
+                )
+            )
+            return issues
+
+        # 2. Validate source/target entity types
+        source_type = relationship.source_type.title()
+        target_type = relationship.target_type.title()
+
+        if source_type not in VALID_ENTITY_TYPES:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    code="INVALID_SOURCE_TYPE",
+                    message=f"Unknown source entity type for {rel_type}",
+                    entity_name=relationship.source_name,
+                    entity_type=source_type,
+                )
+            )
+
+        if target_type not in VALID_ENTITY_TYPES:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.ERROR,
+                    code="INVALID_TARGET_TYPE",
+                    message=f"Unknown target entity type for {rel_type}",
+                    entity_name=relationship.target_name,
+                    entity_type=target_type,
+                )
+            )
+
+        # 3. Validate relationship constraints (source/target compatibility)
+        if rel_type in RELATIONSHIP_CONSTRAINTS:
+            allowed_sources, allowed_targets = RELATIONSHIP_CONSTRAINTS[rel_type]
+
+            if source_type not in allowed_sources:
+                issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.ERROR,
+                        code="INVALID_SOURCE_FOR_RELATIONSHIP",
+                        message=f"{rel_type} cannot have {source_type} as source",
+                        entity_name=relationship.source_name,
+                        entity_type=source_type,
+                        expected=", ".join(sorted(allowed_sources)),
+                        actual=source_type,
+                    )
+                )
+
+            if target_type not in allowed_targets:
+                issues.append(
+                    ValidationIssue(
+                        severity=ValidationSeverity.ERROR,
+                        code="INVALID_TARGET_FOR_RELATIONSHIP",
+                        message=f"{rel_type} cannot have {target_type} as target",
+                        entity_name=relationship.target_name,
+                        entity_type=target_type,
+                        expected=", ".join(sorted(allowed_targets)),
+                        actual=target_type,
+                    )
+                )
+
+        # 4. Validate low confidence extractions
+        if relationship.confidence < 0.5:
+            issues.append(
+                ValidationIssue(
+                    severity=ValidationSeverity.INFO,
+                    code="LOW_CONFIDENCE",
+                    message=f"Relationship extraction has low confidence: {relationship.confidence:.0%}",
+                    entity_name=f"{relationship.source_name} -{rel_type}-> {relationship.target_name}",
+                )
+            )
+
+        return issues
+
+    def is_valid_entity_type(self, entity_type: str) -> bool:
+        """Check if an entity type is valid according to the ontology."""
+        return entity_type in VALID_ENTITY_TYPES or entity_type.title() in VALID_ENTITY_TYPES
+
+    def is_valid_relationship_type(self, relationship_type: str) -> bool:
+        """Check if a relationship type is valid according to the ontology."""
+        return relationship_type.upper() in VALID_RELATIONSHIP_TYPES
+
+    def get_valid_entity_types(self) -> list[str]:
+        """Return list of valid entity types."""
+        return sorted(VALID_ENTITY_TYPES)
+
+    def get_valid_relationship_types(self) -> list[str]:
+        """Return list of valid relationship types."""
+        return sorted(VALID_RELATIONSHIP_TYPES)
+
+    def get_entity_type_model(self, entity_type: str) -> type[BaseModel] | None:
+        """Get the Pydantic model for an entity type, if available."""
+        return ENTITY_TYPES.get(entity_type)
+
+
+# ===========================================================================
+# Convenience Functions
+# ===========================================================================
+
+
+def validate_extraction(
+    extraction: ExtractionResult, strict: bool = False, trace_id: str | None = None
+) -> ValidationResult:
+    """
+    Validate an extraction result against the ontology.
+
+    Args:
+        extraction: The extraction to validate.
+        strict: If True, treat warnings as errors.
+        trace_id: Optional trace ID for logging.
+
+    Returns:
+        ValidationResult with validation outcome and any issues.
+    """
+    validator = OntologyValidator(strict=strict)
+    return validator.validate_extraction(extraction, trace_id=trace_id)
+
+
+def is_valid_entity_type(entity_type: str) -> bool:
+    """Check if an entity type is valid according to the ontology."""
+    return entity_type in VALID_ENTITY_TYPES or entity_type.title() in VALID_ENTITY_TYPES
+
+
+def is_valid_relationship_type(relationship_type: str) -> bool:
+    """Check if a relationship type is valid according to the ontology."""
+    return relationship_type.upper() in VALID_RELATIONSHIP_TYPES
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "PROPERTY_TYPE_CONSTRAINTS",
+    "RELATIONSHIP_CONSTRAINTS",
+    "STATUS_CONSTRAINTS",
+    "VALID_ENTITY_TYPES",
+    "VALID_RELATIONSHIP_TYPES",
+    "ExtractedEntity",
+    "ExtractedRelationship",
+    "ExtractionResult",
+    "OntologyValidator",
+    "ValidationIssue",
+    "ValidationResult",
+    "ValidationSeverity",
+    "is_valid_entity_type",
+    "is_valid_relationship_type",
+    "validate_extraction",
+]

--- a/tests/unit/test_pre_extraction.py
+++ b/tests/unit/test_pre_extraction.py
@@ -1,0 +1,443 @@
+"""
+Tests for LLM-based pre-extraction module.
+
+Tests the PreExtractionEngine which uses Claude Haiku to extract entities
+and relationships before Graphiti ingestion.
+
+Issues: #11, #13
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klabautermann.agents.pre_extraction import (
+    PreExtractionConfig,
+    PreExtractionEngine,
+    pre_extract_entities,
+)
+
+
+# Disable workflow inspector logging during tests
+@pytest.fixture(autouse=True)
+def disable_workflow_inspector():
+    """Disable workflow inspector logging for tests."""
+    with patch("klabautermann.agents.pre_extraction.log_thinking", return_value=None):
+        yield
+
+
+# ===========================================================================
+# Test PreExtractionConfig
+# ===========================================================================
+
+
+class TestPreExtractionConfig:
+    """Tests for PreExtractionConfig."""
+
+    def test_default_values(self) -> None:
+        """Test default configuration values."""
+        config = PreExtractionConfig()
+        assert config.enabled is True
+        assert config.model == "claude-3-5-haiku-latest"
+        assert config.min_confidence == 0.5
+        assert config.max_tokens == 2048
+        assert config.temperature == 0.0
+        assert config.validate_ontology is True
+        assert config.strict_validation is False
+
+    def test_custom_values(self) -> None:
+        """Test custom configuration values."""
+        config = PreExtractionConfig(
+            enabled=False,
+            model="claude-3-sonnet",
+            min_confidence=0.7,
+            strict_validation=True,
+        )
+        assert config.enabled is False
+        assert config.model == "claude-3-sonnet"
+        assert config.min_confidence == 0.7
+        assert config.strict_validation is True
+
+
+# ===========================================================================
+# Test PreExtractionEngine
+# ===========================================================================
+
+
+class TestPreExtractionEngine:
+    """Tests for PreExtractionEngine."""
+
+    @pytest.fixture
+    def mock_anthropic(self) -> AsyncMock:
+        """Create a mock Anthropic client."""
+        mock = AsyncMock()
+        return mock
+
+    @pytest.fixture
+    def engine(self, mock_anthropic: AsyncMock) -> PreExtractionEngine:
+        """Create an extraction engine with mock client."""
+        return PreExtractionEngine(anthropic_client=mock_anthropic)
+
+    @pytest.fixture
+    def disabled_engine(self, mock_anthropic: AsyncMock) -> PreExtractionEngine:
+        """Create a disabled extraction engine."""
+        config = PreExtractionConfig(enabled=False)
+        return PreExtractionEngine(anthropic_client=mock_anthropic, config=config)
+
+    # --- Basic Extraction Tests ---
+
+    @pytest.mark.asyncio
+    async def test_extract_returns_empty_when_disabled(
+        self, disabled_engine: PreExtractionEngine
+    ) -> None:
+        """Test that disabled engine returns empty result."""
+        result, validation = await disabled_engine.extract("Test text")
+        assert result.entities == []
+        assert result.relationships == []
+        assert validation is None
+
+    @pytest.mark.asyncio
+    async def test_extract_returns_empty_for_short_text(self, engine: PreExtractionEngine) -> None:
+        """Test that very short text returns empty result."""
+        result, validation = await engine.extract("Hi")
+        assert result.entities == []
+        assert result.relationships == []
+
+    @pytest.mark.asyncio
+    async def test_extract_calls_llm(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test that extraction calls the LLM."""
+        # Setup mock response
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "John Smith",
+                                "entity_type": "Person",
+                                "properties": {"email": "john@example.com"},
+                                "confidence": 0.95,
+                            }
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, validation = await engine.extract("I met John Smith (john@example.com) today.")
+
+        # Verify LLM was called
+        mock_anthropic.messages.create.assert_called_once()
+
+        # Verify extraction result
+        assert len(result.entities) == 1
+        assert result.entities[0].name == "John Smith"
+        assert result.entities[0].entity_type == "Person"
+        assert result.entities[0].confidence == 0.95
+
+    @pytest.mark.asyncio
+    async def test_extract_with_relationships(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test extraction of entities and relationships."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "John Smith",
+                                "entity_type": "Person",
+                                "properties": {},
+                                "confidence": 0.9,
+                            },
+                            {
+                                "name": "Acme Corp",
+                                "entity_type": "Organization",
+                                "properties": {},
+                                "confidence": 0.85,
+                            },
+                        ],
+                        "relationships": [
+                            {
+                                "source_name": "John Smith",
+                                "source_type": "Person",
+                                "relationship_type": "WORKS_AT",
+                                "target_name": "Acme Corp",
+                                "target_type": "Organization",
+                                "properties": {},
+                                "confidence": 0.8,
+                            }
+                        ],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, validation = await engine.extract("John Smith works at Acme Corp as a PM.")
+
+        assert len(result.entities) == 2
+        assert len(result.relationships) == 1
+        assert result.relationships[0].relationship_type == "WORKS_AT"
+
+    # --- Confidence Filtering ---
+
+    @pytest.mark.asyncio
+    async def test_filters_low_confidence_entities(self, mock_anthropic: AsyncMock) -> None:
+        """Test that low confidence entities are filtered out."""
+        config = PreExtractionConfig(min_confidence=0.6)
+        engine = PreExtractionEngine(anthropic_client=mock_anthropic, config=config)
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "High Confidence",
+                                "entity_type": "Person",
+                                "properties": {},
+                                "confidence": 0.9,
+                            },
+                            {
+                                "name": "Low Confidence",
+                                "entity_type": "Person",
+                                "properties": {},
+                                "confidence": 0.4,  # Below threshold
+                            },
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, _ = await engine.extract("Test text with entities")
+
+        # Only high confidence entity should remain
+        assert len(result.entities) == 1
+        assert result.entities[0].name == "High Confidence"
+
+    # --- Validation Integration ---
+
+    @pytest.mark.asyncio
+    async def test_validates_extraction(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test that extraction result is validated."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "John",
+                                "entity_type": "Person",
+                                "properties": {},
+                                "confidence": 0.9,
+                            }
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, validation = await engine.extract("I met John today.")
+
+        assert validation is not None
+        assert validation.is_valid
+        assert validation.entities_validated == 1
+
+    @pytest.mark.asyncio
+    async def test_validation_catches_invalid_types(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test that validation catches invalid entity types."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "Test Entity",
+                                "entity_type": "InvalidType",  # Invalid
+                                "properties": {},
+                                "confidence": 0.9,
+                            }
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        # Text must be >= 10 chars to trigger extraction
+        result, validation = await engine.extract("This is test text for extraction validation")
+
+        assert validation is not None
+        assert not validation.is_valid
+        assert validation.error_count > 0
+
+    @pytest.mark.asyncio
+    async def test_validation_disabled(self, mock_anthropic: AsyncMock) -> None:
+        """Test extraction without validation."""
+        config = PreExtractionConfig(validate_ontology=False)
+        engine = PreExtractionEngine(anthropic_client=mock_anthropic, config=config)
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text=json.dumps({"entities": [], "relationships": []}))]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, validation = await engine.extract("Test text")
+
+        assert validation is None  # No validation performed
+
+    # --- Error Handling ---
+
+    @pytest.mark.asyncio
+    async def test_handles_invalid_json_response(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test graceful handling of invalid JSON from LLM."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="This is not valid JSON")]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        result, validation = await engine.extract("Test text for extraction")
+
+        # Should return empty result, not crash
+        assert result.entities == []
+        assert result.relationships == []
+
+    @pytest.mark.asyncio
+    async def test_handles_llm_exception(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test graceful handling of LLM exceptions."""
+        mock_anthropic.messages.create = AsyncMock(side_effect=Exception("LLM API error"))
+
+        # Text must be >= 10 chars to trigger extraction
+        result, validation = await engine.extract("This is test text for extraction")
+
+        # Should return empty result, not crash
+        assert result.entities == []
+        assert result.relationships == []
+
+    @pytest.mark.asyncio
+    async def test_handles_malformed_entity(
+        self, engine: PreExtractionEngine, mock_anthropic: AsyncMock
+    ) -> None:
+        """Test handling of malformed entity data."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "Valid Entity",
+                                "entity_type": "Person",
+                                "confidence": 0.9,
+                            },
+                            {
+                                # Missing required fields
+                                "name": "",
+                                "entity_type": "",
+                            },
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        # Text must be >= 10 chars to trigger extraction
+        result, _ = await engine.extract("This is test text for entity extraction")
+
+        # Valid entity should be extracted, malformed one skipped
+        assert len(result.entities) == 1
+        assert result.entities[0].name == "Valid Entity"
+
+
+# ===========================================================================
+# Test Convenience Function
+# ===========================================================================
+
+
+class TestPreExtractEntities:
+    """Tests for the pre_extract_entities convenience function."""
+
+    @pytest.mark.asyncio
+    async def test_convenience_function(self) -> None:
+        """Test the pre_extract_entities convenience function."""
+        mock_anthropic = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                text=json.dumps(
+                    {
+                        "entities": [
+                            {
+                                "name": "Test Person",
+                                "entity_type": "Person",
+                                "properties": {},
+                                "confidence": 0.9,
+                            }
+                        ],
+                        "relationships": [],
+                    }
+                )
+            )
+        ]
+        mock_anthropic.messages.create = AsyncMock(return_value=mock_response)
+
+        # Text must be >= 10 chars to trigger extraction
+        with patch("klabautermann.agents.pre_extraction.log_thinking", return_value=None):
+            result, validation = await pre_extract_entities(
+                text="This is a test text for entity extraction",
+                anthropic_client=mock_anthropic,
+            )
+
+        assert len(result.entities) == 1
+        assert validation is not None
+
+
+# ===========================================================================
+# Test Module Exports
+# ===========================================================================
+
+
+class TestModuleExports:
+    """Tests for module exports."""
+
+    def test_exports_from_agents_module(self) -> None:
+        """Test that pre-extraction exports are available from agents module."""
+        from klabautermann.agents import (
+            PreExtractionConfig,
+            PreExtractionEngine,
+            pre_extract_entities,
+        )
+
+        assert PreExtractionConfig is not None
+        assert PreExtractionEngine is not None
+        assert pre_extract_entities is not None
+
+        # Test config defaults
+        config = PreExtractionConfig()
+        assert config.enabled is True

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,583 @@
+"""
+Tests for ontology validation module.
+
+Tests the OntologyValidator which validates extracted entities and relationships
+against the Klabautermann ontology schema.
+
+Issues: #11, #13
+"""
+
+import pytest
+
+from klabautermann.core.validation import (
+    RELATIONSHIP_CONSTRAINTS,
+    VALID_ENTITY_TYPES,
+    VALID_RELATIONSHIP_TYPES,
+    ExtractedEntity,
+    ExtractedRelationship,
+    ExtractionResult,
+    OntologyValidator,
+    ValidationIssue,
+    ValidationResult,
+    ValidationSeverity,
+    is_valid_entity_type,
+    is_valid_relationship_type,
+    validate_extraction,
+)
+
+
+# ===========================================================================
+# Test ValidationSeverity
+# ===========================================================================
+
+
+class TestValidationSeverity:
+    """Tests for ValidationSeverity enum."""
+
+    def test_severity_values(self) -> None:
+        """Test that severity levels have expected values."""
+        assert ValidationSeverity.ERROR.value == "error"
+        assert ValidationSeverity.WARNING.value == "warning"
+        assert ValidationSeverity.INFO.value == "info"
+
+
+# ===========================================================================
+# Test ValidationIssue
+# ===========================================================================
+
+
+class TestValidationIssue:
+    """Tests for ValidationIssue dataclass."""
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        issue = ValidationIssue(
+            severity=ValidationSeverity.ERROR,
+            code="TEST_CODE",
+            message="Test message",
+            entity_name="John",
+            entity_type="Person",
+            property_name="email",
+            expected="str",
+            actual="int",
+        )
+        result = issue.to_dict()
+
+        assert result["severity"] == "error"
+        assert result["code"] == "TEST_CODE"
+        assert result["message"] == "Test message"
+        assert result["entity_name"] == "John"
+        assert result["entity_type"] == "Person"
+        assert result["property_name"] == "email"
+        assert result["expected"] == "str"
+        assert result["actual"] == "int"
+
+    def test_to_dict_with_none_values(self) -> None:
+        """Test conversion with None optional values."""
+        issue = ValidationIssue(
+            severity=ValidationSeverity.WARNING,
+            code="SIMPLE",
+            message="Simple issue",
+        )
+        result = issue.to_dict()
+
+        assert result["entity_name"] is None
+        assert result["property_name"] is None
+
+
+# ===========================================================================
+# Test ValidationResult
+# ===========================================================================
+
+
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_error_count(self) -> None:
+        """Test error count calculation."""
+        result = ValidationResult(
+            is_valid=False,
+            issues=[
+                ValidationIssue(ValidationSeverity.ERROR, "E1", "Error 1"),
+                ValidationIssue(ValidationSeverity.ERROR, "E2", "Error 2"),
+                ValidationIssue(ValidationSeverity.WARNING, "W1", "Warning 1"),
+            ],
+        )
+        assert result.error_count == 2
+
+    def test_warning_count(self) -> None:
+        """Test warning count calculation."""
+        result = ValidationResult(
+            is_valid=True,
+            issues=[
+                ValidationIssue(ValidationSeverity.WARNING, "W1", "Warning 1"),
+                ValidationIssue(ValidationSeverity.WARNING, "W2", "Warning 2"),
+                ValidationIssue(ValidationSeverity.INFO, "I1", "Info 1"),
+            ],
+        )
+        assert result.warning_count == 2
+
+    def test_to_dict(self) -> None:
+        """Test conversion to dictionary."""
+        result = ValidationResult(
+            is_valid=True,
+            issues=[],
+            entities_validated=5,
+            relationships_validated=3,
+        )
+        data = result.to_dict()
+
+        assert data["is_valid"] is True
+        assert data["error_count"] == 0
+        assert data["warning_count"] == 0
+        assert data["entities_validated"] == 5
+        assert data["relationships_validated"] == 3
+        assert data["issues"] == []
+
+
+# ===========================================================================
+# Test ExtractedEntity
+# ===========================================================================
+
+
+class TestExtractedEntity:
+    """Tests for ExtractedEntity model."""
+
+    def test_basic_entity(self) -> None:
+        """Test creating a basic entity."""
+        entity = ExtractedEntity(
+            name="John Smith",
+            entity_type="Person",
+            properties={"email": "john@example.com"},
+            confidence=0.95,
+        )
+        assert entity.name == "John Smith"
+        assert entity.entity_type == "Person"
+        assert entity.properties["email"] == "john@example.com"
+        assert entity.confidence == 0.95
+
+    def test_entity_type_normalization(self) -> None:
+        """Test that lowercase entity types are normalized."""
+        entity = ExtractedEntity(
+            name="Test",
+            entity_type="person",  # lowercase
+        )
+        assert entity.entity_type == "Person"  # Should be title-cased
+
+    def test_default_confidence(self) -> None:
+        """Test default confidence is 1.0."""
+        entity = ExtractedEntity(name="Test", entity_type="Person")
+        assert entity.confidence == 1.0
+
+    def test_empty_properties(self) -> None:
+        """Test default empty properties."""
+        entity = ExtractedEntity(name="Test", entity_type="Person")
+        assert entity.properties == {}
+
+
+# ===========================================================================
+# Test ExtractedRelationship
+# ===========================================================================
+
+
+class TestExtractedRelationship:
+    """Tests for ExtractedRelationship model."""
+
+    def test_basic_relationship(self) -> None:
+        """Test creating a basic relationship."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="WORKS_AT",
+            target_name="Acme Corp",
+            target_type="Organization",
+            confidence=0.9,
+        )
+        assert rel.source_name == "John"
+        assert rel.relationship_type == "WORKS_AT"
+        assert rel.target_name == "Acme Corp"
+
+    def test_relationship_type_normalization(self) -> None:
+        """Test that relationship types are uppercased."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="works_at",  # lowercase
+            target_name="Acme",
+            target_type="Organization",
+        )
+        assert rel.relationship_type == "WORKS_AT"  # Should be uppercased
+
+
+# ===========================================================================
+# Test ExtractionResult
+# ===========================================================================
+
+
+class TestExtractionResult:
+    """Tests for ExtractionResult model."""
+
+    def test_empty_result(self) -> None:
+        """Test empty extraction result."""
+        result = ExtractionResult()
+        assert result.entities == []
+        assert result.relationships == []
+        assert result.source_text == ""
+
+    def test_result_with_data(self) -> None:
+        """Test extraction result with entities and relationships."""
+        result = ExtractionResult(
+            entities=[
+                ExtractedEntity(name="John", entity_type="Person"),
+            ],
+            relationships=[
+                ExtractedRelationship(
+                    source_name="John",
+                    source_type="Person",
+                    relationship_type="WORKS_AT",
+                    target_name="Acme",
+                    target_type="Organization",
+                ),
+            ],
+            source_text="John works at Acme",
+        )
+        assert len(result.entities) == 1
+        assert len(result.relationships) == 1
+
+
+# ===========================================================================
+# Test Constants
+# ===========================================================================
+
+
+class TestValidationConstants:
+    """Tests for validation constants."""
+
+    def test_valid_entity_types_includes_core_types(self) -> None:
+        """Test that core entity types are defined."""
+        assert "Person" in VALID_ENTITY_TYPES
+        assert "Organization" in VALID_ENTITY_TYPES
+        assert "Project" in VALID_ENTITY_TYPES
+        assert "Task" in VALID_ENTITY_TYPES
+        assert "Event" in VALID_ENTITY_TYPES
+        assert "Location" in VALID_ENTITY_TYPES
+
+    def test_valid_entity_types_includes_personal_types(self) -> None:
+        """Test that personal life entity types are defined."""
+        assert "Hobby" in VALID_ENTITY_TYPES
+        assert "Pet" in VALID_ENTITY_TYPES
+        assert "Milestone" in VALID_ENTITY_TYPES
+        assert "Routine" in VALID_ENTITY_TYPES
+        assert "Preference" in VALID_ENTITY_TYPES
+
+    def test_valid_relationship_types_includes_core_types(self) -> None:
+        """Test that core relationship types are defined."""
+        assert "WORKS_AT" in VALID_RELATIONSHIP_TYPES
+        assert "REPORTS_TO" in VALID_RELATIONSHIP_TYPES
+        assert "KNOWS" in VALID_RELATIONSHIP_TYPES
+        assert "BLOCKS" in VALID_RELATIONSHIP_TYPES
+        assert "ASSIGNED_TO" in VALID_RELATIONSHIP_TYPES
+
+    def test_relationship_constraints_defined(self) -> None:
+        """Test that relationship constraints are defined."""
+        assert "WORKS_AT" in RELATIONSHIP_CONSTRAINTS
+        assert "REPORTS_TO" in RELATIONSHIP_CONSTRAINTS
+
+        # Check WORKS_AT constraints
+        sources, targets = RELATIONSHIP_CONSTRAINTS["WORKS_AT"]
+        assert "Person" in sources
+        assert "Organization" in targets
+
+
+# ===========================================================================
+# Test OntologyValidator
+# ===========================================================================
+
+
+class TestOntologyValidator:
+    """Tests for OntologyValidator."""
+
+    @pytest.fixture
+    def validator(self) -> OntologyValidator:
+        """Create a validator instance."""
+        return OntologyValidator(strict=False)
+
+    @pytest.fixture
+    def strict_validator(self) -> OntologyValidator:
+        """Create a strict validator instance."""
+        return OntologyValidator(strict=True)
+
+    # --- Entity Type Validation ---
+
+    def test_valid_entity_type(self, validator: OntologyValidator) -> None:
+        """Test validation of valid entity type."""
+        entity = ExtractedEntity(name="John", entity_type="Person")
+        result = validator.validate_entity(entity)
+        assert result.is_valid
+        assert result.error_count == 0
+
+    def test_invalid_entity_type(self, validator: OntologyValidator) -> None:
+        """Test validation fails for invalid entity type."""
+        entity = ExtractedEntity(name="Test", entity_type="InvalidType")
+        result = validator.validate_entity(entity)
+        assert not result.is_valid
+        assert result.error_count == 1
+        assert result.issues[0].code == "INVALID_ENTITY_TYPE"
+
+    # --- Relationship Type Validation ---
+
+    def test_valid_relationship_type(self, validator: OntologyValidator) -> None:
+        """Test validation of valid relationship type."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="WORKS_AT",
+            target_name="Acme",
+            target_type="Organization",
+        )
+        result = validator.validate_relationship(rel)
+        assert result.is_valid
+
+    def test_invalid_relationship_type(self, validator: OntologyValidator) -> None:
+        """Test validation fails for invalid relationship type."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="INVALID_REL",
+            target_name="Acme",
+            target_type="Organization",
+        )
+        result = validator.validate_relationship(rel)
+        assert not result.is_valid
+        assert result.issues[0].code == "INVALID_RELATIONSHIP_TYPE"
+
+    # --- Relationship Constraint Validation ---
+
+    def test_valid_relationship_constraints(self, validator: OntologyValidator) -> None:
+        """Test validation passes for valid source/target types."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="REPORTS_TO",
+            target_name="Jane",
+            target_type="Person",
+        )
+        result = validator.validate_relationship(rel)
+        assert result.is_valid
+
+    def test_invalid_source_for_relationship(self, validator: OntologyValidator) -> None:
+        """Test validation fails when source type is invalid for relationship."""
+        rel = ExtractedRelationship(
+            source_name="Acme",
+            source_type="Organization",  # Organization can't WORKS_AT
+            relationship_type="WORKS_AT",
+            target_name="Corp",
+            target_type="Organization",
+        )
+        result = validator.validate_relationship(rel)
+        assert not result.is_valid
+        assert any(i.code == "INVALID_SOURCE_FOR_RELATIONSHIP" for i in result.issues)
+
+    def test_invalid_target_for_relationship(self, validator: OntologyValidator) -> None:
+        """Test validation fails when target type is invalid for relationship."""
+        rel = ExtractedRelationship(
+            source_name="John",
+            source_type="Person",
+            relationship_type="WORKS_AT",
+            target_name="John",
+            target_type="Person",  # Person can't be target of WORKS_AT
+        )
+        result = validator.validate_relationship(rel)
+        assert not result.is_valid
+        assert any(i.code == "INVALID_TARGET_FOR_RELATIONSHIP" for i in result.issues)
+
+    # --- Property Validation ---
+
+    def test_valid_property_type(self, validator: OntologyValidator) -> None:
+        """Test validation passes for correct property types."""
+        entity = ExtractedEntity(
+            name="John",
+            entity_type="Person",
+            properties={"email": "john@example.com"},  # String as expected
+        )
+        result = validator.validate_entity(entity)
+        assert result.is_valid
+
+    def test_invalid_property_type(self, validator: OntologyValidator) -> None:
+        """Test validation warns for incorrect property types."""
+        entity = ExtractedEntity(
+            name="John",
+            entity_type="Person",
+            properties={"email": 12345},  # Should be string
+        )
+        result = validator.validate_entity(entity)
+        # Should be valid (warning only) but have warnings
+        assert result.is_valid
+        assert any(i.code == "INVALID_PROPERTY_TYPE" for i in result.issues)
+
+    # --- Enum Validation ---
+
+    def test_valid_enum_value(self, validator: OntologyValidator) -> None:
+        """Test validation passes for valid enum values."""
+        entity = ExtractedEntity(
+            name="My Task",
+            entity_type="Task",
+            properties={"status": "todo"},
+        )
+        result = validator.validate_entity(entity)
+        assert result.is_valid
+
+    def test_invalid_enum_value(self, validator: OntologyValidator) -> None:
+        """Test validation warns for invalid enum values."""
+        entity = ExtractedEntity(
+            name="My Task",
+            entity_type="Task",
+            properties={"status": "invalid_status"},
+        )
+        result = validator.validate_entity(entity)
+        assert result.is_valid  # Warning only
+        assert any(i.code == "INVALID_ENUM_VALUE" for i in result.issues)
+
+    # --- Confidence Validation ---
+
+    def test_low_confidence_info(self, validator: OntologyValidator) -> None:
+        """Test low confidence generates INFO issue."""
+        entity = ExtractedEntity(
+            name="Maybe John",
+            entity_type="Person",
+            confidence=0.3,
+        )
+        result = validator.validate_entity(entity)
+        assert result.is_valid
+        assert any(
+            i.code == "LOW_CONFIDENCE" and i.severity == ValidationSeverity.INFO
+            for i in result.issues
+        )
+
+    # --- Complete Extraction Validation ---
+
+    def test_validate_complete_extraction(self, validator: OntologyValidator) -> None:
+        """Test validation of complete extraction result."""
+        extraction = ExtractionResult(
+            entities=[
+                ExtractedEntity(name="John", entity_type="Person"),
+                ExtractedEntity(name="Acme", entity_type="Organization"),
+            ],
+            relationships=[
+                ExtractedRelationship(
+                    source_name="John",
+                    source_type="Person",
+                    relationship_type="WORKS_AT",
+                    target_name="Acme",
+                    target_type="Organization",
+                ),
+            ],
+        )
+        result = validator.validate_extraction(extraction)
+        assert result.is_valid
+        assert result.entities_validated == 2
+        assert result.relationships_validated == 1
+
+    def test_validate_extraction_with_errors(self, validator: OntologyValidator) -> None:
+        """Test validation fails with invalid entities."""
+        extraction = ExtractionResult(
+            entities=[
+                ExtractedEntity(name="Test", entity_type="InvalidType"),
+            ],
+        )
+        result = validator.validate_extraction(extraction)
+        assert not result.is_valid
+        assert result.error_count == 1
+
+    # --- Strict Mode ---
+
+    def test_strict_mode_fails_on_warnings(self, strict_validator: OntologyValidator) -> None:
+        """Test strict mode treats warnings as errors."""
+        entity = ExtractedEntity(
+            name="My Task",
+            entity_type="Task",
+            properties={"status": "invalid_status"},  # Will generate warning
+        )
+        result = strict_validator.validate_entity(entity)
+        assert not result.is_valid  # Strict mode fails on warnings
+
+    # --- Helper Methods ---
+
+    def test_is_valid_entity_type_method(self, validator: OntologyValidator) -> None:
+        """Test is_valid_entity_type method."""
+        assert validator.is_valid_entity_type("Person")
+        assert validator.is_valid_entity_type("person")  # Case insensitive
+        assert not validator.is_valid_entity_type("InvalidType")
+
+    def test_is_valid_relationship_type_method(self, validator: OntologyValidator) -> None:
+        """Test is_valid_relationship_type method."""
+        assert validator.is_valid_relationship_type("WORKS_AT")
+        assert validator.is_valid_relationship_type("works_at")  # Case insensitive
+        assert not validator.is_valid_relationship_type("INVALID")
+
+    def test_get_valid_entity_types(self, validator: OntologyValidator) -> None:
+        """Test get_valid_entity_types returns sorted list."""
+        types = validator.get_valid_entity_types()
+        assert isinstance(types, list)
+        assert "Person" in types
+        assert types == sorted(types)  # Should be sorted
+
+    def test_get_entity_type_model(self, validator: OntologyValidator) -> None:
+        """Test get_entity_type_model returns Pydantic model."""
+        model = validator.get_entity_type_model("Person")
+        assert model is not None
+        # Model should have email field
+        assert "email" in model.model_fields
+
+
+# ===========================================================================
+# Test Convenience Functions
+# ===========================================================================
+
+
+class TestConvenienceFunctions:
+    """Tests for module-level convenience functions."""
+
+    def test_validate_extraction_function(self) -> None:
+        """Test the validate_extraction convenience function."""
+        extraction = ExtractionResult(
+            entities=[
+                ExtractedEntity(name="John", entity_type="Person"),
+            ],
+        )
+        result = validate_extraction(extraction)
+        assert result.is_valid
+
+    def test_is_valid_entity_type_function(self) -> None:
+        """Test the is_valid_entity_type convenience function."""
+        assert is_valid_entity_type("Person")
+        assert is_valid_entity_type("person")  # Case insensitive
+        assert not is_valid_entity_type("Invalid")
+
+    def test_is_valid_relationship_type_function(self) -> None:
+        """Test the is_valid_relationship_type convenience function."""
+        assert is_valid_relationship_type("WORKS_AT")
+        assert is_valid_relationship_type("works_at")
+        assert not is_valid_relationship_type("INVALID")
+
+
+# ===========================================================================
+# Test Module Exports
+# ===========================================================================
+
+
+class TestModuleExports:
+    """Tests for module exports."""
+
+    def test_exports_from_core_module(self) -> None:
+        """Test that validation exports are available from core module."""
+        from klabautermann.core import (
+            ExtractionResult,
+            OntologyValidator,
+            is_valid_entity_type,
+        )
+
+        # Basic smoke test
+        assert ExtractionResult is not None
+        assert OntologyValidator is not None
+        assert is_valid_entity_type("Person")


### PR DESCRIPTION
## Summary

- **#11 LLM Pre-Extraction**: Add pre-extraction step using Claude Haiku before Graphiti ingestion
- **#13 Ontology Validation**: Validate extracted entities and relationships against the graph schema

## Changes

### Ontology Validation (#13)
New `validation.py` module with:
- `OntologyValidator` class with configurable strict mode
- Validates entity types against `NodeLabel` enum
- Validates relationship types against `RelationType` enum  
- Validates source/target type constraints (e.g., WORKS_AT: Person -> Organization)
- Validates property types and enum values (status, priority, etc.)
- `ValidationSeverity` levels: ERROR, WARNING, INFO
- `ExtractedEntity`, `ExtractedRelationship`, `ExtractionResult` models

### LLM Pre-Extraction (#11)
New `pre_extraction.py` module with:
- `PreExtractionEngine` using Claude Haiku for fast extraction
- `PreExtractionConfig` for customization (model, min_confidence, etc.)
- Confidence filtering (default threshold: 0.5)
- Graceful fallback if pre-extraction fails
- Integrated into `Ingestor` agent via optional `anthropic_client`

### Ingestor Integration
- Optional pre-extraction step before Graphiti ingestion
- Logs pre-extracted entities and validation results
- Non-blocking: continues even if pre-extraction fails

## Test Plan
- [x] 56 new unit tests in `test_validation.py` and `test_pre_extraction.py`
- [x] Entity type validation tests
- [x] Relationship type and constraint validation tests
- [x] Strict mode behavior tests
- [x] Confidence filtering tests
- [x] Error handling tests (invalid JSON, LLM failures, malformed data)
- [x] Linting and type checking pass

## Closes
- Closes #11
- Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)