### PR TITLE
feat(core): Add multi-model orchestration (#3)

### DIFF
--- a/src/klabautermann/core/__init__.py
+++ b/src/klabautermann/core/__init__.py
@@ -5,6 +5,7 @@ Contains:
 - models: Pydantic data models
 - ontology: Graph schema constants
 - validation: Ontology validation for entity/relationship extraction
+- model_selector: Multi-model orchestration for task-appropriate model selection
 - logger: Nautical logging system
 - exceptions: Custom exception types
 - workflow_inspector: Agent workflow inspection for debugging
@@ -17,6 +18,18 @@ from klabautermann.core.exceptions import (
     GraphConnectionError,
     KlabautermannError,
     ValidationError,
+)
+from klabautermann.core.model_selector import (
+    COMPLEXITY_TO_TIER,
+    DEFAULT_MODELS,
+    PURPOSE_TO_TIER,
+    ModelCallResult,
+    ModelSelectionConfig,
+    ModelSelector,
+    ModelTier,
+    TaskComplexity,
+    TaskPurpose,
+    get_model_for_agent,
 )
 from klabautermann.core.tracing import (
     Span,
@@ -57,42 +70,53 @@ from klabautermann.core.workflow_inspector import (
 
 
 __all__ = [
+    # Model Selection
+    "COMPLEXITY_TO_TIER",
+    "DEFAULT_MODELS",
+    "PURPOSE_TO_TIER",
     "CircuitOpenError",
     "ExternalServiceError",
+    "ExtractedEntity",
+    "ExtractedRelationship",
+    # Ontology Validation
+    "ExtractionResult",
     "GraphConnectionError",
     "KlabautermannError",
-    "ValidationError",
+    "ModelCallResult",
+    "ModelSelectionConfig",
+    "ModelSelector",
+    "ModelTier",
+    "OntologyValidator",
     # Tracing
     "Span",
     "SpanStatus",
+    "TaskComplexity",
+    "TaskPurpose",
     "TraceContext",
     "Tracer",
+    "ValidationError",
+    "ValidationIssue",
+    "ValidationResult",
+    "ValidationSeverity",
+    # Workflow Inspector
+    "WorkflowEntry",
+    "WorkflowInspector",
+    "WorkflowPhase",
     "current_span_id",
     "current_trace_id",
     "generate_short_trace_id",
     "generate_span_id",
     "generate_trace_id",
+    "get_inspector",
+    "get_model_for_agent",
     "get_tracer",
-    "reset_tracer",
-    "start_trace",
-    "trace_span",
-    # Ontology Validation
-    "ExtractionResult",
-    "ExtractedEntity",
-    "ExtractedRelationship",
-    "OntologyValidator",
-    "ValidationIssue",
-    "ValidationResult",
-    "ValidationSeverity",
     "is_valid_entity_type",
     "is_valid_relationship_type",
-    "validate_extraction",
-    # Workflow Inspector
-    "WorkflowEntry",
-    "WorkflowInspector",
-    "WorkflowPhase",
-    "get_inspector",
     "log_output",
     "log_request",
     "log_thinking",
+    "reset_tracer",
+    "start_trace",
+    "trace_span",
+    "validate_extraction",
 ]

--- a/src/klabautermann/core/config.py
+++ b/src/klabautermann/core/config.py
@@ -25,7 +25,15 @@ class Settings(BaseModel):
     anthropic_api_key: str = ""
     openai_api_key: str = ""
 
-    # Model selection
+    # Model selection (multi-model orchestration)
+    # Haiku: Fast, cheap - classification, extraction, simple queries
+    haiku_model: str = "claude-3-5-haiku-20241022"
+    # Sonnet: Balanced - reasoning, synthesis, actions
+    sonnet_model: str = "claude-sonnet-4-20250514"
+    # Opus: Most capable - complex planning, critical decisions
+    opus_model: str = "claude-opus-4-5-20251101"
+
+    # Legacy aliases (for backward compatibility)
     primary_model: str = "claude-sonnet-4-20250514"
     fast_model: str = "claude-3-5-haiku-20241022"
 
@@ -38,19 +46,30 @@ class Settings(BaseModel):
     debug: bool = False
     disable_ingestion: bool = False
 
+    # Model selection feature flag
+    enable_multi_model: bool = True
+
     @classmethod
     def from_env(cls) -> Settings:
         """Load settings from environment variables."""
         return cls(
             anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", ""),
             openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+            # Multi-model orchestration settings
+            haiku_model=os.getenv("HAIKU_MODEL", "claude-3-5-haiku-20241022"),
+            sonnet_model=os.getenv("SONNET_MODEL", "claude-sonnet-4-20250514"),
+            opus_model=os.getenv("OPUS_MODEL", "claude-opus-4-5-20251101"),
+            # Legacy aliases
             primary_model=os.getenv("ORCHESTRATOR_MODEL", "claude-sonnet-4-20250514"),
             fast_model=os.getenv("HAIKU_MODEL", "claude-3-5-haiku-20241022"),
+            # Neo4j
             neo4j_uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
             neo4j_username=os.getenv("NEO4J_USERNAME", "neo4j"),
             neo4j_password=os.getenv("NEO4J_PASSWORD", ""),
+            # Feature flags
             debug=os.getenv("DEBUG", "false").lower() == "true",
             disable_ingestion=os.getenv("DISABLE_INGESTION", "false").lower() == "true",
+            enable_multi_model=os.getenv("ENABLE_MULTI_MODEL", "true").lower() == "true",
         )
 
 

--- a/src/klabautermann/core/model_selector.py
+++ b/src/klabautermann/core/model_selector.py
@@ -1,0 +1,539 @@
+"""
+Multi-model orchestration for Klabautermann.
+
+Dynamically selects the appropriate Claude model based on task complexity,
+optimizing for cost while maintaining quality.
+
+Reference: specs/architecture/AGENTS.md Section 3
+Reference: Issue #3 [AGT-P-002]
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from klabautermann.core.logger import logger
+from klabautermann.core.metrics import record_llm_call, record_llm_latency, record_llm_tokens
+
+
+if TYPE_CHECKING:
+    import anthropic
+
+
+class ModelTier(str, Enum):
+    """Available Claude model tiers.
+
+    Models are organized by capability and cost:
+    - HAIKU: Fast, cheap, good for simple tasks
+    - SONNET: Balanced, good for complex reasoning
+    - OPUS: Most capable, highest cost, for critical tasks
+    """
+
+    HAIKU = "haiku"
+    SONNET = "sonnet"
+    OPUS = "opus"
+
+
+class TaskComplexity(str, Enum):
+    """Task complexity levels for model selection.
+
+    Complexity determines which model tier to use:
+    - SIMPLE: Classification, extraction, simple queries -> Haiku
+    - MODERATE: Reasoning, synthesis, planning -> Sonnet
+    - COMPLEX: Multi-step reasoning, critical decisions -> Opus
+    """
+
+    SIMPLE = "simple"
+    MODERATE = "moderate"
+    COMPLEX = "complex"
+
+
+class TaskPurpose(str, Enum):
+    """Purpose of the LLM call for metrics and selection.
+
+    These map to specific model tiers by default:
+    - CLASSIFICATION: Intent detection -> Haiku
+    - EXTRACTION: Entity extraction -> Haiku
+    - SEARCH_PLANNING: Query construction -> Haiku
+    - REASONING: Complex reasoning -> Sonnet
+    - SYNTHESIS: Response generation -> Sonnet/Opus
+    - PLANNING: Task planning -> Opus
+    - ACTION: Tool/MCP execution -> Sonnet
+    """
+
+    CLASSIFICATION = "classification"
+    EXTRACTION = "extraction"
+    SEARCH_PLANNING = "search_planning"
+    REASONING = "reasoning"
+    SYNTHESIS = "synthesis"
+    PLANNING = "planning"
+    ACTION = "action"
+
+
+# Default model IDs for each tier
+DEFAULT_MODELS: dict[ModelTier, str] = {
+    ModelTier.HAIKU: "claude-3-5-haiku-20241022",
+    ModelTier.SONNET: "claude-sonnet-4-20250514",
+    ModelTier.OPUS: "claude-opus-4-5-20251101",
+}
+
+# Map task purpose to default model tier
+PURPOSE_TO_TIER: dict[TaskPurpose, ModelTier] = {
+    TaskPurpose.CLASSIFICATION: ModelTier.HAIKU,
+    TaskPurpose.EXTRACTION: ModelTier.HAIKU,
+    TaskPurpose.SEARCH_PLANNING: ModelTier.HAIKU,
+    TaskPurpose.REASONING: ModelTier.SONNET,
+    TaskPurpose.SYNTHESIS: ModelTier.SONNET,
+    TaskPurpose.PLANNING: ModelTier.OPUS,
+    TaskPurpose.ACTION: ModelTier.SONNET,
+}
+
+# Map complexity to default model tier
+COMPLEXITY_TO_TIER: dict[TaskComplexity, ModelTier] = {
+    TaskComplexity.SIMPLE: ModelTier.HAIKU,
+    TaskComplexity.MODERATE: ModelTier.SONNET,
+    TaskComplexity.COMPLEX: ModelTier.OPUS,
+}
+
+
+@dataclass
+class ModelSelectionConfig:
+    """Configuration for model selection.
+
+    Allows per-agent and per-purpose model overrides.
+    """
+
+    # Default models by tier (can be overridden)
+    models: dict[ModelTier, str] = field(default_factory=lambda: dict(DEFAULT_MODELS))
+
+    # Per-purpose overrides (e.g., use Sonnet for extraction in prod)
+    purpose_overrides: dict[TaskPurpose, ModelTier] = field(default_factory=dict)
+
+    # Per-agent overrides (e.g., researcher always uses Opus)
+    agent_overrides: dict[str, ModelTier] = field(default_factory=dict)
+
+    # Fallback model if primary fails
+    fallback_tier: ModelTier = ModelTier.SONNET
+
+    # Enable metrics recording
+    record_metrics: bool = True
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None) -> ModelSelectionConfig:
+        """Create ModelSelectionConfig from agent config dict.
+
+        Args:
+            config: Agent configuration dictionary.
+
+        Returns:
+            ModelSelectionConfig instance.
+        """
+        if not config:
+            return cls()
+
+        model_config = config.get("model_selection", {})
+
+        # Parse model overrides
+        models = dict(DEFAULT_MODELS)
+        if "models" in model_config:
+            for tier_name, model_id in model_config["models"].items():
+                try:
+                    tier = ModelTier(tier_name.lower())
+                    models[tier] = model_id
+                except ValueError:
+                    logger.warning(f"[SWELL] Unknown model tier: {tier_name}")
+
+        # Parse purpose overrides
+        purpose_overrides: dict[TaskPurpose, ModelTier] = {}
+        if "purpose_overrides" in model_config:
+            for purpose_name, tier_name in model_config["purpose_overrides"].items():
+                try:
+                    purpose = TaskPurpose(purpose_name.lower())
+                    tier = ModelTier(tier_name.lower())
+                    purpose_overrides[purpose] = tier
+                except ValueError:
+                    logger.warning(f"[SWELL] Unknown purpose or tier: {purpose_name}={tier_name}")
+
+        # Parse agent overrides
+        agent_overrides: dict[str, ModelTier] = {}
+        if "agent_overrides" in model_config:
+            for agent_name, tier_name in model_config["agent_overrides"].items():
+                try:
+                    tier = ModelTier(tier_name.lower())
+                    agent_overrides[agent_name] = tier
+                except ValueError:
+                    logger.warning(f"[SWELL] Unknown tier for agent {agent_name}: {tier_name}")
+
+        # Parse fallback
+        fallback_tier = ModelTier.SONNET
+        if "fallback_tier" in model_config:
+            try:
+                fallback_tier = ModelTier(model_config["fallback_tier"].lower())
+            except ValueError:
+                logger.warning(f"[SWELL] Unknown fallback tier: {model_config['fallback_tier']}")
+
+        return cls(
+            models=models,
+            purpose_overrides=purpose_overrides,
+            agent_overrides=agent_overrides,
+            fallback_tier=fallback_tier,
+            record_metrics=model_config.get("record_metrics", True),
+        )
+
+
+@dataclass
+class ModelCallResult:
+    """Result of a model call with metadata."""
+
+    response: str
+    model_id: str
+    model_tier: ModelTier
+    input_tokens: int
+    output_tokens: int
+    latency_seconds: float
+    used_fallback: bool = False
+
+
+class ModelSelector:
+    """Selects and calls the appropriate Claude model based on task complexity.
+
+    This class provides a unified interface for model selection across all agents,
+    implementing the multi-model orchestration pattern from Issue #3.
+
+    Example usage:
+        selector = ModelSelector(anthropic_client, config)
+
+        # Select model by purpose
+        result = await selector.call(
+            prompt="Classify this intent: ...",
+            purpose=TaskPurpose.CLASSIFICATION,
+            trace_id=trace_id,
+        )
+
+        # Select model by complexity
+        result = await selector.call(
+            prompt="Plan the following tasks...",
+            complexity=TaskComplexity.COMPLEX,
+            trace_id=trace_id,
+        )
+
+        # Agent-specific override
+        result = await selector.call(
+            prompt="Search for...",
+            purpose=TaskPurpose.SEARCH_PLANNING,
+            agent_name="researcher",
+            trace_id=trace_id,
+        )
+    """
+
+    def __init__(
+        self,
+        anthropic_client: anthropic.Anthropic,
+        config: ModelSelectionConfig | None = None,
+    ) -> None:
+        """Initialize the model selector.
+
+        Args:
+            anthropic_client: Anthropic client for API calls.
+            config: Model selection configuration.
+        """
+        self.client = anthropic_client
+        self.config = config or ModelSelectionConfig()
+
+    def select_model(
+        self,
+        purpose: TaskPurpose | None = None,
+        complexity: TaskComplexity | None = None,
+        agent_name: str | None = None,
+    ) -> tuple[str, ModelTier]:
+        """Select the appropriate model based on purpose, complexity, and agent.
+
+        Priority order:
+        1. Agent override (if configured)
+        2. Purpose override (if configured)
+        3. Complexity (if provided)
+        4. Purpose default (if provided)
+        5. Fallback to SONNET
+
+        Args:
+            purpose: Purpose of the LLM call.
+            complexity: Complexity level of the task.
+            agent_name: Name of the calling agent.
+
+        Returns:
+            Tuple of (model_id, model_tier).
+        """
+        tier: ModelTier | None = None
+
+        # 1. Check agent override
+        if agent_name and agent_name in self.config.agent_overrides:
+            tier = self.config.agent_overrides[agent_name]
+            logger.debug(
+                f"[WHISPER] Using agent override for {agent_name}: {tier.value}",
+                extra={"agent_name": agent_name, "model_tier": tier.value},
+            )
+
+        # 2. Check purpose override
+        elif purpose and purpose in self.config.purpose_overrides:
+            tier = self.config.purpose_overrides[purpose]
+            logger.debug(
+                f"[WHISPER] Using purpose override for {purpose.value}: {tier.value}",
+                extra={"purpose": purpose.value, "model_tier": tier.value},
+            )
+
+        # 3. Use complexity if provided
+        elif complexity:
+            tier = COMPLEXITY_TO_TIER[complexity]
+            logger.debug(
+                f"[WHISPER] Selected model by complexity {complexity.value}: {tier.value}",
+                extra={"complexity": complexity.value, "model_tier": tier.value},
+            )
+
+        # 4. Use purpose default
+        elif purpose:
+            tier = PURPOSE_TO_TIER[purpose]
+            logger.debug(
+                f"[WHISPER] Selected model by purpose {purpose.value}: {tier.value}",
+                extra={"purpose": purpose.value, "model_tier": tier.value},
+            )
+
+        # 5. Fallback
+        if tier is None:
+            tier = self.config.fallback_tier
+            logger.debug(
+                f"[WHISPER] Using fallback model tier: {tier.value}",
+                extra={"model_tier": tier.value},
+            )
+
+        model_id = self.config.models[tier]
+        return model_id, tier
+
+    async def call(
+        self,
+        prompt: str,
+        purpose: TaskPurpose | None = None,
+        complexity: TaskComplexity | None = None,
+        agent_name: str | None = None,
+        trace_id: str | None = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        system_prompt: str | None = None,
+    ) -> ModelCallResult:
+        """Call the appropriate model based on task characteristics.
+
+        Selects model, makes the API call, records metrics, and handles fallback.
+
+        Args:
+            prompt: The prompt to send to the model.
+            purpose: Purpose of the LLM call (for model selection and metrics).
+            complexity: Complexity level of the task.
+            agent_name: Name of the calling agent.
+            trace_id: Request trace ID for logging.
+            max_tokens: Maximum tokens in response.
+            temperature: Sampling temperature.
+            system_prompt: Optional system prompt.
+
+        Returns:
+            ModelCallResult with response and metadata.
+        """
+        model_id, tier = self.select_model(purpose, complexity, agent_name)
+
+        logger.info(
+            f"[WHISPER] Calling {tier.value} model ({model_id})",
+            extra={
+                "trace_id": trace_id,
+                "model": model_id,
+                "model_tier": tier.value,
+                "purpose": purpose.value if purpose else None,
+                "agent_name": agent_name,
+            },
+        )
+
+        start_time = time.perf_counter()
+        used_fallback = False
+
+        try:
+            response = await self._make_call(
+                model_id=model_id,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                system_prompt=system_prompt,
+            )
+        except Exception as e:
+            # Try fallback model
+            fallback_id = self.config.models[self.config.fallback_tier]
+            if fallback_id != model_id:
+                logger.warning(
+                    f"[SWELL] Primary model {model_id} failed, trying fallback {fallback_id}: {e}",
+                    extra={"trace_id": trace_id, "error": str(e)},
+                )
+                response = await self._make_call(
+                    model_id=fallback_id,
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    system_prompt=system_prompt,
+                )
+                model_id = fallback_id
+                tier = self.config.fallback_tier
+                used_fallback = True
+            else:
+                raise
+
+        latency = time.perf_counter() - start_time
+
+        # Extract response text and token counts
+        response_text = response.content[0].text if response.content else ""
+        input_tokens = response.usage.input_tokens
+        output_tokens = response.usage.output_tokens
+
+        # Record metrics
+        if self.config.record_metrics:
+            purpose_str = purpose.value if purpose else "unknown"
+            record_llm_call(model=tier.value, purpose=purpose_str)
+            record_llm_tokens(
+                model=tier.value, input_tokens=input_tokens, output_tokens=output_tokens
+            )
+            record_llm_latency(model=tier.value, latency_seconds=latency)
+
+        logger.debug(
+            f"[BEACON] Model call completed in {latency:.2f}s",
+            extra={
+                "trace_id": trace_id,
+                "model": model_id,
+                "model_tier": tier.value,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "latency_seconds": latency,
+                "used_fallback": used_fallback,
+            },
+        )
+
+        return ModelCallResult(
+            response=response_text,
+            model_id=model_id,
+            model_tier=tier,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_seconds=latency,
+            used_fallback=used_fallback,
+        )
+
+    async def _make_call(
+        self,
+        model_id: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        system_prompt: str | None,
+    ) -> Any:
+        """Make the actual API call.
+
+        Args:
+            model_id: Model ID to use.
+            prompt: User prompt.
+            max_tokens: Max response tokens.
+            temperature: Sampling temperature.
+            system_prompt: Optional system prompt.
+
+        Returns:
+            API response object.
+        """
+        import asyncio
+
+        messages = [{"role": "user", "content": prompt}]
+
+        # Run synchronous Anthropic call in executor
+        def _sync_call() -> Any:
+            kwargs: dict[str, Any] = {
+                "model": model_id,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "messages": messages,
+            }
+            if system_prompt:
+                kwargs["system"] = system_prompt
+            return self.client.messages.create(**kwargs)
+
+        return await asyncio.get_event_loop().run_in_executor(None, _sync_call)
+
+    def get_model_for_purpose(self, purpose: TaskPurpose) -> str:
+        """Get the model ID for a specific purpose.
+
+        Convenience method for agents that need to know the model
+        without making a call.
+
+        Args:
+            purpose: Purpose of the LLM call.
+
+        Returns:
+            Model ID string.
+        """
+        model_id, _ = self.select_model(purpose=purpose)
+        return model_id
+
+    def get_model_for_complexity(self, complexity: TaskComplexity) -> str:
+        """Get the model ID for a specific complexity level.
+
+        Args:
+            complexity: Complexity level.
+
+        Returns:
+            Model ID string.
+        """
+        model_id, _ = self.select_model(complexity=complexity)
+        return model_id
+
+
+def get_model_for_agent(agent_name: str, config: dict[str, Any] | None = None) -> str:
+    """Get the recommended model for a specific agent.
+
+    This is a convenience function for agents that don't use the full
+    ModelSelector but still want to respect the model selection config.
+
+    Args:
+        agent_name: Name of the agent.
+        config: Agent configuration.
+
+    Returns:
+        Model ID string.
+    """
+    selection_config = ModelSelectionConfig.from_config(config)
+
+    # Check agent override first
+    if agent_name in selection_config.agent_overrides:
+        tier = selection_config.agent_overrides[agent_name]
+        return selection_config.models[tier]
+
+    # Default mapping based on agent name
+    agent_tiers: dict[str, ModelTier] = {
+        "orchestrator": ModelTier.SONNET,
+        "ingestor": ModelTier.HAIKU,
+        "researcher": ModelTier.HAIKU,  # Per spec: "Query construction"
+        "executor": ModelTier.SONNET,
+        "archivist": ModelTier.HAIKU,
+        "scribe": ModelTier.HAIKU,
+        "bard": ModelTier.HAIKU,
+        "officer": ModelTier.HAIKU,
+    }
+
+    tier = agent_tiers.get(agent_name, selection_config.fallback_tier)
+    return selection_config.models[tier]
+
+
+__all__ = [
+    "COMPLEXITY_TO_TIER",
+    "DEFAULT_MODELS",
+    "PURPOSE_TO_TIER",
+    "ModelCallResult",
+    "ModelSelectionConfig",
+    "ModelSelector",
+    "ModelTier",
+    "TaskComplexity",
+    "TaskPurpose",
+    "get_model_for_agent",
+]

--- a/tests/unit/test_model_selector.py
+++ b/tests/unit/test_model_selector.py
@@ -1,0 +1,480 @@
+"""
+Tests for multi-model orchestration (model_selector.py).
+
+Tests the ModelSelector's ability to dynamically select models based on
+task complexity, purpose, and agent-specific overrides.
+
+Reference: Issue #3 [AGT-P-002]
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from klabautermann.core.model_selector import (
+    COMPLEXITY_TO_TIER,
+    DEFAULT_MODELS,
+    PURPOSE_TO_TIER,
+    ModelCallResult,
+    ModelSelectionConfig,
+    ModelSelector,
+    ModelTier,
+    TaskComplexity,
+    TaskPurpose,
+    get_model_for_agent,
+)
+
+
+# ===========================================================================
+# ModelTier Tests
+# ===========================================================================
+
+
+class TestModelTier:
+    """Tests for ModelTier enum."""
+
+    def test_model_tiers_defined(self) -> None:
+        """All expected model tiers exist."""
+        assert ModelTier.HAIKU == "haiku"
+        assert ModelTier.SONNET == "sonnet"
+        assert ModelTier.OPUS == "opus"
+
+    def test_all_tiers_have_default_models(self) -> None:
+        """Each tier has a default model ID."""
+        for tier in ModelTier:
+            assert tier in DEFAULT_MODELS
+            assert DEFAULT_MODELS[tier].startswith("claude")
+
+
+# ===========================================================================
+# TaskComplexity Tests
+# ===========================================================================
+
+
+class TestTaskComplexity:
+    """Tests for TaskComplexity enum."""
+
+    def test_complexity_levels_defined(self) -> None:
+        """All expected complexity levels exist."""
+        assert TaskComplexity.SIMPLE == "simple"
+        assert TaskComplexity.MODERATE == "moderate"
+        assert TaskComplexity.COMPLEX == "complex"
+
+    def test_complexity_maps_to_tier(self) -> None:
+        """Each complexity level maps to a model tier."""
+        assert COMPLEXITY_TO_TIER[TaskComplexity.SIMPLE] == ModelTier.HAIKU
+        assert COMPLEXITY_TO_TIER[TaskComplexity.MODERATE] == ModelTier.SONNET
+        assert COMPLEXITY_TO_TIER[TaskComplexity.COMPLEX] == ModelTier.OPUS
+
+
+# ===========================================================================
+# TaskPurpose Tests
+# ===========================================================================
+
+
+class TestTaskPurpose:
+    """Tests for TaskPurpose enum."""
+
+    def test_purpose_types_defined(self) -> None:
+        """All expected purpose types exist."""
+        assert TaskPurpose.CLASSIFICATION == "classification"
+        assert TaskPurpose.EXTRACTION == "extraction"
+        assert TaskPurpose.SEARCH_PLANNING == "search_planning"
+        assert TaskPurpose.REASONING == "reasoning"
+        assert TaskPurpose.SYNTHESIS == "synthesis"
+        assert TaskPurpose.PLANNING == "planning"
+        assert TaskPurpose.ACTION == "action"
+
+    def test_purpose_maps_to_tier(self) -> None:
+        """Each purpose maps to a default model tier."""
+        # Simple tasks -> Haiku
+        assert PURPOSE_TO_TIER[TaskPurpose.CLASSIFICATION] == ModelTier.HAIKU
+        assert PURPOSE_TO_TIER[TaskPurpose.EXTRACTION] == ModelTier.HAIKU
+        assert PURPOSE_TO_TIER[TaskPurpose.SEARCH_PLANNING] == ModelTier.HAIKU
+
+        # Moderate tasks -> Sonnet
+        assert PURPOSE_TO_TIER[TaskPurpose.REASONING] == ModelTier.SONNET
+        assert PURPOSE_TO_TIER[TaskPurpose.SYNTHESIS] == ModelTier.SONNET
+        assert PURPOSE_TO_TIER[TaskPurpose.ACTION] == ModelTier.SONNET
+
+        # Complex tasks -> Opus
+        assert PURPOSE_TO_TIER[TaskPurpose.PLANNING] == ModelTier.OPUS
+
+
+# ===========================================================================
+# ModelSelectionConfig Tests
+# ===========================================================================
+
+
+class TestModelSelectionConfig:
+    """Tests for ModelSelectionConfig."""
+
+    def test_default_config(self) -> None:
+        """Default config uses default models and tiers."""
+        config = ModelSelectionConfig()
+
+        assert config.models == DEFAULT_MODELS
+        assert config.purpose_overrides == {}
+        assert config.agent_overrides == {}
+        assert config.fallback_tier == ModelTier.SONNET
+        assert config.record_metrics is True
+
+    def test_from_config_empty(self) -> None:
+        """from_config with None returns default config."""
+        config = ModelSelectionConfig.from_config(None)
+        assert config.models == DEFAULT_MODELS
+
+    def test_from_config_with_model_overrides(self) -> None:
+        """from_config parses model overrides."""
+        config_dict = {
+            "model_selection": {
+                "models": {
+                    "haiku": "claude-3-haiku-custom",
+                    "sonnet": "claude-sonnet-custom",
+                }
+            }
+        }
+        config = ModelSelectionConfig.from_config(config_dict)
+
+        assert config.models[ModelTier.HAIKU] == "claude-3-haiku-custom"
+        assert config.models[ModelTier.SONNET] == "claude-sonnet-custom"
+        # Opus should still be default
+        assert config.models[ModelTier.OPUS] == DEFAULT_MODELS[ModelTier.OPUS]
+
+    def test_from_config_with_purpose_overrides(self) -> None:
+        """from_config parses purpose overrides."""
+        config_dict = {
+            "model_selection": {
+                "purpose_overrides": {
+                    "extraction": "sonnet",  # Upgrade extraction to Sonnet
+                    "synthesis": "opus",  # Upgrade synthesis to Opus
+                }
+            }
+        }
+        config = ModelSelectionConfig.from_config(config_dict)
+
+        assert config.purpose_overrides[TaskPurpose.EXTRACTION] == ModelTier.SONNET
+        assert config.purpose_overrides[TaskPurpose.SYNTHESIS] == ModelTier.OPUS
+
+    def test_from_config_with_agent_overrides(self) -> None:
+        """from_config parses agent overrides."""
+        config_dict = {
+            "model_selection": {
+                "agent_overrides": {
+                    "researcher": "opus",  # Always use Opus for researcher
+                    "ingestor": "sonnet",  # Upgrade ingestor to Sonnet
+                }
+            }
+        }
+        config = ModelSelectionConfig.from_config(config_dict)
+
+        assert config.agent_overrides["researcher"] == ModelTier.OPUS
+        assert config.agent_overrides["ingestor"] == ModelTier.SONNET
+
+    def test_from_config_with_fallback(self) -> None:
+        """from_config parses fallback tier."""
+        config_dict = {"model_selection": {"fallback_tier": "haiku"}}
+        config = ModelSelectionConfig.from_config(config_dict)
+
+        assert config.fallback_tier == ModelTier.HAIKU
+
+    def test_from_config_ignores_invalid_tiers(self) -> None:
+        """from_config ignores invalid tier names."""
+        config_dict = {
+            "model_selection": {
+                "models": {"invalid_tier": "some-model"},
+                "purpose_overrides": {"invalid_purpose": "haiku"},
+                "agent_overrides": {"test": "invalid_tier"},
+            }
+        }
+        config = ModelSelectionConfig.from_config(config_dict)
+
+        # Should still have defaults
+        assert config.models == DEFAULT_MODELS
+        assert config.purpose_overrides == {}
+        assert config.agent_overrides == {}
+
+
+# ===========================================================================
+# ModelSelector Tests
+# ===========================================================================
+
+
+class TestModelSelector:
+    """Tests for ModelSelector."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Create a mock Anthropic client."""
+        return MagicMock()
+
+    @pytest.fixture
+    def selector(self, mock_client: MagicMock) -> ModelSelector:
+        """Create a ModelSelector with default config."""
+        return ModelSelector(mock_client)
+
+    def test_select_by_purpose(self, selector: ModelSelector) -> None:
+        """select_model selects by purpose."""
+        # Classification -> Haiku
+        model_id, tier = selector.select_model(purpose=TaskPurpose.CLASSIFICATION)
+        assert tier == ModelTier.HAIKU
+        assert model_id == DEFAULT_MODELS[ModelTier.HAIKU]
+
+        # Planning -> Opus
+        model_id, tier = selector.select_model(purpose=TaskPurpose.PLANNING)
+        assert tier == ModelTier.OPUS
+        assert model_id == DEFAULT_MODELS[ModelTier.OPUS]
+
+        # Action -> Sonnet
+        model_id, tier = selector.select_model(purpose=TaskPurpose.ACTION)
+        assert tier == ModelTier.SONNET
+        assert model_id == DEFAULT_MODELS[ModelTier.SONNET]
+
+    def test_select_by_complexity(self, selector: ModelSelector) -> None:
+        """select_model selects by complexity."""
+        # Simple -> Haiku
+        _model_id, tier = selector.select_model(complexity=TaskComplexity.SIMPLE)
+        assert tier == ModelTier.HAIKU
+
+        # Moderate -> Sonnet
+        _model_id, tier = selector.select_model(complexity=TaskComplexity.MODERATE)
+        assert tier == ModelTier.SONNET
+
+        # Complex -> Opus
+        _model_id, tier = selector.select_model(complexity=TaskComplexity.COMPLEX)
+        assert tier == ModelTier.OPUS
+
+    def test_complexity_overrides_purpose(self, selector: ModelSelector) -> None:
+        """Complexity takes precedence over purpose default."""
+        # Classification (default Haiku) with Complex -> Opus
+        _model_id, tier = selector.select_model(
+            purpose=TaskPurpose.CLASSIFICATION, complexity=TaskComplexity.COMPLEX
+        )
+        assert tier == ModelTier.OPUS
+
+    def test_agent_override_takes_precedence(self, mock_client: MagicMock) -> None:
+        """Agent override takes highest precedence."""
+        config = ModelSelectionConfig(
+            agent_overrides={"test_agent": ModelTier.OPUS},
+            purpose_overrides={TaskPurpose.CLASSIFICATION: ModelTier.SONNET},
+        )
+        selector = ModelSelector(mock_client, config)
+
+        # Even with classification purpose (default Haiku, override Sonnet),
+        # agent override should win
+        _model_id, tier = selector.select_model(
+            purpose=TaskPurpose.CLASSIFICATION,
+            agent_name="test_agent",
+        )
+        assert tier == ModelTier.OPUS
+
+    def test_purpose_override_takes_precedence_over_default(self, mock_client: MagicMock) -> None:
+        """Purpose override takes precedence over default."""
+        config = ModelSelectionConfig(purpose_overrides={TaskPurpose.EXTRACTION: ModelTier.SONNET})
+        selector = ModelSelector(mock_client, config)
+
+        # Extraction default is Haiku, override is Sonnet
+        _model_id, tier = selector.select_model(purpose=TaskPurpose.EXTRACTION)
+        assert tier == ModelTier.SONNET
+
+    def test_fallback_when_no_criteria(self, selector: ModelSelector) -> None:
+        """Falls back to config fallback tier when no criteria provided."""
+        _model_id, tier = selector.select_model()
+        assert tier == ModelTier.SONNET  # Default fallback
+
+    def test_get_model_for_purpose(self, selector: ModelSelector) -> None:
+        """get_model_for_purpose returns model ID."""
+        model_id = selector.get_model_for_purpose(TaskPurpose.CLASSIFICATION)
+        assert model_id == DEFAULT_MODELS[ModelTier.HAIKU]
+
+    def test_get_model_for_complexity(self, selector: ModelSelector) -> None:
+        """get_model_for_complexity returns model ID."""
+        model_id = selector.get_model_for_complexity(TaskComplexity.COMPLEX)
+        assert model_id == DEFAULT_MODELS[ModelTier.OPUS]
+
+
+class TestModelSelectorCall:
+    """Tests for ModelSelector.call method."""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        """Create a mock Anthropic client with response."""
+        client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="Test response")]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        client.messages.create.return_value = mock_response
+        return client
+
+    @pytest.fixture
+    def selector(self, mock_client: MagicMock) -> ModelSelector:
+        """Create ModelSelector with mock client."""
+        config = ModelSelectionConfig(record_metrics=False)
+        return ModelSelector(mock_client, config)
+
+    @pytest.mark.asyncio
+    async def test_call_returns_result(self, selector: ModelSelector) -> None:
+        """call returns ModelCallResult with response."""
+        result = await selector.call(
+            prompt="Test prompt",
+            purpose=TaskPurpose.CLASSIFICATION,
+            trace_id="test-123",
+        )
+
+        assert isinstance(result, ModelCallResult)
+        assert result.response == "Test response"
+        assert result.model_tier == ModelTier.HAIKU
+        assert result.input_tokens == 100
+        assert result.output_tokens == 50
+        assert result.used_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_call_uses_correct_model(
+        self, mock_client: MagicMock, selector: ModelSelector
+    ) -> None:
+        """call uses the model selected for the purpose."""
+        await selector.call(
+            prompt="Test prompt",
+            purpose=TaskPurpose.PLANNING,  # Should use Opus
+        )
+
+        # Check that Opus was used
+        call_args = mock_client.messages.create.call_args
+        assert DEFAULT_MODELS[ModelTier.OPUS] in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_call_with_fallback(self, mock_client: MagicMock) -> None:
+        """call uses fallback model when primary fails."""
+        # Make first call fail, second succeed
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="Fallback response")]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+
+        mock_client.messages.create.side_effect = [
+            Exception("Primary failed"),
+            mock_response,
+        ]
+
+        config = ModelSelectionConfig(fallback_tier=ModelTier.SONNET, record_metrics=False)
+        selector = ModelSelector(mock_client, config)
+
+        result = await selector.call(
+            prompt="Test prompt",
+            purpose=TaskPurpose.PLANNING,  # Primary is Opus
+        )
+
+        assert result.response == "Fallback response"
+        assert result.model_tier == ModelTier.SONNET  # Fell back to Sonnet
+        assert result.used_fallback is True
+
+    @pytest.mark.asyncio
+    async def test_call_records_metrics(self, mock_client: MagicMock) -> None:
+        """call records LLM metrics when enabled."""
+        config = ModelSelectionConfig(record_metrics=True)
+        selector = ModelSelector(mock_client, config)
+
+        with (
+            patch("klabautermann.core.model_selector.record_llm_call") as mock_record_call,
+            patch("klabautermann.core.model_selector.record_llm_tokens") as mock_record_tokens,
+            patch("klabautermann.core.model_selector.record_llm_latency") as mock_record_latency,
+        ):
+            await selector.call(
+                prompt="Test prompt",
+                purpose=TaskPurpose.CLASSIFICATION,
+            )
+
+            mock_record_call.assert_called_once_with(model="haiku", purpose="classification")
+            mock_record_tokens.assert_called_once()
+            mock_record_latency.assert_called_once()
+
+
+# ===========================================================================
+# get_model_for_agent Tests
+# ===========================================================================
+
+
+class TestGetModelForAgent:
+    """Tests for get_model_for_agent helper function."""
+
+    def test_default_agent_models(self) -> None:
+        """Default models for known agents."""
+        # Haiku agents
+        assert get_model_for_agent("ingestor") == DEFAULT_MODELS[ModelTier.HAIKU]
+        assert get_model_for_agent("researcher") == DEFAULT_MODELS[ModelTier.HAIKU]
+        assert get_model_for_agent("archivist") == DEFAULT_MODELS[ModelTier.HAIKU]
+        assert get_model_for_agent("scribe") == DEFAULT_MODELS[ModelTier.HAIKU]
+        assert get_model_for_agent("bard") == DEFAULT_MODELS[ModelTier.HAIKU]
+        assert get_model_for_agent("officer") == DEFAULT_MODELS[ModelTier.HAIKU]
+
+        # Sonnet agents
+        assert get_model_for_agent("orchestrator") == DEFAULT_MODELS[ModelTier.SONNET]
+        assert get_model_for_agent("executor") == DEFAULT_MODELS[ModelTier.SONNET]
+
+    def test_unknown_agent_uses_fallback(self) -> None:
+        """Unknown agents use fallback tier (Sonnet)."""
+        assert get_model_for_agent("unknown_agent") == DEFAULT_MODELS[ModelTier.SONNET]
+
+    def test_agent_override_from_config(self) -> None:
+        """Agent override from config takes precedence."""
+        config = {
+            "model_selection": {
+                "agent_overrides": {
+                    "ingestor": "opus",  # Override ingestor to use Opus
+                }
+            }
+        }
+        assert get_model_for_agent("ingestor", config) == DEFAULT_MODELS[ModelTier.OPUS]
+
+
+# ===========================================================================
+# Integration Tests
+# ===========================================================================
+
+
+class TestModelSelectorIntegration:
+    """Integration tests for complete model selection workflows."""
+
+    def test_full_config_chain(self) -> None:
+        """Test complete configuration chain."""
+        config_dict = {
+            "model_selection": {
+                "models": {
+                    "haiku": "claude-3-5-haiku-custom",
+                    "sonnet": "claude-sonnet-4-custom",
+                    "opus": "claude-opus-4-custom",
+                },
+                "purpose_overrides": {
+                    "extraction": "sonnet",  # Upgrade extraction
+                },
+                "agent_overrides": {
+                    "critical_agent": "opus",  # Always Opus
+                },
+                "fallback_tier": "haiku",
+            }
+        }
+
+        config = ModelSelectionConfig.from_config(config_dict)
+        client = MagicMock()
+        selector = ModelSelector(client, config)
+
+        # Agent override takes precedence
+        model_id, tier = selector.select_model(
+            purpose=TaskPurpose.EXTRACTION,  # Would be Sonnet from override
+            agent_name="critical_agent",  # Opus override wins
+        )
+        assert tier == ModelTier.OPUS
+        assert model_id == "claude-opus-4-custom"
+
+        # Purpose override works when no agent override
+        model_id, tier = selector.select_model(purpose=TaskPurpose.EXTRACTION)
+        assert tier == ModelTier.SONNET
+        assert model_id == "claude-sonnet-4-custom"
+
+        # Default purpose still works
+        model_id, tier = selector.select_model(purpose=TaskPurpose.CLASSIFICATION)
+        assert tier == ModelTier.HAIKU
+        assert model_id == "claude-3-5-haiku-custom"


### PR DESCRIPTION
## Summary

- Implement dynamic model selection based on task complexity and purpose
- Use cheaper/faster models (Haiku) for simple tasks, more capable models (Opus) for complex reasoning
- Add configurable per-agent and per-purpose model overrides
- Record LLM usage metrics (calls, tokens, latency) for cost monitoring

## Changes

### New Files
- `src/klabautermann/core/model_selector.py` - Core model selection logic
- `tests/unit/test_model_selector.py` - 29 tests for model selection

### Modified Files
- `src/klabautermann/core/__init__.py` - Export model selector types
- `src/klabautermann/core/config.py` - Add multi-model config settings

## Model Selection Logic

| Task Purpose | Default Model | Rationale |
|-------------|---------------|-----------|
| Classification | Haiku | Fast intent detection |
| Extraction | Haiku | Pattern-based entity extraction |
| Search Planning | Haiku | Query construction |
| Reasoning | Sonnet | Balanced reasoning |
| Synthesis | Sonnet | Response generation |
| Action | Sonnet | Tool/MCP execution |
| Planning | Opus | Complex multi-step reasoning |

## Configuration

```yaml
model_selection:
  models:
    haiku: claude-3-5-haiku-20241022
    sonnet: claude-sonnet-4-20250514
    opus: claude-opus-4-5-20251101
  purpose_overrides:
    extraction: sonnet  # Upgrade if needed
  agent_overrides:
    researcher: opus    # Always use Opus
  fallback_tier: sonnet
```

## Test plan

- [x] All 29 new model selector tests pass
- [x] Full test suite (2211 tests) passes
- [x] Linting passes
- [x] Type checking passes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)