### PR TITLE
feat(hull-cleaner): Add transitive redundancy detection (#86)

### DIFF
--- a/src/klabautermann/agents/hull_cleaner.py
+++ b/src/klabautermann/agents/hull_cleaner.py
@@ -12,7 +12,7 @@ Audit entries are generated for all pruning operations and can be persisted
 to Neo4j as AuditLog nodes for historical review and compliance.
 
 Reference: specs/architecture/AGENTS_EXTENDED.md Section 5
-Issues: #79, #80, #81, #84, #85, #87, #88
+Issues: #79, #80, #81, #84, #85, #86, #87, #88
 """
 
 from __future__ import annotations
@@ -56,6 +56,64 @@ class PruningAction(str, Enum):
     ARCHIVE_THREAD = "ARCHIVE_THREAD"
     PREVIEW = "PREVIEW"
     MERGE_PREVIEW = "MERGE_PREVIEW"
+    TRANSITIVE_REDUCTION = "TRANSITIVE_REDUCTION"
+    TRANSITIVE_PREVIEW = "TRANSITIVE_PREVIEW"
+
+
+@dataclass
+class TransitivePath:
+    """A redundant transitive path A->B->C where A->C also exists."""
+
+    source_uuid: str
+    intermediate_uuid: str
+    target_uuid: str
+    source_name: str
+    intermediate_name: str
+    target_name: str
+    relationship_type: str
+    direct_weight: float  # Weight of A->C
+    indirect_weight: float  # Combined weight of A->B + B->C
+    redundant_rel_id: int  # ID of the relationship to remove
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "source_uuid": self.source_uuid,
+            "intermediate_uuid": self.intermediate_uuid,
+            "target_uuid": self.target_uuid,
+            "source_name": self.source_name,
+            "intermediate_name": self.intermediate_name,
+            "target_name": self.target_name,
+            "relationship_type": self.relationship_type,
+            "direct_weight": round(self.direct_weight, 3),
+            "indirect_weight": round(self.indirect_weight, 3),
+            "redundant_rel_id": self.redundant_rel_id,
+        }
+
+
+@dataclass
+class TransitiveResult:
+    """Result of a transitive reduction operation."""
+
+    operation: str
+    dry_run: bool
+    paths_found: int
+    paths_reduced: int
+    errors: list[str]
+    duration_ms: float
+    audit_entries: list[AuditEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "paths_found": self.paths_found,
+            "paths_reduced": self.paths_reduced,
+            "errors": self.errors,
+            "duration_ms": round(self.duration_ms, 2),
+            "audit_entry_count": len(self.audit_entries),
+        }
 
 
 @dataclass
@@ -110,6 +168,11 @@ class HullCleanerConfig:
     duplicate_similarity_threshold: float = 0.85
     duplicate_auto_merge_threshold: float = 0.95  # Auto-merge above this threshold
     max_duplicates_per_run: int = 100
+
+    # Transitive redundancy detection settings (#86)
+    detect_transitive_redundancy: bool = True
+    transitive_weight_threshold: float = 0.5  # Remove if direct > indirect combined
+    max_transitive_per_run: int = 100
 
     # Run limits
     max_deletions_per_run: int = 1000
@@ -323,6 +386,17 @@ class HullCleaner(BaseAgent):
         elif operation == "merge_duplicates":
             merge_result = await self.merge_duplicates(dry_run=dry_run, trace_id=trace_id)
             result_payload = merge_result.to_dict()
+        elif operation == "find_transitive_paths":
+            paths = await self.find_transitive_paths(trace_id=trace_id)
+            result_payload = {
+                "transitive_paths": [p.to_dict() for p in paths],
+                "count": len(paths),
+            }
+        elif operation == "reduce_transitive_paths":
+            transitive_result = await self.reduce_transitive_paths(
+                dry_run=dry_run, trace_id=trace_id
+            )
+            result_payload = transitive_result.to_dict()
         elif operation == "query_stored_audit":
             # Query persisted audit entries from Neo4j
             filters = payload.get("filters", {})
@@ -433,8 +507,22 @@ class HullCleaner(BaseAgent):
                 )
                 errors.append(error_msg)
 
-        # Future: Add more pruning operations here
-        # - Transitive path reduction
+        # 4. Detect and reduce transitive redundancy
+        if self.hull_config.detect_transitive_redundancy:
+            try:
+                transitive_result = await self.reduce_transitive_paths(
+                    dry_run=dry_run, trace_id=trace_id
+                )
+                total_rels_found += transitive_result.paths_found
+                total_rels_pruned += transitive_result.paths_reduced
+                self._audit_log.extend(transitive_result.audit_entries)
+            except Exception as e:
+                error_msg = f"Transitive reduction failed: {e}"
+                logger.error(
+                    f"[STORM] {error_msg}",
+                    extra={"trace_id": trace_id, "agent_name": self.name},
+                )
+                errors.append(error_msg)
 
         # Persist audit entries to Neo4j if requested
         if persist_audit and self._audit_log:
@@ -1096,6 +1184,195 @@ class HullCleaner(BaseAgent):
         return False
 
     # =========================================================================
+    # Transitive Redundancy Detection (#86)
+    # =========================================================================
+
+    async def find_transitive_paths(
+        self,
+        limit: int | None = None,
+        trace_id: str | None = None,
+    ) -> list[TransitivePath]:
+        """
+        Find redundant transitive paths in the graph.
+
+        A transitive path A->B->C is redundant when:
+        1. A direct relationship A->C exists
+        2. The direct relationship has equal or greater weight
+
+        Args:
+            limit: Maximum paths to return.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            List of TransitivePath objects describing redundant paths.
+        """
+        limit = limit or self.hull_config.max_transitive_per_run
+
+        logger.info(
+            "[CHART] Searching for transitive redundancy",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        # Find triangles where direct relationship is stronger than indirect path
+        # Only consider weighted relationship types used by Graphiti
+        query = """
+        MATCH (a)-[r1]->(b)-[r2]->(c)
+        WHERE (a)-[direct]->(c)
+        AND type(r1) = type(r2)
+        AND type(r1) = type(direct)
+        AND r1.weight IS NOT NULL
+        AND r2.weight IS NOT NULL
+        AND direct.weight IS NOT NULL
+        AND direct.weight >= (r1.weight + r2.weight) / 2
+        AND a <> c
+        AND a <> b
+        AND b <> c
+        RETURN DISTINCT
+            a.uuid as source_uuid,
+            b.uuid as intermediate_uuid,
+            c.uuid as target_uuid,
+            COALESCE(a.name, a.uuid) as source_name,
+            COALESCE(b.name, b.uuid) as intermediate_name,
+            COALESCE(c.name, c.uuid) as target_name,
+            type(r2) as relationship_type,
+            direct.weight as direct_weight,
+            (r1.weight + r2.weight) / 2 as indirect_weight,
+            id(r2) as redundant_rel_id
+        ORDER BY direct_weight - indirect_weight DESC
+        LIMIT $limit
+        """
+
+        result = await self.neo4j.execute_query(
+            query,
+            {"limit": limit},
+            trace_id=trace_id,
+        )
+
+        paths = [
+            TransitivePath(
+                source_uuid=row["source_uuid"],
+                intermediate_uuid=row["intermediate_uuid"],
+                target_uuid=row["target_uuid"],
+                source_name=row["source_name"],
+                intermediate_name=row["intermediate_name"],
+                target_name=row["target_name"],
+                relationship_type=row["relationship_type"],
+                direct_weight=float(row["direct_weight"]),
+                indirect_weight=float(row["indirect_weight"]),
+                redundant_rel_id=int(row["redundant_rel_id"]),
+            )
+            for row in result
+        ]
+
+        logger.info(
+            f"[BEACON] Found {len(paths)} transitive redundant paths",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return paths
+
+    async def reduce_transitive_paths(
+        self,
+        dry_run: bool = True,
+        trace_id: str | None = None,
+    ) -> TransitiveResult:
+        """
+        Find and remove redundant transitive relationships.
+
+        When A->B->C exists and A->C also exists with sufficient weight,
+        the B->C relationship is redundant and can be removed.
+
+        Args:
+            dry_run: If True, only preview without deleting.
+            trace_id: Optional trace ID for logging.
+
+        Returns:
+            TransitiveResult with operation statistics.
+        """
+        start_time = time.time()
+        errors: list[str] = []
+
+        logger.info(
+            f"[CHART] Starting transitive reduction (dry_run={dry_run})",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        # Find redundant paths
+        paths = await self.find_transitive_paths(trace_id=trace_id)
+
+        audit_entries: list[AuditEntry] = []
+        paths_reduced = 0
+
+        for path in paths:
+            # Create audit entry
+            action = (
+                PruningAction.TRANSITIVE_PREVIEW if dry_run else PruningAction.TRANSITIVE_REDUCTION
+            )
+            entry = AuditEntry(
+                timestamp=datetime.now(),
+                action=action,
+                entity_type="relationship",
+                entity_id=path.redundant_rel_id,
+                reason=(
+                    f"Transitive redundancy: {path.source_name}->{path.intermediate_name}"
+                    f"->{path.target_name} (direct weight {path.direct_weight:.2f} >= "
+                    f"indirect {path.indirect_weight:.2f})"
+                ),
+                metadata={
+                    "source_uuid": path.source_uuid,
+                    "intermediate_uuid": path.intermediate_uuid,
+                    "target_uuid": path.target_uuid,
+                    "relationship_type": path.relationship_type,
+                    "direct_weight": path.direct_weight,
+                    "indirect_weight": path.indirect_weight,
+                },
+            )
+            audit_entries.append(entry)
+
+            if not dry_run:
+                try:
+                    # Delete the redundant relationship
+                    delete_query = """
+                    MATCH ()-[r]->()
+                    WHERE id(r) = $rel_id
+                    DELETE r
+                    RETURN count(r) as deleted
+                    """
+                    result = await self.neo4j.execute_query(
+                        delete_query,
+                        {"rel_id": path.redundant_rel_id},
+                        trace_id=trace_id,
+                    )
+                    if result and result[0].get("deleted", 0) > 0:
+                        paths_reduced += 1
+                except Exception as e:
+                    errors.append(f"Failed to delete relationship {path.redundant_rel_id}: {e}")
+
+        if dry_run:
+            paths_reduced = len(paths)  # Preview counts all found as "would reduce"
+
+        duration_ms = (time.time() - start_time) * 1000
+
+        result = TransitiveResult(
+            operation="reduce_transitive_paths",
+            dry_run=dry_run,
+            paths_found=len(paths),
+            paths_reduced=paths_reduced,
+            errors=errors,
+            duration_ms=duration_ms,
+            audit_entries=audit_entries,
+        )
+
+        logger.info(
+            f"[BEACON] Transitive reduction complete: "
+            f"found {len(paths)} paths, reduced {paths_reduced} "
+            f"({'preview' if dry_run else 'actual'})",
+            extra={"trace_id": trace_id, "agent_name": self.name},
+        )
+
+        return result
+
+    # =========================================================================
     # Statistics
     # =========================================================================
 
@@ -1303,4 +1580,6 @@ __all__ = [
     "PruningAction",
     "PruningResult",
     "PruningRule",
+    "TransitivePath",
+    "TransitiveResult",
 ]

--- a/tests/unit/test_hull_cleaner.py
+++ b/tests/unit/test_hull_cleaner.py
@@ -1396,12 +1396,14 @@ class TestScrapeBarnaclesWithDuplicates:
     @pytest.mark.asyncio
     async def test_scrape_handles_duplicate_errors(self, cleaner, mock_neo4j):
         """Test that scrape_barnacles handles duplicate merge errors gracefully."""
-        # First two calls succeed (weak rels, orphans), third fails
+        # First two calls succeed (weak rels, orphans), third fails (duplicates),
+        # fourth succeeds (transitive)
         mock_neo4j.execute_query = AsyncMock(
             side_effect=[
                 [],  # weak rels
                 [],  # orphans
                 Exception("Duplicate detection failed"),  # duplicates - persons
+                [],  # transitive paths
             ]
         )
 
@@ -1410,3 +1412,374 @@ class TestScrapeBarnaclesWithDuplicates:
         # Should have captured the error but not crashed
         assert len(result.errors) == 1
         assert "Duplicate entity merge failed" in result.errors[0]
+
+
+# ===========================================================================
+# Transitive Redundancy Detection Tests (#86)
+# ===========================================================================
+
+
+class TestTransitivePath:
+    """Tests for TransitivePath dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        from klabautermann.agents.hull_cleaner import TransitivePath
+
+        path = TransitivePath(
+            source_uuid="uuid-a",
+            intermediate_uuid="uuid-b",
+            target_uuid="uuid-c",
+            source_name="Alice",
+            intermediate_name="Bob",
+            target_name="Charlie",
+            relationship_type="KNOWS",
+            direct_weight=0.8,
+            indirect_weight=0.5,
+            redundant_rel_id=12345,
+        )
+
+        result = path.to_dict()
+
+        assert result["source_uuid"] == "uuid-a"
+        assert result["source_name"] == "Alice"
+        assert result["relationship_type"] == "KNOWS"
+        assert result["direct_weight"] == 0.8
+        assert result["indirect_weight"] == 0.5
+        assert result["redundant_rel_id"] == 12345
+
+
+class TestTransitiveResult:
+    """Tests for TransitiveResult dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        from klabautermann.agents.hull_cleaner import TransitiveResult
+
+        result = TransitiveResult(
+            operation="reduce_transitive_paths",
+            dry_run=True,
+            paths_found=5,
+            paths_reduced=5,
+            errors=[],
+            duration_ms=100.5,
+            audit_entries=[],
+        )
+
+        output = result.to_dict()
+
+        assert output["operation"] == "reduce_transitive_paths"
+        assert output["dry_run"] is True
+        assert output["paths_found"] == 5
+        assert output["paths_reduced"] == 5
+        assert output["audit_entry_count"] == 0
+
+
+class TestHullCleanerConfigTransitive:
+    """Tests for HullCleanerConfig transitive settings."""
+
+    def test_default_transitive_values(self):
+        """Test default transitive config values."""
+        config = HullCleanerConfig()
+
+        assert config.detect_transitive_redundancy is True
+        assert config.transitive_weight_threshold == 0.5
+        assert config.max_transitive_per_run == 100
+
+    def test_custom_transitive_values(self):
+        """Test custom transitive config values."""
+        config = HullCleanerConfig(
+            detect_transitive_redundancy=False,
+            transitive_weight_threshold=0.7,
+            max_transitive_per_run=50,
+        )
+
+        assert config.detect_transitive_redundancy is False
+        assert config.transitive_weight_threshold == 0.7
+        assert config.max_transitive_per_run == 50
+
+
+class TestFindTransitivePaths:
+    """Tests for find_transitive_paths method."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_find_transitive_paths_empty(self, cleaner, mock_neo4j):
+        """Test finding transitive paths with empty result."""
+        mock_neo4j.execute_query = AsyncMock(return_value=[])
+
+        paths = await cleaner.find_transitive_paths()
+
+        assert len(paths) == 0
+        mock_neo4j.execute_query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_find_transitive_paths_with_results(self, cleaner, mock_neo4j):
+        """Test finding transitive paths with results."""
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "source_uuid": "uuid-a",
+                    "intermediate_uuid": "uuid-b",
+                    "target_uuid": "uuid-c",
+                    "source_name": "Alice",
+                    "intermediate_name": "Bob",
+                    "target_name": "Charlie",
+                    "relationship_type": "KNOWS",
+                    "direct_weight": 0.9,
+                    "indirect_weight": 0.5,
+                    "redundant_rel_id": 12345,
+                }
+            ]
+        )
+
+        paths = await cleaner.find_transitive_paths()
+
+        assert len(paths) == 1
+        assert paths[0].source_name == "Alice"
+        assert paths[0].intermediate_name == "Bob"
+        assert paths[0].target_name == "Charlie"
+        assert paths[0].direct_weight == 0.9
+        assert paths[0].indirect_weight == 0.5
+
+
+class TestReduceTransitivePaths:
+    """Tests for reduce_transitive_paths method."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_reduce_dry_run(self, cleaner, mock_neo4j):
+        """Test transitive reduction in dry-run mode."""
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "source_uuid": "uuid-a",
+                    "intermediate_uuid": "uuid-b",
+                    "target_uuid": "uuid-c",
+                    "source_name": "Alice",
+                    "intermediate_name": "Bob",
+                    "target_name": "Charlie",
+                    "relationship_type": "KNOWS",
+                    "direct_weight": 0.9,
+                    "indirect_weight": 0.5,
+                    "redundant_rel_id": 12345,
+                }
+            ]
+        )
+
+        result = await cleaner.reduce_transitive_paths(dry_run=True)
+
+        assert result.dry_run is True
+        assert result.paths_found == 1
+        assert result.paths_reduced == 1  # Preview counts as "would reduce"
+        assert len(result.audit_entries) == 1
+        assert result.audit_entries[0].action == PruningAction.TRANSITIVE_PREVIEW
+
+    @pytest.mark.asyncio
+    async def test_reduce_actual_delete(self, cleaner, mock_neo4j):
+        """Test actual transitive reduction."""
+        mock_neo4j.execute_query = AsyncMock(
+            side_effect=[
+                # First call: find paths
+                [
+                    {
+                        "source_uuid": "uuid-a",
+                        "intermediate_uuid": "uuid-b",
+                        "target_uuid": "uuid-c",
+                        "source_name": "Alice",
+                        "intermediate_name": "Bob",
+                        "target_name": "Charlie",
+                        "relationship_type": "KNOWS",
+                        "direct_weight": 0.9,
+                        "indirect_weight": 0.5,
+                        "redundant_rel_id": 12345,
+                    }
+                ],
+                # Second call: delete relationship
+                [{"deleted": 1}],
+            ]
+        )
+
+        result = await cleaner.reduce_transitive_paths(dry_run=False)
+
+        assert result.dry_run is False
+        assert result.paths_found == 1
+        assert result.paths_reduced == 1
+        assert len(result.audit_entries) == 1
+        assert result.audit_entries[0].action == PruningAction.TRANSITIVE_REDUCTION
+
+    @pytest.mark.asyncio
+    async def test_reduce_handles_delete_error(self, cleaner, mock_neo4j):
+        """Test that reduction handles delete errors gracefully."""
+        mock_neo4j.execute_query = AsyncMock(
+            side_effect=[
+                # First call: find paths
+                [
+                    {
+                        "source_uuid": "uuid-a",
+                        "intermediate_uuid": "uuid-b",
+                        "target_uuid": "uuid-c",
+                        "source_name": "Alice",
+                        "intermediate_name": "Bob",
+                        "target_name": "Charlie",
+                        "relationship_type": "KNOWS",
+                        "direct_weight": 0.9,
+                        "indirect_weight": 0.5,
+                        "redundant_rel_id": 12345,
+                    }
+                ],
+                # Second call: delete fails
+                Exception("Delete failed"),
+            ]
+        )
+
+        result = await cleaner.reduce_transitive_paths(dry_run=False)
+
+        assert result.paths_found == 1
+        assert result.paths_reduced == 0  # Delete failed
+        assert len(result.errors) == 1
+        assert "Failed to delete relationship" in result.errors[0]
+
+
+class TestProcessMessageTransitiveOperations:
+    """Tests for process_message transitive operations."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with mock client."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_process_find_transitive_paths(self, cleaner, mock_neo4j):
+        """Test process_message with find_transitive_paths operation."""
+        mock_neo4j.execute_query = AsyncMock(return_value=[])
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="hull_cleaner",
+            intent="hull_cleaner_command",
+            payload={"operation": "find_transitive_paths"},
+            trace_id="test-trace",
+        )
+
+        result = await cleaner.process_message(msg)
+
+        assert result is not None
+        assert result.payload["count"] == 0
+        assert result.payload["transitive_paths"] == []
+
+    @pytest.mark.asyncio
+    async def test_process_reduce_transitive_paths(self, cleaner, mock_neo4j):
+        """Test process_message with reduce_transitive_paths operation."""
+        mock_neo4j.execute_query = AsyncMock(return_value=[])
+
+        msg = AgentMessage(
+            source_agent="orchestrator",
+            target_agent="hull_cleaner",
+            intent="hull_cleaner_command",
+            payload={"operation": "reduce_transitive_paths", "dry_run": True},
+            trace_id="test-trace",
+        )
+
+        result = await cleaner.process_message(msg)
+
+        assert result is not None
+        assert result.payload["operation"] == "reduce_transitive_paths"
+        assert result.payload["dry_run"] is True
+
+
+class TestScrapeBarnaclesWithTransitive:
+    """Tests for scrape_barnacles with transitive reduction."""
+
+    @pytest.fixture
+    def mock_neo4j(self):
+        """Create mock Neo4j client."""
+        client = MagicMock()
+        client.execute_query = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def cleaner(self, mock_neo4j):
+        """Create HullCleaner with all rules enabled."""
+        return HullCleaner(neo4j_client=mock_neo4j)
+
+    @pytest.mark.asyncio
+    async def test_scrape_includes_transitive(self, mock_neo4j):
+        """Test scrape_barnacles includes transitive reduction."""
+        # Disable other operations to isolate transitive testing
+        config = HullCleanerConfig(
+            prune_weak_relationships=False,
+            remove_orphan_messages=False,
+            detect_duplicates=False,
+            detect_transitive_redundancy=True,
+        )
+        cleaner = HullCleaner(neo4j_client=mock_neo4j, config=config)
+
+        mock_neo4j.execute_query = AsyncMock(
+            return_value=[
+                {
+                    "source_uuid": "uuid-a",
+                    "intermediate_uuid": "uuid-b",
+                    "target_uuid": "uuid-c",
+                    "source_name": "A",
+                    "intermediate_name": "B",
+                    "target_name": "C",
+                    "relationship_type": "KNOWS",
+                    "direct_weight": 0.9,
+                    "indirect_weight": 0.5,
+                    "redundant_rel_id": 123,
+                }
+            ]
+        )
+
+        result = await cleaner.scrape_barnacles(dry_run=True)
+
+        # Should have found the transitive path
+        assert result.relationships_found == 1
+        assert result.relationships_pruned == 1
+
+    @pytest.mark.asyncio
+    async def test_scrape_with_transitive_disabled(self, mock_neo4j):
+        """Test scrape with transitive detection disabled."""
+        config = HullCleanerConfig(
+            prune_weak_relationships=False,
+            remove_orphan_messages=False,
+            detect_duplicates=False,
+            detect_transitive_redundancy=False,
+        )
+        cleaner = HullCleaner(neo4j_client=mock_neo4j, config=config)
+
+        result = await cleaner.scrape_barnacles(dry_run=True)
+
+        # No operations should be processed
+        assert result.relationships_found == 0
+        assert result.nodes_found == 0


### PR DESCRIPTION
## Summary

Implements transitive redundancy detection for the HullCleaner, finding and pruning redundant transitive paths in the knowledge graph.

When A->B->C exists and A->C also exists with sufficient weight, the intermediate B->C relationship is redundant and can be removed.

## Changes

### New Dataclasses
- `TransitivePath` - Represents a redundant transitive path with source, intermediate, and target nodes
- `TransitiveResult` - Operation result with paths found/reduced counts

### New Config Options
- `detect_transitive_redundancy: bool = True` - Enable/disable detection
- `transitive_weight_threshold: float = 0.5` - Weight comparison threshold  
- `max_transitive_per_run: int = 100` - Limit paths per operation

### New Methods
- `find_transitive_paths()` - Find redundant transitive paths using Cypher
- `reduce_transitive_paths()` - Find and prune with dry_run support

### Integration
- Transitive reduction now runs as step 4 in `scrape_barnacles()`
- New process_message operations: `find_transitive_paths`, `reduce_transitive_paths`
- Audit entries generated with `TRANSITIVE_REDUCTION` / `TRANSITIVE_PREVIEW` actions

## Test Plan

- [x] 13 new tests for transitive redundancy detection
- [x] All 72 hull_cleaner tests pass
- [x] Ruff linting passes

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)