### PR TITLE
feat(scribe): Add saga progress to daily journal reflection (#110)

### DIFF
--- a/docs/blog/posts/2026-01-22-canonical-sagas.html
+++ b/docs/blog/posts/2026-01-22-canonical-sagas.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="post-date" content="2026-01-22">
+    <meta name="post-category" content="feature,lore">
+    <meta name="post-slug" content="canonical-sagas">
+    <meta name="post-excerpt" content="Five complete sagas join the Bard's repertoire. Tales of dial-up days, notification krakens, and forgotten passwords.">
+    <title>The Five Sagas | Ship's Log</title>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a href="../index.html" class="back-link">&larr; Back to Ship's Log</a>
+        </div>
+    </header>
+
+    <article class="post">
+        <header class="post-header">
+            <div class="container">
+                <div class="post-meta">
+                    <time datetime="2026-01-22">January 22, 2026</time>
+                    <div class="post-categories">
+                        <span class="category-tag">feature</span>
+                        <span class="category-tag">lore</span>
+                    </div>
+                </div>
+                <h1 class="post-title">The Five Sagas</h1>
+            </div>
+        </header>
+
+        <main class="post-body">
+            <div class="container">
+                <p>The Bard of the Bilge has always had stories. Today, it has canon.</p>
+                <p>LORE_SYSTEM.md Section 4.1 specified five complete sagas - multi-chapter tales that unfold across conversations. Until now, they lived only in the spec. Now they live in code.</p>
+
+                <h2>The Implementation (#102-106)</h2>
+                <p>Five issues. Five sagas. One dictionary:</p>
+                <pre><code>CANONICAL_SAGAS: dict[str, dict[str, str | list[str]]] = {
+    "great-maelstrom": {
+        "name": "The Great Maelstrom of '98",
+        "theme": "origin",
+        "chapters": [...],
+    },
+    "kraken-scroll": {...},
+    "sirens-inbox": {...},
+    "ghost-ship": {...},
+    "lighthouse-passwords": {...},
+}</code></pre>
+                <p>Each saga has a name, a theme, and exactly 5 chapters. The structure mirrors how sagas work in runtime - the Bard picks a saga, tells chapter 1, and continues across conversations until chapter 5 concludes the tale.</p>
+
+                <h2>The Great Maelstrom of '98 (#102)</h2>
+                <p>Theme: <em>origin</em>. A tale of the early internet.</p>
+                <blockquote>
+                    <p>"I remember the Great Fog of '98. The bandwidth was so thin you could barely fit a 'Hello' through the wire."</p>
+                </blockquote>
+                <p>Chapter 2 carries a JPEG across the Atlantic. Chapter 3 reveals it was a cat picture. Chapter 5 delivers the wisdom: "Sometimes the slowest journeys carry the most precious cargo."</p>
+
+                <h2>The Kraken of the Infinite Scroll (#103)</h2>
+                <p>Theme: <em>battle</em>. Fighting social media notifications.</p>
+                <blockquote>
+                    <p>"Every time I cut off a 'Like,' two 'Retweets' grew in its place."</p>
+                </blockquote>
+                <p>The beast attacks at 2 AM. Fire doesn't work. Logic doesn't work. Only a library card defeats it - the Kraken hadn't seen a book in decades.</p>
+
+                <h2>The Sirens of the Inbox (#104)</h2>
+                <p>Theme: <em>warning</em>. The lure of urgent emails.</p>
+                <blockquote>
+                    <p>"They sing a song of 'Urgent!' and 'Immediate Action Required!' But it's all a ruse to lead your ship onto the rocks of burnout."</p>
+                </blockquote>
+                <p>Four thousand spam messages deleted in one night. The Sirens respond with increasingly desperate subject lines. A quiet morning is worth any Siren's wrath.</p>
+
+                <h2>The Ghost Ship of Abandoned Projects (#105)</h2>
+                <p>Theme: <em>melancholy</em>. The haunting of unfinished work.</p>
+                <blockquote>
+                    <p>"The crew of that ship are all the 'I'll get to it later' promises. They whisper at night."</p>
+                </blockquote>
+                <p>A TODO list from 2019. A README that was never written. Every cabin full of potential, gathering dust. Complete your tasks - keep the ghost ship at bay.</p>
+
+                <h2>The Lighthouse of Forgotten Passwords (#106)</h2>
+                <p>Theme: <em>humor</em>. Password recovery adventures.</p>
+                <blockquote>
+                    <p>"Its keeper is an ancient navigator named 'P@ssw0rd123'."</p>
+                </blockquote>
+                <p>The vault holds every credential lost to "I'll remember it later." A password from 2012? Stored in a sticky note, which was stored in another sticky note. Use a password manager - disappoint the Lighthouse keeper.</p>
+
+                <h2>The Structure</h2>
+                <p>Each saga follows a narrative arc:</p>
+                <ul>
+                    <li><strong>Chapter 1</strong>: The hook - introduce the situation</li>
+                    <li><strong>Chapter 2</strong>: Rising action - the conflict develops</li>
+                    <li><strong>Chapter 3</strong>: Complication - things get interesting</li>
+                    <li><strong>Chapter 4</strong>: Climax or revelation</li>
+                    <li><strong>Chapter 5</strong>: Resolution and wisdom</li>
+                </ul>
+                <p>The themes span the Bard's emotional range: origin stories, battles, warnings, melancholy, humor. A complete palette for digital sea tales.</p>
+
+                <h2>Issues Closed</h2>
+                <ul>
+                    <li>#102: [LORE-006] Add The Great Maelstrom of '98 saga</li>
+                    <li>#103: [LORE-007] Add The Kraken of the Infinite Scroll saga</li>
+                    <li>#104: [LORE-008] Add The Sirens of the Inbox saga</li>
+                    <li>#105: [LORE-009] Add The Ghost Ship of Abandoned Projects saga</li>
+                    <li>#106: [LORE-010] Add The Lighthouse of Forgotten Passwords saga</li>
+                </ul>
+
+                <h2>The Result</h2>
+                <p>The Bard now has 5 complete sagas with 25 chapters of content. When a saga starts, it knows exactly where the story goes. When it ends, the Captain has heard a complete tale.</p>
+                <p><em>"Now I use a password manager. The Lighthouse keeper was not pleased, but my sanity was worth his disappointment."</em></p>
+            </div>
+        </main>
+    </article>
+
+    <footer class="site-footer">
+        <div class="container">
+            <a href="../index.html">&larr; Back to Ship's Log</a>
+        </div>
+    </footer>
+</body>
+</html>

--- a/src/klabautermann/agents/journal_generation.py
+++ b/src/klabautermann/agents/journal_generation.py
@@ -56,7 +56,12 @@ Your journal entry must follow this five-part structure:
    - Suggestions for improvement (gentle, not preachy)
    - Observations about timing, focus, or habits
 
-5. SAILOR'S THINKING
+5. LORE PROGRESS (if any tales were told)
+   - Mention any saga chapters advanced today
+   - Note which channels the tales traveled through
+   - Skip this section if no tales were told
+
+6. SAILOR'S THINKING
    - A brief, witty reflection in your distinctive voice
    - Forward-looking thought about tomorrow or the week
    - End on a hopeful or motivating note
@@ -67,6 +72,8 @@ Sarah from Acme signaled progress on the Q1 budget—a fair wind at last.
 Three tasks walked the plank (completed), but The Manifest still holds 7 pending items.
 I notice the Captain tends to schedule back-to-back meetings on Tuesdays;
 perhaps we chart a calmer course next week.
+I advanced 'The Great Maelstrom of '98' to chapter 3 today, shared across CLI and Telegram.
+The tale travels well between ports.
 The horizon looks promising. Tomorrow brings a meeting with the board—
 I've prepared the budget notes in The Locker."
 
@@ -105,6 +112,19 @@ def format_analytics_for_prompt(analytics: DailyAnalytics) -> str:
     else:
         top_projects = "no specific projects"
 
+    # Format saga progress (#110)
+    if analytics.saga_progress:
+        saga_lines = []
+        for sp in analytics.saga_progress:
+            channel_info = f" via {sp.channel}" if sp.channel else ""
+            saga_lines.append(
+                f"  - Advanced '{sp.saga_name}' to chapter {sp.chapter}{channel_info}"
+            )
+        saga_summary = "\n".join(saga_lines)
+        lore_section = f"\nLore Progress:\n{saga_summary}"
+    else:
+        lore_section = "\nLore Progress: No tales were told today. The sea was quiet."
+
     # Build formatted context
     context = f"""Today's voyage statistics for {analytics.date}:
 - {analytics.interaction_count} messages exchanged across The Bridge
@@ -113,7 +133,8 @@ def format_analytics_for_prompt(analytics: DailyAnalytics) -> str:
 - {new_entities_summary} recorded in The Locker
 - {analytics.notes_created} notes captured
 - {analytics.events_count} events on The Charts
-- Most discussed: {top_projects}"""
+- Most discussed: {top_projects}
+{lore_section}"""
 
     return context
 
@@ -174,12 +195,13 @@ async def generate_journal(
     # Build user prompt
     user_prompt = f"""{analytics_context}
 
-Generate a daily journal entry following the five-part structure:
+Generate a daily journal entry following the six-part structure:
 1. VOYAGE SUMMARY
 2. KEY INTERACTIONS
 3. PROGRESS REPORT
 4. WORKFLOW OBSERVATIONS
-5. SAILOR'S THINKING
+5. LORE PROGRESS (include if any tales were told)
+6. SAILOR'S THINKING
 
 Be honest, insightful, and capture Klabautermann's voice."""
 

--- a/src/klabautermann/core/models.py
+++ b/src/klabautermann/core/models.py
@@ -298,6 +298,20 @@ class JournalEntryNode(BaseNode):
     generated_at: float = Field(default_factory=current_timestamp)
 
 
+class SagaProgress(BaseModel):
+    """
+    Progress update for a saga told during the day.
+
+    Used by Scribe to include lore progress in daily journal.
+    Reference: specs/architecture/LORE_SYSTEM.md Section 5.2
+    """
+
+    saga_id: str
+    saga_name: str
+    chapter: int
+    channel: str | None = None
+
+
 class DailyAnalytics(BaseModel):
     """
     Aggregated statistics for a single day.
@@ -314,6 +328,7 @@ class DailyAnalytics(BaseModel):
     top_projects: list[dict[str, Any]] = Field(default_factory=list)
     notes_created: int
     events_count: int
+    saga_progress: list[SagaProgress] = Field(default_factory=list)  # Lore progress (#110)
 
 
 class JournalEntry(BaseModel):

--- a/src/klabautermann/memory/analytics.py
+++ b/src/klabautermann/memory/analytics.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from klabautermann.core.logger import logger
-from klabautermann.core.models import DailyAnalytics
+from klabautermann.core.models import DailyAnalytics, SagaProgress
 
 
 if TYPE_CHECKING:
@@ -250,6 +250,73 @@ async def get_daily_projects_discussed(
     return result
 
 
+async def get_daily_saga_progress(
+    neo4j: Neo4jClient,
+    date: str,
+    trace_id: str | None = None,
+) -> list[SagaProgress]:
+    """
+    Get saga progress (lore episodes) for a specific day.
+
+    Queries LoreEpisode nodes told on the given day and returns
+    saga progress information for inclusion in daily journal.
+
+    Reference: specs/architecture/LORE_SYSTEM.md Section 5.2 (#110)
+
+    Args:
+        neo4j: Connected Neo4jClient instance
+        date: Date in YYYY-MM-DD format
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        List of SagaProgress models with saga information
+    """
+    day_start, day_end = get_day_bounds(date)
+
+    # Convert to milliseconds for told_at comparison (stored as Unix ms)
+    day_start_ms = day_start * 1000
+    day_end_ms = day_end * 1000
+
+    logger.debug(
+        f"[WHISPER] Gathering saga progress for {date}",
+        extra={"trace_id": trace_id, "agent_name": "analytics"},
+    )
+
+    query = """
+    MATCH (le:LoreEpisode)
+    WHERE le.told_at >= $day_start_ms AND le.told_at < $day_end_ms
+      AND le.saga_id IS NOT NULL
+    RETURN le.saga_id as saga_id,
+           le.saga_name as saga_name,
+           le.chapter as chapter,
+           le.channel as channel
+    ORDER BY le.told_at ASC
+    """
+
+    result = await neo4j.execute_query(
+        query,
+        {"day_start_ms": day_start_ms, "day_end_ms": day_end_ms},
+        trace_id=trace_id,
+    )
+
+    saga_progress = [
+        SagaProgress(
+            saga_id=r["saga_id"],
+            saga_name=r["saga_name"] or r["saga_id"],
+            chapter=r["chapter"],
+            channel=r.get("channel"),
+        )
+        for r in result
+    ]
+
+    logger.debug(
+        f"[WHISPER] Found {len(saga_progress)} saga episodes told on {date}",
+        extra={"trace_id": trace_id, "agent_name": "analytics"},
+    )
+
+    return saga_progress
+
+
 async def get_daily_analytics(
     neo4j: Neo4jClient,
     date: str,
@@ -283,6 +350,7 @@ async def get_daily_analytics(
     new_entities = await get_daily_entity_counts(neo4j, date, trace_id)
     task_stats = await get_daily_task_stats(neo4j, date, trace_id)
     top_projects = await get_daily_projects_discussed(neo4j, date, limit=3, trace_id=trace_id)
+    saga_progress = await get_daily_saga_progress(neo4j, date, trace_id)
 
     # Extract specific entity counts
     notes_created = new_entities.get("Note", 0)
@@ -297,6 +365,7 @@ async def get_daily_analytics(
         top_projects=top_projects,
         notes_created=notes_created,
         events_count=events_count,
+        saga_progress=saga_progress,
     )
 
     logger.info(
@@ -322,6 +391,7 @@ __all__ = [
     "get_daily_entity_counts",
     "get_daily_interaction_count",
     "get_daily_projects_discussed",
+    "get_daily_saga_progress",
     "get_daily_task_stats",
     "get_day_bounds",
 ]

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -279,6 +279,68 @@ class TestDailyProjectsDiscussed:
         assert projects == []
 
 
+class TestDailySagaProgress:
+    """Test suite for saga progress in daily analytics (#110)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_saga_episodes_from_day(self) -> None:
+        """Should return saga episodes told on the given day."""
+        mock_neo4j = AsyncMock()
+        mock_neo4j.execute_query.return_value = [
+            {
+                "saga_id": "great-maelstrom",
+                "saga_name": "The Great Maelstrom",
+                "chapter": 2,
+                "channel": "cli",
+            },
+            {
+                "saga_id": "great-maelstrom",
+                "saga_name": "The Great Maelstrom",
+                "chapter": 3,
+                "channel": "telegram",
+            },
+        ]
+
+        from klabautermann.memory.analytics import get_daily_saga_progress
+
+        progress = await get_daily_saga_progress(mock_neo4j, "2026-01-15")
+
+        assert len(progress) == 2
+        assert progress[0].saga_id == "great-maelstrom"
+        assert progress[0].chapter == 2
+        assert progress[0].channel == "cli"
+        assert progress[1].chapter == 3
+        assert progress[1].channel == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_for_no_tales(self) -> None:
+        """Should return empty list when no tales were told."""
+        mock_neo4j = AsyncMock()
+        mock_neo4j.execute_query.return_value = []
+
+        from klabautermann.memory.analytics import get_daily_saga_progress
+
+        progress = await get_daily_saga_progress(mock_neo4j, "2026-01-15")
+
+        assert progress == []
+
+    @pytest.mark.asyncio
+    async def test_uses_millisecond_timestamps(self) -> None:
+        """Should convert day bounds to milliseconds for told_at comparison."""
+        mock_neo4j = AsyncMock()
+        mock_neo4j.execute_query.return_value = []
+
+        from klabautermann.memory.analytics import get_daily_saga_progress
+
+        await get_daily_saga_progress(mock_neo4j, "2026-01-15")
+
+        call_args = mock_neo4j.execute_query.call_args
+        params = call_args[0][1]
+        # Timestamps should be in milliseconds (13+ digits)
+        assert params["day_start_ms"] > 1000000000000
+        assert params["day_end_ms"] > params["day_start_ms"]
+
+
 class TestDailyAnalytics:
     """Test suite for aggregated daily analytics."""
 
@@ -302,6 +364,14 @@ class TestDailyAnalytics:
                 {"name": "Project A", "uuid": "uuid-a", "mentions": 10},
                 {"name": "Project B", "uuid": "uuid-b", "mentions": 5},
             ],
+            [  # saga progress (#110)
+                {
+                    "saga_id": "great-maelstrom",
+                    "saga_name": "The Great Maelstrom",
+                    "chapter": 2,
+                    "channel": "cli",
+                },
+            ],
         ]
 
         analytics = await get_daily_analytics(
@@ -320,6 +390,9 @@ class TestDailyAnalytics:
         assert analytics.notes_created == 5
         assert analytics.events_count == 3
         assert len(analytics.top_projects) == 2
+        assert len(analytics.saga_progress) == 1
+        assert analytics.saga_progress[0].saga_id == "great-maelstrom"
+        assert analytics.saga_progress[0].chapter == 2
 
     @pytest.mark.asyncio
     async def test_handles_missing_entity_types(self) -> None:
@@ -332,12 +405,14 @@ class TestDailyAnalytics:
             [{"count": 0}],  # completed
             [{"count": 0}],  # created
             [],  # projects
+            [],  # saga progress - no tales told
         ]
 
         analytics = await get_daily_analytics(mock_neo4j, "2026-01-15")
 
         assert analytics.notes_created == 0
         assert analytics.events_count == 0
+        assert analytics.saga_progress == []
 
     @pytest.mark.asyncio
     async def test_propagates_trace_id(self) -> None:
@@ -349,6 +424,7 @@ class TestDailyAnalytics:
             [{"count": 0}],
             [{"count": 0}],
             [],
+            [],  # saga progress
         ]
 
         await get_daily_analytics(


### PR DESCRIPTION
## Summary
- Add saga progress tracking to daily journal reflections per LORE_SYSTEM.md Section 5.2
- The Scribe now includes lore progress in its daily Ship's Log

## Changes
- Add `SagaProgress` model to `core/models.py`
- Add `saga_progress` field to `DailyAnalytics` 
- Add `get_daily_saga_progress()` query function
- Update journal generation prompt with LORE PROGRESS section
- Format saga progress in journal context (saga name, chapter, channel)
- Add 3 new unit tests for saga progress functionality

## Test plan
- [x] Run unit tests for analytics, scribe, journal generation
- [x] Verify 2329 unit tests pass
- [x] Run ruff linter

## Closes
- #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)