### PR TITLE
test(lore): Add saga continuation, cross-channel, and E2E tests (#122, #123, #124)

### DIFF
--- a/tests/e2e/test_lore_golden_scenarios.py
+++ b/tests/e2e/test_lore_golden_scenarios.py
@@ -1,0 +1,375 @@
+"""
+Golden Scenario E2E Tests for Lore System.
+
+Tests the cross-conversation saga scenario from LORE_SYSTEM.md Section 8.2.
+
+Issue: #124
+
+IMPORTANT: Tests define what code SHOULD do according to specs.
+If tests fail, fix the CODE, not the tests.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klabautermann.agents.bard import (
+    BardConfig,
+    BardOfTheBilge,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    """Create a mock Neo4j client."""
+    mock = MagicMock()
+    mock.execute_query = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def captain_uuid() -> str:
+    """Fixture for Captain's UUID."""
+    return "captain-e2e-lore-test"
+
+
+@pytest.fixture
+def now_ms() -> int:
+    """Get current timestamp in milliseconds."""
+    return int(time.time() * 1000)
+
+
+@pytest.fixture
+def bard_e2e(mock_neo4j: MagicMock, captain_uuid: str) -> BardOfTheBilge:
+    """Create a BardOfTheBilge for E2E testing."""
+    config = BardConfig(
+        tidbit_probability=1.0,  # Always add tidbit for testing
+        saga_continuation_probability=1.0,  # Always continue sagas
+        max_saga_chapters=5,
+        min_chapter_interval_hours=0,  # No interval for testing
+    )
+    return BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+
+# =============================================================================
+# E2E Cross-Conversation Saga Test (#124)
+# =============================================================================
+
+
+@pytest.mark.e2e
+@pytest.mark.lore
+class TestLoreGoldenScenarioCrossConversation:
+    """
+    Golden Scenario: Cross-Conversation Saga (#124)
+
+    Tests the complete flow:
+    1. CLI: User asks about tasks -> Bard starts saga, Chapter 1
+    2. Telegram: User checks calendar -> Bard continues with Chapter 2
+    3. CLI (next day): User asks "What story were you telling?" ->
+       Bard retrieves saga and continues with Chapter 3
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 8.2
+    """
+
+    @pytest.mark.asyncio
+    async def test_cli_starts_saga(
+        self, bard_e2e: BardOfTheBilge, mock_neo4j: MagicMock, captain_uuid: str
+    ) -> None:
+        """CLI: User asks about tasks, Bard starts saga with Chapter 1."""
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga - no active sagas
+            [],
+            # _save_episode
+            [{"uuid": "ep-ch1"}],
+        ]
+
+        # Simulate salt_response starting a new saga
+        # Force the new saga path by ensuring no active saga exists
+        with patch.object(bard_e2e, "_get_active_saga", new_callable=AsyncMock, return_value=None):
+            mock_neo4j.execute_query.side_effect = [
+                [],  # _get_active_sagas for start_new_saga check
+                [{"uuid": "ep-ch1"}],  # _save_episode
+            ]
+            content, saga_id, chapter = await bard_e2e.start_new_saga(
+                channel="cli", trace_id="e2e-124-step1"
+            )
+
+        assert chapter == 1, "First chapter should be 1"
+        assert saga_id is not None, "Saga ID should be created"
+
+        # Verify channel was CLI
+        save_call = mock_neo4j.execute_query.call_args_list[-1]
+        assert save_call[0][1]["channel"] == "cli"
+
+    @pytest.mark.asyncio
+    async def test_telegram_continues_saga(
+        self, bard_e2e: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Telegram: User checks calendar, Bard continues saga with Chapter 2."""
+        saga_id = "e2e-saga-124"
+
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga - return active saga from CLI
+            [
+                {
+                    "saga_id": saga_id,
+                    "saga_name": "The E2E Tale",
+                    "last_chapter": 1,
+                    "last_told": now_ms - 3600000,  # 1 hour ago
+                }
+            ],
+            # _save_episode
+            [{"uuid": "ep-ch2"}],
+        ]
+
+        # salt_response on Telegram should continue the saga
+        result = await bard_e2e.salt_response(
+            clean_response="Here's your calendar for today...",
+            channel="telegram",
+            trace_id="e2e-124-step2",
+        )
+
+        assert result.tidbit_added is True, "Tidbit should be added"
+        assert result.is_continuation is True, "Should be a saga continuation"
+        assert result.chapter == 2, "Should be chapter 2"
+        assert result.saga_id == saga_id, "Should continue same saga"
+
+        # Verify chapter 2 was saved with telegram channel
+        save_call = mock_neo4j.execute_query.call_args_list[-1]
+        assert save_call[0][1]["channel"] == "telegram"
+        assert save_call[0][1]["chapter"] == 2
+
+    @pytest.mark.asyncio
+    async def test_cli_retrieves_and_continues_saga(
+        self, bard_e2e: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """CLI (next day): User asks about story, Bard retrieves and continues."""
+        saga_id = "e2e-saga-124"
+
+        # Mock active saga that has traveled CLI -> Telegram
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga - saga at chapter 2 from Telegram
+            [
+                {
+                    "saga_id": saga_id,
+                    "saga_name": "The E2E Tale",
+                    "last_chapter": 2,
+                    "last_told": now_ms - 86400000,  # 1 day ago
+                }
+            ],
+            # _save_episode for chapter 3
+            [{"uuid": "ep-ch3"}],
+        ]
+
+        # User on CLI asks about the story - Bard continues
+        result = await bard_e2e.salt_response(
+            clean_response="The story I was telling? Let me continue...",
+            channel="cli",
+            trace_id="e2e-124-step3",
+        )
+
+        assert result.tidbit_added is True
+        assert result.is_continuation is True
+        assert result.chapter == 3, "Should continue to chapter 3"
+        assert result.saga_id == saga_id
+
+        # Verify chapter 3 saved back to CLI
+        save_call = mock_neo4j.execute_query.call_args_list[-1]
+        assert save_call[0][1]["channel"] == "cli"
+        assert save_call[0][1]["chapter"] == 3
+
+    @pytest.mark.asyncio
+    async def test_complete_cross_conversation_flow(
+        self, mock_neo4j: MagicMock, captain_uuid: str, now_ms: int
+    ) -> None:
+        """
+        Complete E2E flow: CLI start -> Telegram continue -> CLI retrieve and continue.
+
+        This is the Golden Scenario from LORE_SYSTEM.md Section 8.2.
+        """
+        config = BardConfig(
+            tidbit_probability=1.0,
+            saga_continuation_probability=1.0,
+            max_saga_chapters=5,
+            min_chapter_interval_hours=0,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        saga_id = "cross-conversation-saga"
+
+        # =========================================
+        # Step 1: CLI - User asks about tasks
+        # =========================================
+        mock_neo4j.execute_query.side_effect = [
+            [],  # _get_active_sagas (none yet)
+            [{"uuid": "ep-1"}],  # _save_episode
+        ]
+
+        _, saga_id, ch1 = await bard.start_new_saga(channel="cli", trace_id="e2e-cross-1")
+        assert ch1 == 1
+
+        # =========================================
+        # Step 2: Telegram - User checks calendar
+        # =========================================
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga - returns saga from step 1
+            [
+                {
+                    "saga_id": saga_id,
+                    "saga_name": "Generated Saga Name",
+                    "last_chapter": 1,
+                    "last_told": now_ms - 3600000,
+                }
+            ],
+            [{"uuid": "ep-2"}],  # _save_episode
+        ]
+
+        result2 = await bard.salt_response(
+            "Your calendar for today...", channel="telegram", trace_id="e2e-cross-2"
+        )
+
+        assert result2.chapter == 2
+        assert result2.is_continuation is True
+
+        # =========================================
+        # Step 3: CLI (next day) - Ask about story
+        # =========================================
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga - returns saga from step 2
+            [
+                {
+                    "saga_id": saga_id,
+                    "saga_name": "Generated Saga Name",
+                    "last_chapter": 2,
+                    "last_told": now_ms - 86400000,
+                }
+            ],
+            [{"uuid": "ep-3"}],  # _save_episode
+        ]
+
+        result3 = await bard.salt_response(
+            "What story were you telling?", channel="cli", trace_id="e2e-cross-3"
+        )
+
+        assert result3.chapter == 3
+        assert result3.is_continuation is True
+        assert result3.saga_id == saga_id
+
+        # =========================================
+        # Verify: Query the cross-channel saga
+        # =========================================
+        # Reset mock to clear side_effect before setting return_value
+        mock_neo4j.execute_query.reset_mock()
+        mock_neo4j.execute_query.side_effect = None
+        mock_neo4j.execute_query.return_value = [
+            {
+                "chapter": 1,
+                "content": "Started on CLI",
+                "channel": "cli",
+                "told_at": now_ms - 86400000 - 3600000,
+                "saga_name": "Generated Saga Name",
+            },
+            {
+                "chapter": 2,
+                "content": "Continued on Telegram",
+                "channel": "telegram",
+                "told_at": now_ms - 86400000,
+                "saga_name": "Generated Saga Name",
+            },
+            {
+                "chapter": 3,
+                "content": "Back to CLI",
+                "channel": "cli",
+                "told_at": now_ms,
+                "saga_name": "Generated Saga Name",
+            },
+        ]
+
+        cross_channel = await bard.get_cross_channel_story(saga_id=saga_id, trace_id="e2e-verify")
+
+        assert len(cross_channel) == 3, "Should have 3 chapters"
+        assert cross_channel[0]["channel"] == "cli", "Chapter 1 on CLI"
+        assert cross_channel[1]["channel"] == "telegram", "Chapter 2 on Telegram"
+        assert cross_channel[2]["channel"] == "cli", "Chapter 3 on CLI"
+
+
+@pytest.mark.e2e
+@pytest.mark.lore
+class TestLoreGoldenScenarioSagaCompletion:
+    """
+    Tests saga completion behavior when max chapters reached.
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 3.1
+    """
+
+    @pytest.mark.asyncio
+    async def test_saga_completes_at_max_chapters(
+        self, bard_e2e: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Saga should be marked complete when reaching max chapters."""
+        saga_id = "completion-saga"
+
+        # Saga at chapter 4 (one before max of 5)
+        mock_neo4j.execute_query.side_effect = [
+            [
+                {
+                    "saga_id": saga_id,
+                    "saga_name": "The Final Chapter Saga",
+                    "last_chapter": 4,
+                    "last_told": now_ms - 1000,
+                }
+            ],
+            [{"uuid": "ep-5"}],  # Chapter 5 (final)
+        ]
+
+        result = await bard_e2e.salt_response(
+            "One more response...", channel="cli", trace_id="e2e-completion"
+        )
+
+        assert result.chapter == 5, "Should be final chapter 5"
+
+        # After this, the saga should be complete
+        # Next salt_response should not continue this saga
+
+
+@pytest.mark.e2e
+@pytest.mark.lore
+class TestLoreGoldenScenarioStormMode:
+    """
+    Tests storm mode suppresses tidbits during urgent situations.
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 5.1
+    """
+
+    @pytest.mark.asyncio
+    async def test_storm_mode_skips_tidbit(
+        self, bard_e2e: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Storm mode should prevent tidbit addition even with active saga."""
+        mock_neo4j.execute_query.return_value = [
+            {
+                "saga_id": "storm-test-saga",
+                "saga_name": "Interrupted Tale",
+                "last_chapter": 2,
+                "last_told": 1234567890,
+            }
+        ]
+
+        result = await bard_e2e.salt_response(
+            "URGENT: Server is down!",
+            storm_mode=True,
+            channel="cli",
+            trace_id="e2e-storm",
+        )
+
+        assert result.tidbit_added is False, "No tidbit in storm mode"
+        assert result.storm_mode_skipped is True, "Should indicate storm mode skip"
+        assert result.salted_response == "URGENT: Server is down!", "Response unchanged"

--- a/tests/unit/test_lore_system.py
+++ b/tests/unit/test_lore_system.py
@@ -1,0 +1,479 @@
+"""
+Unit tests for Lore System saga continuation and cross-channel persistence.
+
+Tests the saga lifecycle features based on LORE_SYSTEM.md Section 8.1.
+
+Issues: #122, #123
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from klabautermann.agents.bard import (
+    CANONICAL_TIDBITS,
+    ActiveSaga,
+    BardConfig,
+    BardOfTheBilge,
+    LoreEpisode,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_neo4j() -> MagicMock:
+    """Create a mock Neo4j client."""
+    mock = MagicMock()
+    mock.execute_query = AsyncMock(return_value=[])
+    return mock
+
+
+@pytest.fixture
+def captain_uuid() -> str:
+    """Fixture for Captain's UUID."""
+    return "captain-lore-test-uuid"
+
+
+@pytest.fixture
+def now_ms() -> int:
+    """Get current timestamp in milliseconds."""
+    return int(time.time() * 1000)
+
+
+@pytest.fixture
+def bard_with_no_interval(mock_neo4j: MagicMock, captain_uuid: str) -> BardOfTheBilge:
+    """Create a BardOfTheBilge instance with no chapter interval."""
+    config = BardConfig(
+        tidbit_probability=1.0,  # Always add tidbit for testing
+        saga_continuation_probability=1.0,  # Always try to continue
+        max_saga_chapters=5,
+        min_chapter_interval_hours=0,  # No interval for testing
+    )
+    return BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+
+# =============================================================================
+# Test Saga Continuation (#122)
+# =============================================================================
+
+
+class TestSagaContinuation:
+    """
+    Tests for saga continuation functionality (#122).
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 8.1
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_saga_creates_chapter_one(
+        self, bard_with_no_interval: BardOfTheBilge, mock_neo4j: MagicMock
+    ) -> None:
+        """Starting a saga should create chapter 1."""
+        mock_neo4j.execute_query.side_effect = [
+            # First call: _get_active_sagas (no active sagas)
+            [],
+            # Second call: _save_episode
+            [{"uuid": "ep-chapter-1"}],
+        ]
+
+        content, saga_id, chapter = await bard_with_no_interval.start_new_saga(trace_id="test-122")
+
+        assert chapter == 1
+        assert saga_id is not None
+        assert content in CANONICAL_TIDBITS
+
+        # Verify _save_episode was called with chapter=1
+        save_call = mock_neo4j.execute_query.call_args_list[1]
+        assert save_call[0][1]["chapter"] == 1
+
+    @pytest.mark.asyncio
+    async def test_continue_saga_increments_chapter(
+        self, bard_with_no_interval: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Continuing a saga should increment the chapter number."""
+        # Create an active saga at chapter 2
+        saga = ActiveSaga(
+            saga_id="saga-continuation-test",
+            saga_name="The Tale of Testing",
+            last_chapter=2,
+            last_told=now_ms - 1000,  # Told 1 second ago
+        )
+
+        mock_neo4j.execute_query.return_value = [{"uuid": "ep-chapter-3"}]
+
+        content, chapter = await bard_with_no_interval._continue_saga(saga, trace_id="test-122")
+
+        assert chapter == 3
+        assert content in CANONICAL_TIDBITS
+
+    @pytest.mark.asyncio
+    async def test_verify_saga_chain_after_continuation(
+        self, bard_with_no_interval: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """After continuation, get_saga_chain should return all chapters in order."""
+        # Mock the saga chain query to return 3 chapters
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": "saga-chain-test",
+                "saga_name": "The Chronicle of Chains",
+                "chapter": 1,
+                "content": "Chapter one begins",
+                "channel": "cli",
+                "told_at": now_ms - 2000,
+                "created_at": now_ms - 2000,
+                "captain_uuid": "captain-lore-test-uuid",
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": "saga-chain-test",
+                "saga_name": "The Chronicle of Chains",
+                "chapter": 2,
+                "content": "Chapter two continues",
+                "channel": "cli",
+                "told_at": now_ms - 1000,
+                "created_at": now_ms - 1000,
+                "captain_uuid": "captain-lore-test-uuid",
+            },
+            {
+                "uuid": "ep-3",
+                "saga_id": "saga-chain-test",
+                "saga_name": "The Chronicle of Chains",
+                "chapter": 3,
+                "content": "Chapter three concludes",
+                "channel": "cli",
+                "told_at": now_ms,
+                "created_at": now_ms,
+                "captain_uuid": "captain-lore-test-uuid",
+            },
+        ]
+
+        chapters = await bard_with_no_interval.get_saga_chain(
+            saga_id="saga-chain-test", trace_id="test-122"
+        )
+
+        assert len(chapters) == 3
+        assert chapters[0].chapter == 1
+        assert chapters[1].chapter == 2
+        assert chapters[2].chapter == 3
+        assert chapters[0].content == "Chapter one begins"
+        assert chapters[2].content == "Chapter three concludes"
+
+    @pytest.mark.asyncio
+    async def test_full_saga_continuation_flow(
+        self, mock_neo4j: MagicMock, captain_uuid: str, now_ms: int
+    ) -> None:
+        """Test complete flow: start saga -> continue -> continue -> verify chain."""
+        config = BardConfig(
+            tidbit_probability=1.0,
+            saga_continuation_probability=1.0,
+            max_saga_chapters=5,
+            min_chapter_interval_hours=0,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        # Step 1: Start new saga
+        mock_neo4j.execute_query.side_effect = [
+            [],  # No active sagas
+            [{"uuid": "ep-1"}],  # _save_episode for chapter 1
+        ]
+
+        content1, saga_id, chapter1 = await bard.start_new_saga(trace_id="test-122-flow")
+        assert chapter1 == 1
+
+        # Reset mock for step 2
+        mock_neo4j.execute_query.reset_mock()
+        mock_neo4j.execute_query.side_effect = None
+        mock_neo4j.execute_query.return_value = [{"uuid": "ep-2"}]
+
+        # Step 2: Continue saga to chapter 2
+        saga = ActiveSaga(
+            saga_id=saga_id,
+            saga_name="Test Flow Saga",
+            last_chapter=1,
+            last_told=now_ms,
+        )
+
+        content2, chapter2 = await bard._continue_saga(saga, trace_id="test-122-flow")
+        assert chapter2 == 2
+
+        # Reset mock for step 3
+        mock_neo4j.execute_query.reset_mock()
+        mock_neo4j.execute_query.return_value = [{"uuid": "ep-3"}]
+
+        # Step 3: Continue saga to chapter 3
+        saga.last_chapter = 2
+
+        content3, chapter3 = await bard._continue_saga(saga, trace_id="test-122-flow")
+        assert chapter3 == 3
+
+
+# =============================================================================
+# Test Cross-Channel Persistence (#123)
+# =============================================================================
+
+
+class TestCrossChannelPersistence:
+    """
+    Tests for cross-channel story persistence (#123).
+
+    Stories should persist across channels (CLI, Telegram).
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 8.1
+    """
+
+    @pytest.mark.asyncio
+    async def test_tell_story_on_cli_channel(
+        self, bard_with_no_interval: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Story told on CLI should have channel='cli'."""
+        # Mock active saga exists
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga
+            [
+                {
+                    "saga_id": "saga-cli-test",
+                    "saga_name": "The CLI Tale",
+                    "last_chapter": 1,
+                    "last_told": now_ms - 1000,
+                }
+            ],
+            # _save_episode
+            [{"uuid": "ep-cli"}],
+        ]
+
+        result = await bard_with_no_interval.salt_response(
+            clean_response="Hello from CLI",
+            channel="cli",
+            trace_id="test-123-cli",
+        )
+
+        assert result.tidbit_added is True
+
+        # Verify channel was passed to _save_episode
+        save_call = mock_neo4j.execute_query.call_args_list[1]
+        assert save_call[0][1]["channel"] == "cli"
+
+    @pytest.mark.asyncio
+    async def test_continue_story_on_telegram_channel(
+        self, bard_with_no_interval: BardOfTheBilge, mock_neo4j: MagicMock, now_ms: int
+    ) -> None:
+        """Story continued on Telegram should have channel='telegram'."""
+        mock_neo4j.execute_query.side_effect = [
+            # _get_active_saga
+            [
+                {
+                    "saga_id": "saga-telegram-test",
+                    "saga_name": "The Telegram Tale",
+                    "last_chapter": 2,
+                    "last_told": now_ms - 1000,
+                }
+            ],
+            # _save_episode
+            [{"uuid": "ep-telegram"}],
+        ]
+
+        result = await bard_with_no_interval.salt_response(
+            clean_response="Hello from Telegram",
+            channel="telegram",
+            trace_id="test-123-telegram",
+        )
+
+        assert result.tidbit_added is True
+
+        # Verify channel was passed to _save_episode
+        save_call = mock_neo4j.execute_query.call_args_list[1]
+        assert save_call[0][1]["channel"] == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_same_saga_across_channels(
+        self, mock_neo4j: MagicMock, captain_uuid: str, now_ms: int
+    ) -> None:
+        """Same saga should be accessible from different channels."""
+        config = BardConfig(
+            tidbit_probability=1.0,
+            saga_continuation_probability=1.0,
+            max_saga_chapters=5,
+            min_chapter_interval_hours=0,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        # Tell on CLI (chapter 1)
+        mock_neo4j.execute_query.side_effect = [
+            [],  # No active sagas
+            [{"uuid": "ep-1"}],  # _save_episode
+        ]
+
+        _, saga_id, _ = await bard.start_new_saga(channel="cli", trace_id="test-123-cross")
+
+        # Reset mock for continue
+        mock_neo4j.execute_query.reset_mock()
+        mock_neo4j.execute_query.side_effect = None
+        mock_neo4j.execute_query.return_value = [{"uuid": "ep-2"}]
+
+        # Continue on Telegram (chapter 2)
+        saga = ActiveSaga(
+            saga_id=saga_id,
+            saga_name="Cross Channel Saga",
+            last_chapter=1,
+            last_told=now_ms,
+        )
+
+        _, chapter = await bard._continue_saga(saga, channel="telegram", trace_id="test-123-cross")
+
+        assert chapter == 2
+
+        # Reset mock for cross-channel query
+        mock_neo4j.execute_query.reset_mock()
+        mock_neo4j.execute_query.return_value = [
+            {
+                "chapter": 1,
+                "content": "Started on CLI",
+                "channel": "cli",
+                "told_at": now_ms - 1000,
+                "saga_name": "Cross Channel Saga",
+            },
+            {
+                "chapter": 2,
+                "content": "Continued on Telegram",
+                "channel": "telegram",
+                "told_at": now_ms,
+                "saga_name": "Cross Channel Saga",
+            },
+        ]
+
+        cross_channel = await bard.get_cross_channel_story(
+            saga_id=saga_id, trace_id="test-123-cross"
+        )
+
+        assert len(cross_channel) == 2
+        assert cross_channel[0]["channel"] == "cli"
+        assert cross_channel[1]["channel"] == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_saga_persists_after_channel_switch(
+        self, mock_neo4j: MagicMock, captain_uuid: str, now_ms: int
+    ) -> None:
+        """Saga should be retrievable after switching channels."""
+        config = BardConfig(
+            tidbit_probability=1.0,
+            saga_continuation_probability=1.0,
+            max_saga_chapters=5,
+            min_chapter_interval_hours=0,
+        )
+        bard = BardOfTheBilge(neo4j_client=mock_neo4j, captain_uuid=captain_uuid, config=config)
+
+        saga_id = "saga-persist-test"
+
+        # Mock get_saga_chain to return chapters from different channels
+        mock_neo4j.execute_query.return_value = [
+            {
+                "uuid": "ep-1",
+                "saga_id": saga_id,
+                "saga_name": "Persistent Saga",
+                "chapter": 1,
+                "content": "CLI chapter",
+                "channel": "cli",
+                "told_at": now_ms - 3000,
+                "created_at": now_ms - 3000,
+                "captain_uuid": captain_uuid,
+            },
+            {
+                "uuid": "ep-2",
+                "saga_id": saga_id,
+                "saga_name": "Persistent Saga",
+                "chapter": 2,
+                "content": "Telegram chapter",
+                "channel": "telegram",
+                "told_at": now_ms - 2000,
+                "created_at": now_ms - 2000,
+                "captain_uuid": captain_uuid,
+            },
+            {
+                "uuid": "ep-3",
+                "saga_id": saga_id,
+                "saga_name": "Persistent Saga",
+                "chapter": 3,
+                "content": "Back to CLI",
+                "channel": "cli",
+                "told_at": now_ms - 1000,
+                "created_at": now_ms - 1000,
+                "captain_uuid": captain_uuid,
+            },
+        ]
+
+        # Query from "CLI" perspective - should see all chapters
+        chapters = await bard.get_saga_chain(saga_id=saga_id, trace_id="test-123-persist")
+
+        assert len(chapters) == 3
+        assert all(c.saga_id == saga_id for c in chapters)
+
+        # Verify channels are tracked
+        assert chapters[0].channel == "cli"
+        assert chapters[1].channel == "telegram"
+        assert chapters[2].channel == "cli"
+
+
+# =============================================================================
+# Test LoreEpisode with Channel (#122, #123)
+# =============================================================================
+
+
+class TestLoreEpisodeChannel:
+    """Tests for LoreEpisode channel tracking."""
+
+    def test_lore_episode_stores_channel(self, now_ms: int) -> None:
+        """LoreEpisode should store channel information."""
+        episode = LoreEpisode(
+            uuid="ep-channel-test",
+            saga_id="saga-123",
+            saga_name="Channel Test Saga",
+            chapter=1,
+            content="Test content",
+            told_at=now_ms,
+            created_at=now_ms,
+            captain_uuid="captain-test",
+            channel="telegram",
+        )
+
+        assert episode.channel == "telegram"
+        assert episode.to_dict()["channel"] == "telegram"
+
+    def test_lore_episode_channel_defaults_none(self, now_ms: int) -> None:
+        """LoreEpisode channel should default to None for backwards compatibility."""
+        episode = LoreEpisode(
+            uuid="ep-no-channel",
+            saga_id="saga-123",
+            saga_name="No Channel Saga",
+            chapter=1,
+            content="Test content",
+            told_at=now_ms,
+            created_at=now_ms,
+        )
+
+        assert episode.channel is None
+
+    def test_lore_episode_to_dict_includes_channel(self, now_ms: int) -> None:
+        """LoreEpisode.to_dict() should include channel in output."""
+        episode = LoreEpisode(
+            uuid="ep-dict-test",
+            saga_id="saga-123",
+            saga_name="Dict Test Saga",
+            chapter=1,
+            content="Test content",
+            told_at=now_ms,
+            created_at=now_ms,
+            channel="cli",
+        )
+
+        d = episode.to_dict()
+
+        assert "channel" in d
+        assert d["channel"] == "cli"


### PR DESCRIPTION
## Summary

- Add unit tests for saga continuation (#122) - chapter creation and flow
- Add unit tests for cross-channel persistence (#123) - CLI/Telegram tracking
- Add E2E tests for cross-conversation saga scenario (#124)
- 17 new tests covering lore system functionality

## Test Coverage

**Unit tests (test_lore_system.py)**:
- TestSagaContinuation: 4 tests for chapter creation and continuation flow
- TestCrossChannelPersistence: 4 tests for CLI/Telegram channel tracking  
- TestLoreEpisodeChannel: 3 tests for channel field storage and serialization

**E2E tests (test_lore_golden_scenarios.py)**:
- TestLoreGoldenScenarioCrossConversation: 4 tests for cross-conversation saga flow
- TestLoreGoldenScenarioSagaCompletion: 1 test for saga completion at max chapters
- TestLoreGoldenScenarioStormMode: 1 test for storm mode tidbit suppression

## Test plan
- [x] Run unit tests: `uv run pytest tests/unit/test_lore_system.py -v`
- [x] Run E2E tests: `uv run pytest tests/e2e/test_lore_golden_scenarios.py -v`
- [x] Run full test suite: `uv run pytest tests/ --ignore=tests/integration/ -q`

**Results**: 2336 passed, 34 skipped, 5 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)