### PR TITLE
feat(lore): Add lore query methods (#112, #113, #114, #115)

### DIFF
--- a/src/klabautermann/agents/bard.py
+++ b/src/klabautermann/agents/bard.py
@@ -155,6 +155,7 @@ class LoreEpisode:
     told_at: int  # Unix timestamp (milliseconds)
     created_at: int  # Unix timestamp (milliseconds)
     captain_uuid: str | None = None  # The Person this was told to
+    channel: str | None = None  # Channel where this was told (cli, telegram, etc.)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
@@ -167,6 +168,7 @@ class LoreEpisode:
             "told_at": self.told_at,
             "created_at": self.created_at,
             "captain_uuid": self.captain_uuid,
+            "channel": self.channel,
         }
 
 
@@ -368,6 +370,39 @@ class BardOfTheBilge(BaseAgent):
                 "count": len(active),
                 "max_active": self.bard_config.max_active_sagas,
             }
+        elif operation == "get_recent_lore":
+            # #112: Get recent lore episodes
+            limit = payload.get("limit", 5)
+            episodes = await self.get_recent_lore(limit=limit, trace_id=trace_id)
+            result_payload = {
+                "episodes": [e.to_dict() for e in episodes],
+                "count": len(episodes),
+            }
+        elif operation == "get_saga_chain":
+            # #113: Get all chapters of a saga
+            saga_id_param = payload.get("saga_id", "")
+            episodes = await self.get_saga_chain(saga_id=saga_id_param, trace_id=trace_id)
+            result_payload = {
+                "chapters": [e.to_dict() for e in episodes],
+                "count": len(episodes),
+            }
+        elif operation == "get_cross_channel_story":
+            # #114: Show story travel across channels
+            saga_id_param = payload.get("saga_id", "")
+            cross_channel_chapters = await self.get_cross_channel_story(
+                saga_id=saga_id_param, trace_id=trace_id
+            )
+            result_payload = {
+                "chapters": cross_channel_chapters,
+                "count": len(cross_channel_chapters),
+            }
+        elif operation == "get_saga_statistics_by_captain":
+            # #115: Get saga stats grouped by Captain
+            stats = await self.get_saga_statistics_by_captain(trace_id=trace_id)
+            result_payload = {
+                "statistics": stats,
+                "captain_count": len(stats),
+            }
         else:
             result_payload = {"error": f"Unknown operation: {operation}"}
 
@@ -387,6 +422,7 @@ class BardOfTheBilge(BaseAgent):
         self,
         clean_response: str,
         storm_mode: bool = False,
+        channel: str | None = None,
         trace_id: str | None = None,
     ) -> SaltResult:
         """
@@ -399,6 +435,7 @@ class BardOfTheBilge(BaseAgent):
         Args:
             clean_response: The response to potentially salt with a tidbit.
             storm_mode: If True, never add tidbits (urgent situation).
+            channel: Optional channel where this is being told (cli, telegram, etc.).
             trace_id: Optional trace ID for logging.
 
         Returns:
@@ -435,7 +472,9 @@ class BardOfTheBilge(BaseAgent):
         if active_saga and random.random() < self.bard_config.saga_continuation_probability:
             # Try to continue the saga (may fail due to lifecycle rules)
             try:
-                tidbit, chapter = await self._continue_saga(active_saga, trace_id=trace_id)
+                tidbit, chapter = await self._continue_saga(
+                    active_saga, channel=channel, trace_id=trace_id
+                )
                 salted = f"{clean_response}\n\n_{tidbit}_"
 
                 logger.info(
@@ -709,7 +748,7 @@ class BardOfTheBilge(BaseAgent):
         query = """
         MATCH (le:LoreEpisode {saga_id: $saga_id})-[:TOLD_TO]->(p:Person)
         RETURN le.uuid as uuid, le.saga_id as saga_id, le.saga_name as saga_name,
-               le.chapter as chapter, le.content as content,
+               le.chapter as chapter, le.content as content, le.channel as channel,
                le.told_at as told_at, le.created_at as created_at,
                p.uuid as captain_uuid
         ORDER BY le.chapter ASC
@@ -732,6 +771,7 @@ class BardOfTheBilge(BaseAgent):
                 told_at=row["told_at"],
                 created_at=row["created_at"],
                 captain_uuid=row.get("captain_uuid"),
+                channel=row.get("channel"),
             )
             for row in results
         ]
@@ -739,6 +779,7 @@ class BardOfTheBilge(BaseAgent):
     async def _continue_saga(
         self,
         saga: ActiveSaga,
+        channel: str | None = None,
         trace_id: str | None = None,
     ) -> tuple[str, int]:
         """
@@ -754,6 +795,7 @@ class BardOfTheBilge(BaseAgent):
 
         Args:
             saga: The active saga to continue.
+            channel: Optional channel where this chapter is told.
             trace_id: Optional trace ID for logging.
 
         Returns:
@@ -792,6 +834,7 @@ class BardOfTheBilge(BaseAgent):
             saga_name=saga.saga_name,
             chapter=new_chapter,
             content=content,
+            channel=channel,
             trace_id=trace_id,
         )
 
@@ -799,6 +842,7 @@ class BardOfTheBilge(BaseAgent):
 
     async def start_new_saga(
         self,
+        channel: str | None = None,
         trace_id: str | None = None,
     ) -> tuple[str, str, int]:
         """
@@ -808,6 +852,7 @@ class BardOfTheBilge(BaseAgent):
         - Maximum active sagas limit must not be exceeded (#119)
 
         Args:
+            channel: Optional channel where this saga starts.
             trace_id: Optional trace ID for logging.
 
         Returns:
@@ -834,6 +879,7 @@ class BardOfTheBilge(BaseAgent):
             saga_name=saga_name,
             chapter=1,
             content=content,
+            channel=channel,
             trace_id=trace_id,
         )
 
@@ -850,6 +896,7 @@ class BardOfTheBilge(BaseAgent):
         saga_name: str,
         chapter: int,
         content: str,
+        channel: str | None = None,
         trace_id: str | None = None,
     ) -> str:
         """
@@ -864,6 +911,7 @@ class BardOfTheBilge(BaseAgent):
             saga_name: Human-readable name of the saga.
             chapter: Chapter number (1-indexed).
             content: The story content.
+            channel: Optional channel where this was told (cli, telegram, etc.).
             trace_id: Optional trace ID for logging.
 
         Returns:
@@ -880,6 +928,7 @@ class BardOfTheBilge(BaseAgent):
             saga_name: $saga_name,
             chapter: $chapter,
             content: $content,
+            channel: $channel,
             told_at: $now_ms,
             created_at: $now_ms
         })
@@ -902,6 +951,7 @@ class BardOfTheBilge(BaseAgent):
                 "saga_name": saga_name,
                 "chapter": chapter,
                 "content": content,
+                "channel": channel,
                 "now_ms": now_ms,
                 "captain_uuid": self.captain_uuid,
                 "prev_chapter": chapter - 1,
@@ -926,8 +976,177 @@ class BardOfTheBilge(BaseAgent):
         return random.choice(self.CANONICAL_TIDBITS)
 
     # =========================================================================
-    # Query Operations
+    # Query Operations (#112, #113, #114, #115)
     # =========================================================================
+
+    async def get_recent_lore(
+        self,
+        limit: int = 5,
+        trace_id: str | None = None,
+    ) -> list[LoreEpisode]:
+        """
+        Get the most recent story episodes told to this Captain (#112).
+
+        Retrieves lore episodes ordered by told_at descending, allowing
+        the Bard to see what stories were recently told.
+
+        Reference: specs/architecture/LORE_SYSTEM.md Section 6.1
+
+        Args:
+            limit: Maximum number of episodes to return.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of LoreEpisode objects ordered by told_at DESC.
+        """
+        query = """
+        MATCH (le:LoreEpisode)-[:TOLD_TO]->(p:Person {uuid: $captain_uuid})
+        RETURN le.uuid as uuid, le.saga_id as saga_id, le.saga_name as saga_name,
+               le.chapter as chapter, le.content as content, le.channel as channel,
+               le.told_at as told_at, le.created_at as created_at,
+               p.uuid as captain_uuid
+        ORDER BY le.told_at DESC
+        LIMIT $limit
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {"captain_uuid": self.captain_uuid, "limit": limit},
+            trace_id=trace_id,
+        )
+
+        return [
+            LoreEpisode(
+                uuid=row["uuid"],
+                saga_id=row["saga_id"],
+                saga_name=row["saga_name"],
+                chapter=row["chapter"],
+                content=row["content"],
+                told_at=row["told_at"],
+                created_at=row["created_at"],
+                captain_uuid=row.get("captain_uuid"),
+                channel=row.get("channel"),
+            )
+            for row in results
+        ]
+
+    async def get_saga_chain(
+        self,
+        saga_id: str,
+        trace_id: str | None = None,
+    ) -> list[LoreEpisode]:
+        """
+        Get all chapters of a saga in order (#113).
+
+        Retrieves the complete saga chain with all chapters and metadata,
+        ordered by chapter number ascending.
+
+        Reference: specs/architecture/LORE_SYSTEM.md Section 6.2
+
+        Args:
+            saga_id: The saga ID to retrieve.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of LoreEpisode objects ordered by chapter ASC.
+        """
+        # Use existing _get_saga_chapters with a high limit
+        return await self._get_saga_chapters(
+            saga_id,
+            limit=self.bard_config.max_saga_chapters,
+            trace_id=trace_id,
+        )
+
+    async def get_cross_channel_story(
+        self,
+        saga_id: str,
+        trace_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Show how a story traveled across channels (#114).
+
+        Retrieves saga chapters with channel information, showing
+        how the narrative progressed across different communication
+        channels (CLI, Telegram, etc.).
+
+        Reference: specs/architecture/LORE_SYSTEM.md Section 6.3
+
+        Args:
+            saga_id: The saga ID to analyze.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of chapter info dicts with channel details.
+        """
+        query = """
+        MATCH (le:LoreEpisode {saga_id: $saga_id})-[:TOLD_TO]->(p:Person {uuid: $captain_uuid})
+        WITH le ORDER BY le.chapter ASC
+        RETURN le.chapter as chapter, le.content as content,
+               le.channel as channel, le.told_at as told_at,
+               le.saga_name as saga_name
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {"saga_id": saga_id, "captain_uuid": self.captain_uuid},
+            trace_id=trace_id,
+        )
+
+        return [
+            {
+                "chapter": row["chapter"],
+                "content": row["content"],
+                "channel": row.get("channel"),
+                "told_at": row["told_at"],
+                "saga_name": row.get("saga_name"),
+            }
+            for row in results
+        ]
+
+    async def get_saga_statistics_by_captain(
+        self,
+        trace_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get saga statistics grouped by Captain (#115).
+
+        Counts total sagas and chapters for each Captain who has
+        received lore episodes. Useful for admin/analytics views.
+
+        Reference: specs/architecture/LORE_SYSTEM.md Section 6.4
+
+        Args:
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of statistics dicts grouped by captain_uuid.
+        """
+        query = """
+        MATCH (le:LoreEpisode)-[:TOLD_TO]->(p:Person)
+        WITH p.uuid as captain_uuid, p.name as captain_name,
+             le.saga_id as saga_id, count(le) as chapter_count
+        WITH captain_uuid, captain_name,
+             count(DISTINCT saga_id) as total_sagas,
+             sum(chapter_count) as total_chapters
+        RETURN captain_uuid, captain_name, total_sagas, total_chapters
+        ORDER BY total_chapters DESC
+        """
+
+        results = await self.neo4j.execute_query(
+            query,
+            {},
+            trace_id=trace_id,
+        )
+
+        return [
+            {
+                "captain_uuid": row["captain_uuid"],
+                "captain_name": row.get("captain_name"),
+                "total_sagas": row["total_sagas"],
+                "total_chapters": row["total_chapters"],
+            }
+            for row in results
+        ]
 
     async def get_all_sagas(
         self,

--- a/tests/unit/test_bard.py
+++ b/tests/unit/test_bard.py
@@ -1333,3 +1333,457 @@ class TestLifecycleExceptionExports:
 
         for item in expected:
             assert item in __all__
+
+
+# =============================================================================
+# Lore Query Tests (#112, #113, #114, #115)
+# =============================================================================
+
+
+class TestGetRecentLore:
+    """Tests for get_recent_lore query (#112)."""
+
+    @pytest.mark.asyncio
+    async def test_get_recent_lore_returns_episodes(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should return recent episodes ordered by told_at DESC."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-3",
+                "saga_id": "saga-123",
+                "saga_name": "Recent Saga",
+                "chapter": 3,
+                "content": "Most recent",
+                "channel": "telegram",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": "saga-123",
+                "saga_name": "Recent Saga",
+                "chapter": 2,
+                "content": "Second most recent",
+                "channel": "cli",
+                "told_at": now_ms - 1000,
+                "created_at": now_ms - 1000,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        episodes = await bard.get_recent_lore(limit=5, trace_id="test-123")
+
+        assert len(episodes) == 2
+        assert episodes[0].content == "Most recent"
+        assert episodes[0].channel == "telegram"
+        assert episodes[1].content == "Second most recent"
+
+    @pytest.mark.asyncio
+    async def test_get_recent_lore_empty(self, bard: BardOfTheBilge, mock_neo4j: MagicMock) -> None:
+        """Should return empty list when no lore exists."""
+        mock_neo4j.execute_query.return_value = []
+
+        episodes = await bard.get_recent_lore(limit=5, trace_id="test-123")
+
+        assert episodes == []
+
+    @pytest.mark.asyncio
+    async def test_get_recent_lore_respects_limit(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should pass limit to query."""
+        mock_neo4j.execute_query.return_value = []
+
+        await bard.get_recent_lore(limit=3, trace_id="test-123")
+
+        call_args = mock_neo4j.execute_query.call_args
+        assert call_args[0][1]["limit"] == 3
+
+
+class TestGetSagaChain:
+    """Tests for get_saga_chain query (#113)."""
+
+    @pytest.mark.asyncio
+    async def test_get_saga_chain_returns_chapters_in_order(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should return all saga chapters ordered by chapter ASC."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Chapter one",
+                "channel": "cli",
+                "told_at": now_ms - 2000,
+                "created_at": now_ms - 2000,
+                "captain_uuid": "captain-123",
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 2,
+                "content": "Chapter two",
+                "channel": "telegram",
+                "told_at": now_ms - 1000,
+                "created_at": now_ms - 1000,
+                "captain_uuid": "captain-123",
+            },
+            {
+                "uuid": "ep-3",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 3,
+                "content": "Chapter three",
+                "channel": "cli",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        chapters = await bard.get_saga_chain(saga_id="saga-123", trace_id="test-123")
+
+        assert len(chapters) == 3
+        assert chapters[0].chapter == 1
+        assert chapters[1].chapter == 2
+        assert chapters[2].chapter == 3
+
+    @pytest.mark.asyncio
+    async def test_get_saga_chain_includes_all_metadata(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should include channel and all metadata."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Content",
+                "channel": "telegram",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        chapters = await bard.get_saga_chain(saga_id="saga-123", trace_id="test-123")
+
+        assert chapters[0].channel == "telegram"
+        assert chapters[0].saga_name == "Test Saga"
+
+
+class TestGetCrossChannelStory:
+    """Tests for get_cross_channel_story query (#114)."""
+
+    @pytest.mark.asyncio
+    async def test_get_cross_channel_story_shows_channel_travel(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should show how story traveled across channels."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "chapter": 1,
+                "content": "Started on CLI",
+                "channel": "cli",
+                "told_at": now_ms - 2000,
+                "saga_name": "Traveling Tale",
+            },
+            {
+                "chapter": 2,
+                "content": "Continued on Telegram",
+                "channel": "telegram",
+                "told_at": now_ms - 1000,
+                "saga_name": "Traveling Tale",
+            },
+            {
+                "chapter": 3,
+                "content": "Back to CLI",
+                "channel": "cli",
+                "told_at": now_ms,
+                "saga_name": "Traveling Tale",
+            },
+        ]
+
+        chapters = await bard.get_cross_channel_story(saga_id="saga-123", trace_id="test-123")
+
+        assert len(chapters) == 3
+        assert chapters[0]["channel"] == "cli"
+        assert chapters[1]["channel"] == "telegram"
+        assert chapters[2]["channel"] == "cli"
+
+    @pytest.mark.asyncio
+    async def test_get_cross_channel_story_empty_saga(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should return empty list for nonexistent saga."""
+        mock_neo4j.execute_query.return_value = []
+
+        chapters = await bard.get_cross_channel_story(saga_id="nonexistent", trace_id="test-123")
+
+        assert chapters == []
+
+
+class TestGetSagaStatisticsByCaptain:
+    """Tests for get_saga_statistics_by_captain query (#115)."""
+
+    @pytest.mark.asyncio
+    async def test_get_saga_statistics_by_captain_returns_grouped_stats(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should return statistics grouped by Captain."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "captain_uuid": "captain-1",
+                "captain_name": "Alice",
+                "total_sagas": 5,
+                "total_chapters": 15,
+            },
+            {
+                "captain_uuid": "captain-2",
+                "captain_name": "Bob",
+                "total_sagas": 3,
+                "total_chapters": 9,
+            },
+        ]
+
+        stats = await bard.get_saga_statistics_by_captain(trace_id="test-123")
+
+        assert len(stats) == 2
+        assert stats[0]["captain_uuid"] == "captain-1"
+        assert stats[0]["captain_name"] == "Alice"
+        assert stats[0]["total_sagas"] == 5
+        assert stats[0]["total_chapters"] == 15
+        assert stats[1]["captain_uuid"] == "captain-2"
+
+    @pytest.mark.asyncio
+    async def test_get_saga_statistics_by_captain_empty(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should return empty list when no lore exists."""
+        mock_neo4j.execute_query.return_value = []
+
+        stats = await bard.get_saga_statistics_by_captain(trace_id="test-123")
+
+        assert stats == []
+
+
+class TestProcessMessageLoreQueries:
+    """Tests for process_message handling of new lore query operations."""
+
+    @pytest.mark.asyncio
+    async def test_process_get_recent_lore_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should handle get_recent_lore operation (#112)."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Content",
+                "channel": "cli",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_recent_lore", "limit": 5},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["count"] == 1
+        assert len(response.payload["episodes"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_get_saga_chain_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should handle get_saga_chain operation (#113)."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-123",
+                "saga_name": "Test Saga",
+                "chapter": 1,
+                "content": "Content",
+                "channel": "cli",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-123",
+            },
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_saga_chain", "saga_id": "saga-123"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["count"] == 1
+        assert len(response.payload["chapters"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_get_cross_channel_story_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Should handle get_cross_channel_story operation (#114)."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "chapter": 1,
+                "content": "Content",
+                "channel": "cli",
+                "told_at": now_ms,
+                "saga_name": "Test Saga",
+            },
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_cross_channel_story", "saga_id": "saga-123"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["count"] == 1
+        assert len(response.payload["chapters"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_process_get_saga_statistics_by_captain_operation(
+        self, bard: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Should handle get_saga_statistics_by_captain operation (#115)."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "captain_uuid": "captain-1",
+                "captain_name": "Alice",
+                "total_sagas": 5,
+                "total_chapters": 15,
+            },
+        ]
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="bard_of_the_bilge",
+            intent="query",
+            payload={"operation": "get_saga_statistics_by_captain"},
+            trace_id="test-123",
+        )
+
+        response = await bard.process_message(msg)
+
+        assert response is not None
+        assert response.payload["captain_count"] == 1
+        assert len(response.payload["statistics"]) == 1
+
+
+class TestLoreEpisodeChannelField:
+    """Tests for LoreEpisode channel field."""
+
+    def test_lore_episode_with_channel(self, now_ms: int) -> None:
+        """LoreEpisode should store channel."""
+        episode = LoreEpisode(
+            uuid="ep-123",
+            saga_id="saga-456",
+            saga_name="Test Saga",
+            chapter=1,
+            content="Content",
+            told_at=now_ms,
+            created_at=now_ms,
+            captain_uuid="captain-789",
+            channel="telegram",
+        )
+
+        assert episode.channel == "telegram"
+
+    def test_lore_episode_channel_in_to_dict(self, now_ms: int) -> None:
+        """LoreEpisode.to_dict should include channel."""
+        episode = LoreEpisode(
+            uuid="ep-123",
+            saga_id="saga-456",
+            saga_name="Test Saga",
+            chapter=1,
+            content="Content",
+            told_at=now_ms,
+            created_at=now_ms,
+            captain_uuid="captain-789",
+            channel="cli",
+        )
+
+        d = episode.to_dict()
+
+        assert "channel" in d
+        assert d["channel"] == "cli"
+
+    def test_lore_episode_channel_defaults_to_none(self, now_ms: int) -> None:
+        """LoreEpisode channel should default to None."""
+        episode = LoreEpisode(
+            uuid="ep-123",
+            saga_id="saga-456",
+            saga_name="Test Saga",
+            chapter=1,
+            content="Content",
+            told_at=now_ms,
+            created_at=now_ms,
+        )
+
+        assert episode.channel is None
+
+
+class TestSaltResponseChannel:
+    """Tests for salt_response channel parameter."""
+
+    @pytest.mark.asyncio
+    async def test_salt_response_passes_channel_to_continue_saga(
+        self, mock_neo4j: MagicMock, captain_uuid: str, now_ms: int
+    ) -> None:
+        """Should pass channel when continuing a saga."""
+        config = BardConfig(
+            tidbit_probability=1.0,
+            saga_continuation_probability=1.0,
+            min_chapter_interval_hours=0,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga
+            [
+                {
+                    "saga_id": "saga-123",
+                    "saga_name": "Test Saga",
+                    "last_chapter": 2,
+                    "last_told": now_ms - 1000,
+                }
+            ],
+            # _save_episode
+            [{"uuid": "ep-new"}],
+        ]
+
+        await bard.salt_response("Hello", channel="telegram", trace_id="test-123")
+
+        # Verify channel was passed to _save_episode
+        save_call = mock_neo4j.execute_query.call_args_list[1]
+        assert save_call[0][1]["channel"] == "telegram"


### PR DESCRIPTION
## Summary

- Implements `get_recent_lore` (#112) - Retrieve last N story episodes ordered by told_at DESC
- Implements `get_saga_chain` (#113) - Get all chapters of a saga in order with metadata
- Implements `get_cross_channel_story` (#114) - Show how a story traveled across channels
- Implements `get_saga_statistics_by_captain` (#115) - Count sagas and chapters grouped by Captain

Also adds:
- Channel field to LoreEpisode for tracking where episodes were told
- Channel parameter to salt_response, _continue_saga, and start_new_saga
- Process message handlers for all new operations

## Test plan

- [x] 17 new unit tests covering all new query methods
- [x] All 2299 unit tests passing
- [x] mypy type checking passing

Closes #112, #113, #114, #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)