### PR TITLE
feat(agents): Add proactive morning briefing (#4)

### DIFF
--- a/src/klabautermann/agents/officer.py
+++ b/src/klabautermann/agents/officer.py
@@ -59,6 +59,11 @@ class OfficerConfig:
     deadline_warning_hours: int = 24  # Warn when task due within N hours
     meeting_reminder_minutes: int = 15  # Remind N minutes before meeting
 
+    # Morning briefing
+    briefing_hour: int = 7  # Hour (0-23) to generate morning briefing
+    briefing_minute: int = 0  # Minute (0-59)
+    briefing_look_ahead_days: int = 1  # Days to look ahead for events/tasks
+
     # Deep Work detection
     deep_work_keywords: list[str] = field(
         default_factory=lambda: ["Deep Work", "Focus", "Do Not Disturb"]
@@ -119,6 +124,79 @@ class AlertCheckResult:
             "deep_work_event": self.deep_work_event,
             "duration_ms": round(self.duration_ms, 2),
             "alerts": [a.to_dict() for a in self.alerts],
+        }
+
+
+@dataclass
+class CalendarEventSummary:
+    """Summary of a calendar event for morning briefing."""
+
+    uuid: str
+    title: str
+    start_time: int  # Unix timestamp (ms)
+    end_time: int  # Unix timestamp (ms)
+    location: str | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "uuid": self.uuid,
+            "title": self.title,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "location": self.location,
+            "description": self.description,
+        }
+
+
+@dataclass
+class TaskSummary:
+    """Summary of a task for morning briefing."""
+
+    uuid: str
+    action: str
+    priority: str
+    status: str
+    due_date: int | None = None  # Unix timestamp (ms)
+    project_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "uuid": self.uuid,
+            "action": self.action,
+            "priority": self.priority,
+            "status": self.status,
+            "due_date": self.due_date,
+            "project_name": self.project_name,
+        }
+
+
+@dataclass
+class MorningBriefing:
+    """Morning briefing summary with schedule, tasks, and alerts."""
+
+    generated_at: datetime
+    greeting: str
+    events_today: list[CalendarEventSummary]
+    high_priority_tasks: list[TaskSummary]
+    overdue_tasks: list[TaskSummary]
+    overnight_alerts: list[Alert]
+    summary_text: str
+    duration_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "greeting": self.greeting,
+            "events_today": [e.to_dict() for e in self.events_today],
+            "high_priority_tasks": [t.to_dict() for t in self.high_priority_tasks],
+            "overdue_tasks": [t.to_dict() for t in self.overdue_tasks],
+            "overnight_alerts": [a.to_dict() for a in self.overnight_alerts],
+            "summary_text": self.summary_text,
+            "duration_ms": round(self.duration_ms, 2),
         }
 
 
@@ -208,6 +286,9 @@ class OfficerOfTheWatch(BaseAgent):
                 "is_deep_work": is_deep_work,
                 "deep_work_event": self._current_deep_work_event,
             }
+        elif operation == "morning_briefing":
+            briefing = await self.generate_morning_briefing(trace_id=trace_id)
+            result_payload = briefing.to_dict()
         else:
             result_payload = {"error": f"Unknown operation: {operation}"}
 
@@ -294,6 +375,331 @@ class OfficerOfTheWatch(BaseAgent):
         )
 
         return result
+
+    # =========================================================================
+    # Morning Briefing (#4)
+    # =========================================================================
+
+    async def generate_morning_briefing(
+        self,
+        trace_id: str | None = None,
+    ) -> MorningBriefing:
+        """
+        Generate a proactive morning briefing with schedule, tasks, and alerts.
+
+        The morning briefing includes:
+        - Today's calendar events
+        - High-priority tasks (urgent/high)
+        - Overdue tasks
+        - Any overnight alerts
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            MorningBriefing with all relevant information.
+        """
+        start_time = time.time()
+
+        logger.info(
+            "[CHART] Generating morning briefing",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        # Get today's events
+        events_today = await self._get_todays_events(trace_id=trace_id)
+
+        # Get high-priority tasks
+        high_priority_tasks = await self._get_high_priority_tasks(trace_id=trace_id)
+
+        # Get overdue tasks
+        overdue_tasks = await self._get_overdue_tasks_for_briefing(trace_id=trace_id)
+
+        # Get overnight alerts (any alerts generated in last 12 hours)
+        overnight_alerts = await self._get_overnight_alerts(trace_id=trace_id)
+
+        # Generate greeting based on time and workload
+        greeting = self._generate_greeting(
+            event_count=len(events_today),
+            task_count=len(high_priority_tasks),
+            overdue_count=len(overdue_tasks),
+        )
+
+        # Generate summary text
+        summary_text = self._generate_summary_text(
+            events=events_today,
+            high_priority=high_priority_tasks,
+            overdue=overdue_tasks,
+            alerts=overnight_alerts,
+        )
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        briefing = MorningBriefing(
+            generated_at=datetime.now(),
+            greeting=greeting,
+            events_today=events_today,
+            high_priority_tasks=high_priority_tasks,
+            overdue_tasks=overdue_tasks,
+            overnight_alerts=overnight_alerts,
+            summary_text=summary_text,
+            duration_ms=duration_ms,
+        )
+
+        logger.info(
+            f"[BEACON] Morning briefing generated: "
+            f"{len(events_today)} events, {len(high_priority_tasks)} high-priority tasks, "
+            f"{len(overdue_tasks)} overdue",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return briefing
+
+    async def _get_todays_events(
+        self,
+        trace_id: str | None = None,
+    ) -> list[CalendarEventSummary]:
+        """Get all calendar events for today."""
+        # Calculate today's time bounds (midnight to midnight)
+        now = datetime.now()
+        today_start = datetime(now.year, now.month, now.day)
+        today_end = today_start.replace(hour=23, minute=59, second=59)
+
+        today_start_ms = int(today_start.timestamp() * 1000)
+        today_end_ms = int(today_end.timestamp() * 1000)
+
+        query = """
+        MATCH (e:Event)
+        WHERE e.start_time >= $start_ms
+          AND e.start_time <= $end_ms
+          AND e.expired_at IS NULL
+        RETURN e.uuid as uuid, e.title as title, e.start_time as start_time,
+               e.end_time as end_time, e.location_context as location,
+               e.description as description
+        ORDER BY e.start_time ASC
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {
+                "start_ms": today_start_ms,
+                "end_ms": today_end_ms,
+                "limit": self.officer_config.default_query_limit,
+            },
+            trace_id=trace_id,
+        )
+
+        events = []
+        for row in results:
+            event = CalendarEventSummary(
+                uuid=row.get("uuid", ""),
+                title=row.get("title", "Unknown Event"),
+                start_time=row.get("start_time", 0),
+                end_time=row.get("end_time", 0),
+                location=row.get("location"),
+                description=row.get("description"),
+            )
+            events.append(event)
+
+        return events
+
+    async def _get_high_priority_tasks(
+        self,
+        trace_id: str | None = None,
+    ) -> list[TaskSummary]:
+        """Get high-priority tasks (urgent or high priority)."""
+        query = """
+        MATCH (t:Task)
+        WHERE t.status IN ['todo', 'in_progress']
+          AND t.priority IN ['urgent', 'high']
+        OPTIONAL MATCH (t)-[:PART_OF]->(p:Project)
+        RETURN t.uuid as uuid, t.action as action, t.priority as priority,
+               t.status as status, t.due_date as due_date, p.name as project_name
+        ORDER BY
+            CASE t.priority WHEN 'urgent' THEN 0 ELSE 1 END,
+            t.due_date ASC NULLS LAST
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {"limit": self.officer_config.default_query_limit},
+            trace_id=trace_id,
+        )
+
+        tasks = []
+        for row in results:
+            task = TaskSummary(
+                uuid=row.get("uuid", ""),
+                action=row.get("action", "Unknown Task"),
+                priority=row.get("priority", "medium"),
+                status=row.get("status", "todo"),
+                due_date=row.get("due_date"),
+                project_name=row.get("project_name"),
+            )
+            tasks.append(task)
+
+        return tasks
+
+    async def _get_overdue_tasks_for_briefing(
+        self,
+        trace_id: str | None = None,
+    ) -> list[TaskSummary]:
+        """Get overdue tasks for the briefing."""
+        query = """
+        MATCH (t:Task)
+        WHERE t.status IN ['todo', 'in_progress']
+          AND t.due_date IS NOT NULL
+          AND t.due_date < timestamp()
+        OPTIONAL MATCH (t)-[:PART_OF]->(p:Project)
+        RETURN t.uuid as uuid, t.action as action, t.priority as priority,
+               t.status as status, t.due_date as due_date, p.name as project_name
+        ORDER BY t.due_date ASC
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {"limit": self.officer_config.default_query_limit},
+            trace_id=trace_id,
+        )
+
+        tasks = []
+        for row in results:
+            task = TaskSummary(
+                uuid=row.get("uuid", ""),
+                action=row.get("action", "Unknown Task"),
+                priority=row.get("priority", "medium"),
+                status=row.get("status", "todo"),
+                due_date=row.get("due_date"),
+                project_name=row.get("project_name"),
+            )
+            tasks.append(task)
+
+        return tasks
+
+    async def _get_overnight_alerts(
+        self,
+        trace_id: str | None = None,
+    ) -> list[Alert]:
+        """
+        Get alerts that would have been generated overnight.
+
+        This re-runs the alert checks to find any conditions
+        that accumulated overnight.
+        """
+        # Get deadline warnings and overdue tasks
+        deadline_alerts = await self.check_upcoming_deadlines(trace_id=trace_id)
+        overdue_alerts = await self.check_overdue_tasks(trace_id=trace_id)
+
+        # Combine and limit
+        all_alerts = deadline_alerts + overdue_alerts
+        return all_alerts[: self.officer_config.max_alerts_per_check]
+
+    def _generate_greeting(
+        self,
+        event_count: int,
+        task_count: int,
+        overdue_count: int,
+    ) -> str:
+        """Generate a nautical greeting based on the day's outlook."""
+        now = datetime.now()
+        hour = now.hour
+
+        # Time-based greeting
+        if hour < 12:
+            time_greeting = "Good morning, Captain"
+        elif hour < 17:
+            time_greeting = "Good afternoon, Captain"
+        else:
+            time_greeting = "Good evening, Captain"
+
+        # Workload assessment
+        total_items = event_count + task_count
+        if overdue_count > 0:
+            outlook = "There are overdue items requiring attention."
+        elif total_items == 0:
+            outlook = "Clear skies ahead - no events or urgent tasks today."
+        elif total_items <= 3:
+            outlook = "Calm seas - a manageable day ahead."
+        elif total_items <= 6:
+            outlook = "Moderate winds - a full but manageable schedule."
+        else:
+            outlook = "Choppy waters - a busy day ahead. Steady as she goes."
+
+        return f"{time_greeting}. {outlook}"
+
+    def _generate_summary_text(
+        self,
+        events: list[CalendarEventSummary],
+        high_priority: list[TaskSummary],
+        overdue: list[TaskSummary],
+        alerts: list[Alert],
+    ) -> str:
+        """Generate a human-readable summary of the morning briefing."""
+        lines = []
+
+        # Events summary
+        if events:
+            lines.append(f"**Schedule**: {len(events)} event(s) today")
+            for event in events[:5]:  # Limit display
+                start_dt = datetime.fromtimestamp(event.start_time / 1000)
+                time_str = start_dt.strftime("%H:%M")
+                location = f" at {event.location}" if event.location else ""
+                lines.append(f"  - {time_str}: {event.title}{location}")
+            if len(events) > 5:
+                lines.append(f"  - ... and {len(events) - 5} more")
+        else:
+            lines.append("**Schedule**: No events today")
+
+        lines.append("")
+
+        # High-priority tasks
+        if high_priority:
+            lines.append(f"**High Priority Tasks**: {len(high_priority)} task(s)")
+            for task in high_priority[:5]:
+                priority_marker = "[!]" if task.priority == "urgent" else "[H]"
+                project = f" ({task.project_name})" if task.project_name else ""
+                lines.append(f"  - {priority_marker} {task.action}{project}")
+            if len(high_priority) > 5:
+                lines.append(f"  - ... and {len(high_priority) - 5} more")
+        else:
+            lines.append("**High Priority Tasks**: None")
+
+        lines.append("")
+
+        # Overdue tasks
+        if overdue:
+            lines.append(f"**Overdue**: {len(overdue)} task(s) past due")
+            for task in overdue[:3]:
+                due_dt = datetime.fromtimestamp(task.due_date / 1000) if task.due_date else None
+                due_str = f" (due {due_dt.strftime('%Y-%m-%d')})" if due_dt else ""
+                lines.append(f"  - {task.action}{due_str}")
+            if len(overdue) > 3:
+                lines.append(f"  - ... and {len(overdue) - 3} more")
+        else:
+            lines.append("**Overdue**: All clear")
+
+        # Alerts
+        if alerts:
+            lines.append("")
+            lines.append(f"**Alerts**: {len(alerts)} item(s) need attention")
+
+        return "\n".join(lines)
+
+    def is_briefing_time(self) -> bool:
+        """
+        Check if current time matches the configured briefing time.
+
+        Returns:
+            True if it's briefing time, False otherwise.
+        """
+        now = datetime.now()
+        return (
+            now.hour == self.officer_config.briefing_hour
+            and now.minute == self.officer_config.briefing_minute
+        )
 
     # =========================================================================
     # Deep Work Detection
@@ -732,6 +1138,9 @@ __all__ = [
     "AlertCheckResult",
     "AlertPriority",
     "AlertType",
+    "CalendarEventSummary",
+    "MorningBriefing",
     "OfficerConfig",
     "OfficerOfTheWatch",
+    "TaskSummary",
 ]

--- a/tests/unit/test_officer.py
+++ b/tests/unit/test_officer.py
@@ -20,8 +20,11 @@ from klabautermann.agents.officer import (
     AlertCheckResult,
     AlertPriority,
     AlertType,
+    CalendarEventSummary,
+    MorningBriefing,
     OfficerConfig,
     OfficerOfTheWatch,
+    TaskSummary,
 )
 from klabautermann.core.models import AgentMessage
 
@@ -732,3 +735,344 @@ class TestDataClasses:
         assert data["quiet_mode"] is False
         assert data["duration_ms"] == 123.46
         assert len(data["alerts"]) == 1
+
+    def test_calendar_event_summary_to_dict(self) -> None:
+        """CalendarEventSummary should serialize to dict."""
+        event = CalendarEventSummary(
+            uuid="event-123",
+            title="Team Meeting",
+            start_time=1234567890000,
+            end_time=1234571490000,
+            location="Room A",
+            description="Weekly sync",
+        )
+
+        result = event.to_dict()
+
+        assert result["uuid"] == "event-123"
+        assert result["title"] == "Team Meeting"
+        assert result["start_time"] == 1234567890000
+        assert result["location"] == "Room A"
+
+    def test_task_summary_to_dict(self) -> None:
+        """TaskSummary should serialize to dict."""
+        task = TaskSummary(
+            uuid="task-123",
+            action="Review PR",
+            priority="high",
+            status="in_progress",
+            due_date=1234567890000,
+            project_name="Backend",
+        )
+
+        result = task.to_dict()
+
+        assert result["uuid"] == "task-123"
+        assert result["action"] == "Review PR"
+        assert result["priority"] == "high"
+        assert result["project_name"] == "Backend"
+
+    def test_morning_briefing_to_dict(self) -> None:
+        """MorningBriefing should serialize to dict."""
+        from datetime import datetime
+
+        event = CalendarEventSummary(
+            uuid="event-1",
+            title="Meeting",
+            start_time=1234567890000,
+            end_time=1234571490000,
+        )
+        task = TaskSummary(
+            uuid="task-1",
+            action="Task",
+            priority="high",
+            status="todo",
+        )
+        alert = Alert(
+            alert_type=AlertType.DEADLINE_WARNING,
+            priority=AlertPriority.WARNING,
+            message="Alert",
+        )
+
+        briefing = MorningBriefing(
+            generated_at=datetime(2026, 1, 22, 7, 0, 0),
+            greeting="Good morning, Captain",
+            events_today=[event],
+            high_priority_tasks=[task],
+            overdue_tasks=[],
+            overnight_alerts=[alert],
+            summary_text="Test summary",
+            duration_ms=50.5,
+        )
+
+        result = briefing.to_dict()
+
+        assert result["greeting"] == "Good morning, Captain"
+        assert len(result["events_today"]) == 1
+        assert len(result["high_priority_tasks"]) == 1
+        assert len(result["overdue_tasks"]) == 0
+        assert len(result["overnight_alerts"]) == 1
+        assert result["summary_text"] == "Test summary"
+
+
+# =============================================================================
+# Morning Briefing Tests (#4)
+# =============================================================================
+
+
+class TestMorningBriefing:
+    """Tests for morning briefing generation."""
+
+    @pytest.mark.asyncio
+    async def test_generate_morning_briefing_empty(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock
+    ) -> None:
+        """Should generate briefing with no events/tasks."""
+        mock_neo4j.execute_query.return_value = []
+
+        briefing = await officer.generate_morning_briefing()
+
+        assert isinstance(briefing, MorningBriefing)
+        assert briefing.events_today == []
+        assert briefing.high_priority_tasks == []
+        assert briefing.overdue_tasks == []
+        assert "Captain" in briefing.greeting
+        assert "Clear skies" in briefing.greeting or "No events" in briefing.summary_text
+
+    @pytest.mark.asyncio
+    async def test_generate_morning_briefing_with_events(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should include today's events in briefing."""
+        call_count = 0
+
+        async def mock_execute(query: str, params: dict, **kwargs: Any) -> list:
+            nonlocal call_count
+            call_count += 1
+
+            # Events query (first call)
+            if "e:Event" in query and "e.start_time >=" in query:
+                return [
+                    {
+                        "uuid": "event-1",
+                        "title": "Morning Standup",
+                        "start_time": now_ms + (2 * 60 * 60 * 1000),  # 2 hours from now
+                        "end_time": now_ms + (3 * 60 * 60 * 1000),
+                        "location": "Zoom",
+                        "description": "Daily sync",
+                    }
+                ]
+
+            return []
+
+        mock_neo4j.execute_query.side_effect = mock_execute
+
+        briefing = await officer.generate_morning_briefing()
+
+        assert len(briefing.events_today) == 1
+        assert briefing.events_today[0].title == "Morning Standup"
+        assert "Schedule" in briefing.summary_text
+        assert "Morning Standup" in briefing.summary_text
+
+    @pytest.mark.asyncio
+    async def test_generate_morning_briefing_with_high_priority_tasks(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should include high priority tasks in briefing."""
+        call_count = 0
+
+        async def mock_execute(query: str, params: dict, **kwargs: Any) -> list:
+            nonlocal call_count
+            call_count += 1
+
+            # High priority tasks query
+            if "t.priority IN ['urgent', 'high']" in query:
+                return [
+                    {
+                        "uuid": "task-1",
+                        "action": "Deploy hotfix",
+                        "priority": "urgent",
+                        "status": "todo",
+                        "due_date": now_ms + (4 * 60 * 60 * 1000),
+                        "project_name": "Backend",
+                    }
+                ]
+
+            return []
+
+        mock_neo4j.execute_query.side_effect = mock_execute
+
+        briefing = await officer.generate_morning_briefing()
+
+        assert len(briefing.high_priority_tasks) == 1
+        assert briefing.high_priority_tasks[0].action == "Deploy hotfix"
+        assert "High Priority" in briefing.summary_text
+        assert "Deploy hotfix" in briefing.summary_text
+
+    @pytest.mark.asyncio
+    async def test_generate_morning_briefing_with_overdue_tasks(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should include overdue tasks in briefing."""
+        call_count = 0
+
+        async def mock_execute(query: str, params: dict, **kwargs: Any) -> list:
+            nonlocal call_count
+            call_count += 1
+
+            # Overdue tasks query (for briefing)
+            if "t.due_date < timestamp()" in query and "t.priority IN" not in query:
+                return [
+                    {
+                        "uuid": "task-2",
+                        "action": "Complete report",
+                        "priority": "medium",
+                        "status": "in_progress",
+                        "due_date": now_ms - (24 * 60 * 60 * 1000),  # 1 day ago
+                        "project_name": None,
+                    }
+                ]
+
+            return []
+
+        mock_neo4j.execute_query.side_effect = mock_execute
+
+        briefing = await officer.generate_morning_briefing()
+
+        assert len(briefing.overdue_tasks) == 1
+        assert briefing.overdue_tasks[0].action == "Complete report"
+        assert "Overdue" in briefing.summary_text
+
+    @pytest.mark.asyncio
+    async def test_generate_morning_briefing_greeting_with_overdue(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should mention overdue items in greeting when present."""
+
+        async def mock_execute(query: str, params: dict, **kwargs: Any) -> list:
+            # Overdue tasks
+            if "t.due_date < timestamp()" in query and "t.priority IN" not in query:
+                return [
+                    {
+                        "uuid": "task-1",
+                        "action": "Overdue task",
+                        "priority": "medium",
+                        "status": "todo",
+                        "due_date": now_ms - (1 * 60 * 60 * 1000),
+                        "project_name": None,
+                    }
+                ]
+            return []
+
+        mock_neo4j.execute_query.side_effect = mock_execute
+
+        briefing = await officer.generate_morning_briefing()
+
+        assert "overdue" in briefing.greeting.lower()
+
+    @pytest.mark.asyncio
+    async def test_process_message_morning_briefing(
+        self, officer: OfficerOfTheWatch, mock_neo4j: MagicMock
+    ) -> None:
+        """Should handle morning_briefing operation via process_message."""
+        mock_neo4j.execute_query.return_value = []
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="officer_of_the_watch",
+            intent="briefing",
+            payload={"operation": "morning_briefing"},
+            trace_id="test-trace",
+        )
+
+        response = await officer.process_message(msg)
+
+        assert response is not None
+        assert "greeting" in response.payload
+        assert "events_today" in response.payload
+        assert "high_priority_tasks" in response.payload
+        assert "summary_text" in response.payload
+
+
+class TestBriefingTimeConfig:
+    """Tests for briefing time configuration."""
+
+    def test_default_briefing_time(self, mock_neo4j: MagicMock) -> None:
+        """Default briefing time should be 7:00."""
+        officer = OfficerOfTheWatch(neo4j_client=mock_neo4j)
+
+        assert officer.officer_config.briefing_hour == 7
+        assert officer.officer_config.briefing_minute == 0
+
+    def test_custom_briefing_time(self, mock_neo4j: MagicMock) -> None:
+        """Should accept custom briefing time."""
+        config = OfficerConfig(briefing_hour=8, briefing_minute=30)
+        officer = OfficerOfTheWatch(neo4j_client=mock_neo4j, config=config)
+
+        assert officer.officer_config.briefing_hour == 8
+        assert officer.officer_config.briefing_minute == 30
+
+    def test_is_briefing_time_at_configured_time(self, mock_neo4j: MagicMock) -> None:
+        """is_briefing_time should return True at configured time."""
+        from datetime import datetime
+        from unittest.mock import patch
+
+        config = OfficerConfig(briefing_hour=7, briefing_minute=0)
+        officer = OfficerOfTheWatch(neo4j_client=mock_neo4j, config=config)
+
+        # Mock datetime.now() to return 7:00
+        mock_now = datetime(2026, 1, 22, 7, 0, 0)
+        with patch("klabautermann.agents.officer.datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_now
+
+            assert officer.is_briefing_time() is True
+
+    def test_is_briefing_time_not_at_configured_time(self, mock_neo4j: MagicMock) -> None:
+        """is_briefing_time should return False at other times."""
+        from datetime import datetime
+        from unittest.mock import patch
+
+        config = OfficerConfig(briefing_hour=7, briefing_minute=0)
+        officer = OfficerOfTheWatch(neo4j_client=mock_neo4j, config=config)
+
+        # Mock datetime.now() to return 9:30
+        mock_now = datetime(2026, 1, 22, 9, 30, 0)
+        with patch("klabautermann.agents.officer.datetime") as mock_datetime:
+            mock_datetime.now.return_value = mock_now
+
+            assert officer.is_briefing_time() is False
+
+
+class TestGreetingGeneration:
+    """Tests for greeting generation."""
+
+    def test_greeting_clear_skies(self, officer: OfficerOfTheWatch) -> None:
+        """Should generate 'clear skies' greeting with no items."""
+        greeting = officer._generate_greeting(event_count=0, task_count=0, overdue_count=0)
+
+        assert "Captain" in greeting
+        assert "Clear skies" in greeting
+
+    def test_greeting_calm_seas(self, officer: OfficerOfTheWatch) -> None:
+        """Should generate 'calm seas' greeting with few items."""
+        greeting = officer._generate_greeting(event_count=1, task_count=1, overdue_count=0)
+
+        assert "calm" in greeting.lower() or "manageable" in greeting.lower()
+
+    def test_greeting_moderate_winds(self, officer: OfficerOfTheWatch) -> None:
+        """Should generate 'moderate winds' greeting with moderate load."""
+        greeting = officer._generate_greeting(event_count=3, task_count=2, overdue_count=0)
+
+        assert "Moderate" in greeting or "full" in greeting.lower()
+
+    def test_greeting_choppy_waters(self, officer: OfficerOfTheWatch) -> None:
+        """Should generate 'choppy waters' greeting with heavy load."""
+        greeting = officer._generate_greeting(event_count=5, task_count=5, overdue_count=0)
+
+        assert "Choppy" in greeting or "busy" in greeting.lower()
+
+    def test_greeting_overdue_warning(self, officer: OfficerOfTheWatch) -> None:
+        """Should mention overdue items when present."""
+        greeting = officer._generate_greeting(event_count=1, task_count=1, overdue_count=2)
+
+        assert "overdue" in greeting.lower()


### PR DESCRIPTION
## Summary

- Add morning briefing generation to OfficerOfTheWatch agent
- Generates proactive summaries at configurable time (default 7:00 AM)
- Includes today's schedule, high-priority tasks, overdue items, and overnight alerts
- Nautical-themed greetings based on workload assessment

## Changes

### Modified Files
- `src/klabautermann/agents/officer.py` - Add morning briefing functionality
- `tests/unit/test_officer.py` - Add 18 new tests

## Morning Briefing Contents

| Section | Description |
|---------|-------------|
| Greeting | Nautical greeting with workload assessment |
| Schedule | Today's calendar events with times/locations |
| High Priority | Urgent and high priority tasks |
| Overdue | Tasks past their due date |
| Alerts | Deadline warnings and overdue task alerts |
| Summary | Human-readable markdown summary |

## Greeting Variations

- **Clear skies**: No events or urgent tasks
- **Calm seas**: 1-3 items total
- **Moderate winds**: 4-6 items
- **Choppy waters**: 7+ items
- Overdue items trigger special warning

## Configuration

```python
config = OfficerConfig(
    briefing_hour=7,      # Default 7:00 AM
    briefing_minute=0,
    briefing_look_ahead_days=1,
)
```

## Test plan

- [x] All 50 officer tests pass (18 new)
- [x] Full test suite (2229 tests) passes
- [x] Linting passes
- [x] Type checking passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)