### PR TITLE
feat(scheduler): Add Purser scheduled sync job (#55)

### DIFF
--- a/config/scheduler.yaml
+++ b/config/scheduler.yaml
@@ -23,6 +23,18 @@ syncer:
   enabled: true
   interval_minutes: 15  # Sync every 15 minutes
 
+# Purser Configuration
+# Synchronizes Gmail and Calendar via delta-sync (#55)
+purser:
+  enabled: true
+  interval_minutes: 15  # Sync every 15 minutes
+
+# Cartographer Configuration
+# Detects knowledge graph communities (Knowledge Islands)
+cartographer:
+  enabled: true
+  cron: "0 0 * * 0"  # Sunday midnight
+
 # Scheduler Settings
 timezone: UTC  # All jobs run in UTC
 job_store: memory  # Options: 'memory' or 'sqlite'

--- a/src/klabautermann/utils/scheduler.py
+++ b/src/klabautermann/utils/scheduler.py
@@ -250,6 +250,59 @@ def register_scheduled_jobs(
         )
 
     # ========================================================================
+    # Purser: Scheduled sync for Gmail and Calendar
+    # Issue: #55 - [AGT-S-019] Implement scheduled sync job
+    # ========================================================================
+    purser_config = config.get("purser", {})
+    purser_enabled = purser_config.get("enabled", True)
+    purser_interval = purser_config.get("interval_minutes", 15)
+
+    if purser_enabled and "purser" in agents:
+        purser = agents["purser"]
+
+        # Wrap the job to pass trace_id
+        async def purser_job() -> None:
+            job_trace_id = str(uuid.uuid4())
+            logger.info(
+                "[BEACON] Scheduled Purser sync triggered",
+                extra={"trace_id": job_trace_id, "agent_name": "purser"},
+            )
+            try:
+                await purser.sync_all(trace_id=job_trace_id)  # type: ignore[attr-defined]
+                logger.info(
+                    "[BEACON] Purser sync completed successfully",
+                    extra={"trace_id": job_trace_id, "agent_name": "purser"},
+                )
+            except Exception as e:
+                logger.error(
+                    f"[STORM] Purser sync failed: {e}",
+                    extra={"trace_id": job_trace_id, "agent_name": "purser"},
+                )
+                # Don't re-raise - let scheduler continue
+
+        scheduler.add_job(
+            purser_job,
+            trigger=IntervalTrigger(minutes=purser_interval),
+            id="purser_sync",
+            name="Purser Gmail/Calendar Sync",
+            replace_existing=True,
+        )
+        logger.info(
+            f"[CHART] Registered Purser sync job (interval: {purser_interval} minutes)",
+            extra={"trace_id": trace_id},
+        )
+    elif not purser_enabled:
+        logger.info(
+            "[CHART] Purser sync job disabled by config",
+            extra={"trace_id": trace_id},
+        )
+    else:
+        logger.warning(
+            "[SWELL] Purser agent not available, skipping scheduled job",
+            extra={"trace_id": trace_id},
+        )
+
+    # ========================================================================
     # Scribe: Generate daily reflection
     # ========================================================================
     scribe_config = config.get("scribe", {})

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -534,3 +534,140 @@ class TestCartographerScheduledJob:
         call_kwargs = mock_cartographer.detect_communities.call_args.kwargs
         assert "trace_id" in call_kwargs
         assert isinstance(call_kwargs["trace_id"], str)
+
+
+# =============================================================================
+# Purser Scheduled Job Tests (Issue #55)
+# =============================================================================
+
+
+class TestPurserScheduledJob:
+    """Tests for Purser scheduled sync job (Issue #55)."""
+
+    @pytest.fixture
+    def scheduler(self) -> AsyncIOScheduler:
+        """Create scheduler instance for tests."""
+        return create_scheduler()
+
+    @pytest.fixture
+    def mock_purser(self) -> Mock:
+        """Create mock Purser agent."""
+        agent = Mock()
+        agent.sync_all = AsyncMock()
+        return agent
+
+    def test_registers_purser_job_when_enabled(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Should register Purser job when agent available and enabled."""
+        agents = {"purser": mock_purser}
+        config = {"purser": {"enabled": True}}
+
+        register_scheduled_jobs(scheduler, agents, config)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is not None
+        assert job.name == "Purser Gmail/Calendar Sync"
+
+    def test_registers_purser_with_default_interval(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Should use default 15-minute interval."""
+        agents = {"purser": mock_purser}
+        config = {"purser": {"enabled": True}}
+
+        register_scheduled_jobs(scheduler, agents, config)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is not None
+        # Default interval is 15 minutes
+        assert job.trigger.interval.total_seconds() == 15 * 60
+
+    def test_registers_purser_with_custom_interval(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Should use custom interval when provided."""
+        agents = {"purser": mock_purser}
+        config = {"purser": {"enabled": True, "interval_minutes": 30}}
+
+        register_scheduled_jobs(scheduler, agents, config)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is not None
+        # Custom interval is 30 minutes
+        assert job.trigger.interval.total_seconds() == 30 * 60
+
+    def test_skips_purser_when_disabled(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Should not register Purser job when disabled."""
+        agents = {"purser": mock_purser}
+        config = {"purser": {"enabled": False}}
+
+        register_scheduled_jobs(scheduler, agents, config)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is None
+
+    def test_skips_purser_when_not_available(self, scheduler: AsyncIOScheduler) -> None:
+        """Should not register Purser job when agent not available."""
+        agents = {}  # No purser
+        config = {"purser": {"enabled": True}}
+
+        # Should not raise exception
+        register_scheduled_jobs(scheduler, agents, config)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is None
+
+    @pytest.mark.asyncio
+    async def test_purser_job_calls_sync_all(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Purser job should call sync_all when triggered."""
+        agents = {"purser": mock_purser}
+        register_scheduled_jobs(scheduler, agents)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is not None
+
+        # Execute the job function directly
+        await job.func()
+
+        # Verify the agent method was called
+        mock_purser.sync_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_purser_job_handles_failures(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Purser job should handle sync failures gracefully."""
+        # Make sync_all raise an exception
+        mock_purser.sync_all.side_effect = RuntimeError("Sync failed")
+        agents = {"purser": mock_purser}
+        register_scheduled_jobs(scheduler, agents)
+
+        job = scheduler.get_job("purser_sync")
+        assert job is not None
+
+        # Execute should not raise - error is caught and logged
+        await job.func()
+
+        # Job should still have tried to call sync_all
+        mock_purser.sync_all.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_purser_job_receives_trace_id(
+        self, scheduler: AsyncIOScheduler, mock_purser: Mock
+    ) -> None:
+        """Purser job should receive a trace_id when executed."""
+        agents = {"purser": mock_purser}
+        register_scheduled_jobs(scheduler, agents)
+
+        job = scheduler.get_job("purser_sync")
+        await job.func()
+
+        # Verify trace_id was passed
+        call_kwargs = mock_purser.sync_all.call_args.kwargs
+        assert "trace_id" in call_kwargs
+        assert isinstance(call_kwargs["trace_id"], str)


### PR DESCRIPTION
## Summary

- Register Purser with APScheduler using IntervalTrigger
- Default sync interval: 15 minutes (configurable)
- Wrap sync_all() with trace_id generation for request tracing
- Graceful error handling - failures logged but don't stop scheduler
- Add purser config block to scheduler.yaml

## Test plan

- [x] Run `pytest tests/unit/test_scheduler.py::TestPurserScheduledJob -v` - 8 tests pass
- [x] Verify job registered with correct name "Purser Gmail/Calendar Sync"
- [x] Verify default 15-minute interval
- [x] Verify custom interval support
- [x] Verify disabled config skips registration
- [x] Verify sync failures don't crash scheduler

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)