### PR TITLE
feat(channels): Implement Markdown formatting for Telegram (#139)

### DIFF
--- a/src/klabautermann/channels/markdown_formatter.py
+++ b/src/klabautermann/channels/markdown_formatter.py
@@ -1,0 +1,273 @@
+"""
+Markdown formatting utilities for Telegram channel.
+
+Provides escaping and formatting for Telegram's Markdown parser.
+Telegram supports a subset of Markdown with specific escape requirements.
+
+Reference: https://core.telegram.org/bots/api#markdownv2-style
+Issue: #139
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import ClassVar
+
+from klabautermann.core.logger import logger
+
+
+@dataclass
+class FormattingResult:
+    """Result of markdown formatting operation."""
+
+    original: str
+    formatted: str
+    was_escaped: bool = False
+    escape_count: int = 0
+
+
+class TelegramMarkdownFormatter:
+    """
+    Formatter for Telegram Markdown messages.
+
+    Telegram's Markdown parser is strict about special characters.
+    This formatter escapes characters that would break parsing while
+    preserving intentional formatting.
+
+    Supported formatting (preserved):
+    - *bold*
+    - _italic_
+    - `code`
+    - ```pre```
+    - [links](url)
+
+    Special characters (escaped):
+    - _ * [ ] ( ) ~ ` > # + - = | { } . !
+
+    Issue: #139
+    """
+
+    # Characters that need escaping in Telegram Markdown
+    # Note: We don't escape * and _ by default since they're used for formatting
+    ESCAPE_CHARS: ClassVar[str] = r"[\[\]()~`>#+=|{}.!-]"
+    ESCAPE_PATTERN: ClassVar[re.Pattern[str]] = re.compile(ESCAPE_CHARS)
+
+    # Pattern to detect markdown formatting we want to preserve
+    # Matches *bold*, _italic_, `code`, ```pre```, [text](url)
+    FORMATTING_PATTERNS: ClassVar[list[re.Pattern[str]]] = [
+        re.compile(r"\*[^*]+\*"),  # *bold*
+        re.compile(r"_[^_]+_"),  # _italic_
+        re.compile(r"`[^`]+`"),  # `code`
+        re.compile(r"```[\s\S]*?```"),  # ```pre```
+        re.compile(r"\[[^\]]+\]\([^)]+\)"),  # [text](url)
+    ]
+
+    def __init__(self, preserve_formatting: bool = True) -> None:
+        """
+        Initialize the formatter.
+
+        Args:
+            preserve_formatting: If True, preserve intentional Markdown formatting.
+                               If False, escape everything for plain text display.
+        """
+        self.preserve_formatting = preserve_formatting
+
+    def format(self, text: str) -> FormattingResult:
+        """
+        Format text for Telegram Markdown.
+
+        Escapes special characters while preserving intentional formatting.
+
+        Args:
+            text: Raw text to format.
+
+        Returns:
+            FormattingResult with formatted text and metadata.
+        """
+        if not text:
+            return FormattingResult(original=text, formatted=text)
+
+        if self.preserve_formatting:
+            formatted, count = self._escape_preserving_formatting(text)
+        else:
+            formatted, count = self._escape_all(text)
+
+        return FormattingResult(
+            original=text,
+            formatted=formatted,
+            was_escaped=count > 0,
+            escape_count=count,
+        )
+
+    def _escape_preserving_formatting(self, text: str) -> tuple[str, int]:
+        """
+        Escape special characters while preserving Markdown formatting.
+
+        Strategy:
+        1. Find all formatting spans (bold, italic, code, etc.)
+        2. Mark those regions as protected
+        3. Escape special characters only in unprotected regions
+
+        Args:
+            text: Text to process.
+
+        Returns:
+            Tuple of (formatted_text, escape_count).
+        """
+        # Find all protected regions (formatting we want to keep)
+        protected_regions: list[tuple[int, int]] = []
+        for pattern in self.FORMATTING_PATTERNS:
+            for match in pattern.finditer(text):
+                protected_regions.append((match.start(), match.end()))
+
+        # Sort and merge overlapping regions
+        protected_regions.sort()
+        merged: list[tuple[int, int]] = []
+        for start, end in protected_regions:
+            if merged and start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+
+        # Build result by processing unprotected regions
+        result: list[str] = []
+        escape_count = 0
+        pos = 0
+
+        for region_start, region_end in merged:
+            # Process unprotected text before this region
+            if pos < region_start:
+                unprotected = text[pos:region_start]
+                escaped, count = self._escape_segment(unprotected)
+                result.append(escaped)
+                escape_count += count
+
+            # Add protected region unchanged
+            result.append(text[region_start:region_end])
+            pos = region_end
+
+        # Process remaining unprotected text
+        if pos < len(text):
+            unprotected = text[pos:]
+            escaped, count = self._escape_segment(unprotected)
+            result.append(escaped)
+            escape_count += count
+
+        return "".join(result), escape_count
+
+    def _escape_segment(self, text: str) -> tuple[str, int]:
+        """
+        Escape special characters in a text segment.
+
+        Args:
+            text: Text segment to escape.
+
+        Returns:
+            Tuple of (escaped_text, escape_count).
+        """
+        count = len(self.ESCAPE_PATTERN.findall(text))
+        escaped = self.ESCAPE_PATTERN.sub(r"\\\g<0>", text)
+        return escaped, count
+
+    def _escape_all(self, text: str) -> tuple[str, int]:
+        """
+        Escape all special characters including formatting markers.
+
+        Args:
+            text: Text to escape.
+
+        Returns:
+            Tuple of (escaped_text, escape_count).
+        """
+        # Extended pattern including * and _
+        full_pattern = re.compile(r"[_*\[\]()~`>#+=|{}.!-]")
+        count = len(full_pattern.findall(text))
+        escaped = full_pattern.sub(r"\\\g<0>", text)
+        return escaped, count
+
+
+def escape_markdown(text: str, preserve_formatting: bool = True) -> str:
+    """
+    Convenience function to escape text for Telegram Markdown.
+
+    Args:
+        text: Text to escape.
+        preserve_formatting: Whether to preserve intentional formatting.
+
+    Returns:
+        Escaped text safe for Telegram's Markdown parser.
+    """
+    formatter = TelegramMarkdownFormatter(preserve_formatting=preserve_formatting)
+    return formatter.format(text).formatted
+
+
+async def safe_send_markdown(
+    send_func: object,
+    text: str,
+    **kwargs: object,
+) -> bool:
+    """
+    Send a message with Markdown, falling back to plain text on error.
+
+    Attempts to send with Markdown parsing. If that fails (due to malformed
+    Markdown), retries without parse_mode.
+
+    Args:
+        send_func: Async function to send message (e.g., bot.send_message).
+        text: Message text.
+        **kwargs: Additional arguments for send_func.
+
+    Returns:
+        True if message was sent successfully.
+
+    Issue: #139
+    """
+    # Type narrowing for the send function
+    from collections.abc import Callable
+    from typing import Any, cast
+
+    send = cast(Callable[..., Any], send_func)
+
+    try:
+        # First attempt: with Markdown
+        await send(text=text, parse_mode="Markdown", **kwargs)
+        return True
+    except Exception as e:
+        error_msg = str(e).lower()
+
+        # Check if it's a Markdown parsing error
+        if "parse" in error_msg or "markdown" in error_msg or "can't" in error_msg:
+            logger.warning(
+                f"[SWELL] Markdown parsing failed, retrying as plain text: {e}",
+                extra={"agent_name": "telegram"},
+            )
+            try:
+                # Retry without Markdown
+                await send(text=text, **kwargs)
+                return True
+            except Exception as retry_error:
+                logger.error(
+                    f"[STORM] Message send failed even without Markdown: {retry_error}",
+                    extra={"agent_name": "telegram"},
+                )
+                return False
+        else:
+            # Not a Markdown error, re-raise
+            logger.error(
+                f"[STORM] Message send failed: {e}",
+                extra={"agent_name": "telegram"},
+            )
+            return False
+
+
+# ===========================================================================
+# Export
+# ===========================================================================
+
+__all__ = [
+    "FormattingResult",
+    "TelegramMarkdownFormatter",
+    "escape_markdown",
+    "safe_send_markdown",
+]

--- a/src/klabautermann/channels/telegram_driver.py
+++ b/src/klabautermann/channels/telegram_driver.py
@@ -24,6 +24,7 @@ from telegram.ext import (
 )
 
 from klabautermann.channels.base_channel import BaseChannel
+from klabautermann.channels.markdown_formatter import escape_markdown
 from klabautermann.channels.sanitization import InputSanitizer
 from klabautermann.core.logger import logger
 
@@ -68,6 +69,40 @@ class TelegramDriver(BaseChannel):
         self._app: Application | None = None
         self._running = False
         self._sanitizer = InputSanitizer()
+
+    async def _safe_reply(
+        self,
+        message: Any,
+        text: str,
+        use_markdown: bool = True,
+    ) -> None:
+        """
+        Send a reply with Markdown, falling back to plain text on error.
+
+        Args:
+            message: Telegram Message object to reply to.
+            text: Response text.
+            use_markdown: Whether to attempt Markdown formatting.
+
+        Issue: #139
+        """
+        if not use_markdown:
+            await message.reply_text(text)
+            return
+
+        formatted_text = escape_markdown(text)
+        try:
+            await message.reply_text(formatted_text, parse_mode="Markdown")
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "parse" in error_msg or "markdown" in error_msg or "can't" in error_msg:
+                logger.warning(
+                    f"[SWELL] Markdown parsing failed in reply, sending plain: {e}",
+                    extra={"agent_name": "telegram"},
+                )
+                await message.reply_text(text)
+            else:
+                raise
 
     @property
     def channel_type(self) -> str:
@@ -189,11 +224,28 @@ class TelegramDriver(BaseChannel):
             )
             return
 
-        await self._app.bot.send_message(
-            chat_id=chat_id,
-            text=content,
-            parse_mode="Markdown",
-        )
+        # Format content for Telegram Markdown and send with fallback (#139)
+        formatted_content = escape_markdown(content)
+        try:
+            await self._app.bot.send_message(
+                chat_id=chat_id,
+                text=formatted_content,
+                parse_mode="Markdown",
+            )
+        except Exception as e:
+            # Fallback to plain text if Markdown parsing fails
+            error_msg = str(e).lower()
+            if "parse" in error_msg or "markdown" in error_msg or "can't" in error_msg:
+                logger.warning(
+                    f"[SWELL] Markdown parsing failed, sending as plain text: {e}",
+                    extra={"agent_name": "telegram", "chat_id": chat_id},
+                )
+                await self._app.bot.send_message(
+                    chat_id=chat_id,
+                    text=content,  # Send original without parse_mode
+                )
+            else:
+                raise
 
     async def receive_message(
         self,
@@ -253,7 +305,7 @@ class TelegramDriver(BaseChannel):
             "or ask me to find something in The Locker (your knowledge graph).\n\n"
             "Type /help for more information."
         )
-        await update.message.reply_text(welcome, parse_mode="Markdown")
+        await self._safe_reply(update.message, welcome)
 
         logger.info(
             "[CHART] /start command received",
@@ -285,7 +337,7 @@ class TelegramDriver(BaseChannel):
             "- Transcribe voice messages\n\n"
             "Just chat naturally - I'll figure out the rest!"
         )
-        await update.message.reply_text(help_text, parse_mode="Markdown")
+        await self._safe_reply(update.message, help_text)
 
     async def _cmd_status(
         self,
@@ -310,7 +362,7 @@ class TelegramDriver(BaseChannel):
             f"- Status: Online\n"
             f"- Voice: {'Enabled' if self.enable_voice else 'Disabled'}"
         )
-        await update.message.reply_text(status, parse_mode="Markdown")
+        await self._safe_reply(update.message, status)
 
     # =========================================================================
     # Message Handlers
@@ -371,7 +423,7 @@ class TelegramDriver(BaseChannel):
                     "timestamp": datetime.now(UTC).timestamp(),
                 },
             )
-            await update.message.reply_text(response, parse_mode="Markdown")
+            await self._safe_reply(update.message, response)
         except Exception as e:
             logger.error(
                 f"[STORM] Error processing text message: {e}",
@@ -430,10 +482,8 @@ class TelegramDriver(BaseChannel):
                     "duration": voice.duration,
                 },
             )
-            await update.message.reply_text(
-                f"_Transcribed: {transcription}_\n\n{response}",
-                parse_mode="Markdown",
-            )
+            voice_response = f"_Transcribed: {transcription}_\n\n{response}"
+            await self._safe_reply(update.message, voice_response)
 
         except Exception as e:
             logger.error(

--- a/tests/unit/test_markdown_formatter.py
+++ b/tests/unit/test_markdown_formatter.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for Telegram Markdown formatter.
+
+Issue: #139
+"""
+
+import pytest
+
+from klabautermann.channels.markdown_formatter import (
+    FormattingResult,
+    TelegramMarkdownFormatter,
+    escape_markdown,
+)
+
+
+class TestTelegramMarkdownFormatter:
+    """Tests for TelegramMarkdownFormatter class."""
+
+    @pytest.fixture
+    def formatter(self) -> TelegramMarkdownFormatter:
+        """Create a formatter with default settings."""
+        return TelegramMarkdownFormatter()
+
+    def test_empty_string(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Empty string should return unchanged."""
+        result = formatter.format("")
+        assert result.formatted == ""
+        assert result.was_escaped is False
+
+    def test_plain_text_unchanged(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Plain text without special characters should be unchanged."""
+        text = "Hello world"
+        result = formatter.format(text)
+        assert result.formatted == text
+        assert result.was_escaped is False
+
+    def test_escapes_brackets(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should escape square brackets."""
+        text = "Array [0] and [1]"
+        result = formatter.format(text)
+        assert "\\[" in result.formatted
+        assert "\\]" in result.formatted
+        assert result.was_escaped is True
+
+    def test_escapes_parentheses(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should escape parentheses outside of links."""
+        text = "Function call (with args)"
+        result = formatter.format(text)
+        assert "\\(" in result.formatted
+        assert "\\)" in result.formatted
+
+    def test_escapes_special_chars(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should escape various special characters."""
+        text = "Price: $100.00 + tax = total"
+        result = formatter.format(text)
+        assert "\\." in result.formatted
+        assert "\\+" in result.formatted
+        assert "\\=" in result.formatted
+
+    def test_preserves_bold_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve *bold* formatting."""
+        text = "This is *bold* text"
+        result = formatter.format(text)
+        assert "*bold*" in result.formatted
+
+    def test_preserves_italic_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve _italic_ formatting."""
+        text = "This is _italic_ text"
+        result = formatter.format(text)
+        assert "_italic_" in result.formatted
+
+    def test_preserves_code_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve `code` formatting."""
+        text = "Use `print()` function"
+        result = formatter.format(text)
+        assert "`print()`" in result.formatted
+
+    def test_preserves_pre_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve ```pre``` blocks."""
+        text = "Code:\n```\nprint('hello')\n```"
+        result = formatter.format(text)
+        assert "```" in result.formatted
+
+    def test_preserves_links(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve [text](url) links."""
+        text = "Check [this link](https://example.com)"
+        result = formatter.format(text)
+        assert "[this link](https://example.com)" in result.formatted
+
+    def test_mixed_formatting_and_special_chars(
+        self, formatter: TelegramMarkdownFormatter
+    ) -> None:
+        """Should handle mix of formatting and special characters."""
+        text = "*Bold* text [array] with (parens)"
+        result = formatter.format(text)
+        # Bold should be preserved
+        assert "*Bold*" in result.formatted
+        # Brackets should be escaped
+        assert "\\[array\\]" in result.formatted
+        # Parens should be escaped
+        assert "\\(parens\\)" in result.formatted
+
+    def test_escape_all_mode(self) -> None:
+        """With preserve_formatting=False, should escape everything."""
+        formatter = TelegramMarkdownFormatter(preserve_formatting=False)
+        text = "*bold* and _italic_"
+        result = formatter.format(text)
+        # Asterisks and underscores should be escaped
+        assert "\\*" in result.formatted
+        assert "\\_" in result.formatted
+
+    def test_formatting_result_properties(
+        self, formatter: TelegramMarkdownFormatter
+    ) -> None:
+        """FormattingResult should have correct properties."""
+        text = "Test [with] special"
+        result = formatter.format(text)
+        assert result.original == text
+        assert result.was_escaped is True
+        assert result.escape_count == 2  # [ and ]
+
+
+class TestEscapeMarkdownFunction:
+    """Tests for the escape_markdown convenience function."""
+
+    def test_basic_escape(self) -> None:
+        """Should escape special characters."""
+        text = "Price: $100.00"
+        result = escape_markdown(text)
+        assert "\\." in result
+
+    def test_preserve_formatting_default(self) -> None:
+        """Should preserve formatting by default."""
+        text = "*bold* text"
+        result = escape_markdown(text)
+        assert "*bold*" in result
+
+    def test_no_preserve_formatting(self) -> None:
+        """Should escape everything when preserve_formatting=False."""
+        text = "*bold* text"
+        result = escape_markdown(text, preserve_formatting=False)
+        assert "\\*" in result
+
+
+class TestFormattingEdgeCases:
+    """Tests for edge cases in formatting."""
+
+    @pytest.fixture
+    def formatter(self) -> TelegramMarkdownFormatter:
+        """Create a formatter."""
+        return TelegramMarkdownFormatter()
+
+    def test_nested_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should handle adjacent formatting markers."""
+        text = "*bold* and _italic_ together"
+        result = formatter.format(text)
+        assert "*bold*" in result.formatted
+        assert "_italic_" in result.formatted
+
+    def test_unclosed_formatting(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should handle unclosed formatting markers gracefully."""
+        text = "Unclosed *bold and text"
+        result = formatter.format(text)
+        # Should not crash, may escape or pass through
+        assert "Unclosed" in result.formatted
+
+    def test_multiple_special_chars_together(
+        self, formatter: TelegramMarkdownFormatter
+    ) -> None:
+        """Should escape consecutive special characters."""
+        text = "Math: a + b = c (where c > 0)"
+        result = formatter.format(text)
+        assert "\\+" in result.formatted
+        assert "\\=" in result.formatted
+        assert "\\>" in result.formatted
+        assert "\\(" in result.formatted
+        assert "\\)" in result.formatted
+
+    def test_url_with_special_chars(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should preserve URLs in links even with special chars."""
+        text = "Visit [site](https://example.com/path?q=1&x=2)"
+        result = formatter.format(text)
+        # Link should be preserved intact
+        assert "[site](https://example.com/path?q=1&x=2)" in result.formatted
+
+    def test_multiline_text(self, formatter: TelegramMarkdownFormatter) -> None:
+        """Should handle multiline text correctly."""
+        text = "Line 1 [array]\nLine 2 *bold*\nLine 3"
+        result = formatter.format(text)
+        assert "\\[array\\]" in result.formatted
+        assert "*bold*" in result.formatted
+        assert "Line 3" in result.formatted


### PR DESCRIPTION
## Summary

- Add `TelegramMarkdownFormatter` for escaping special characters in outgoing messages
- Add `_safe_reply()` helper with fallback to plain text when Markdown parsing fails
- Apply formatting to all Telegram message replies

## Changes

- `src/klabautermann/channels/markdown_formatter.py` (new):
  - `TelegramMarkdownFormatter` class
  - `escape_markdown()` convenience function
  - `safe_send_markdown()` async helper for send-with-fallback
  - Preserves intentional formatting (*bold*, _italic_, `code`, ```pre```, [links](url))
  - Escapes characters that break Telegram's parser: [ ] ( ) ~ ` > # + - = | { } . !

- `src/klabautermann/channels/telegram_driver.py`:
  - Import `escape_markdown`
  - Add `_safe_reply()` method with error handling and fallback
  - Update `send_message()` to escape and handle errors
  - Update all `reply_text()` calls to use `_safe_reply()`

- `tests/unit/test_markdown_formatter.py` (new):
  - 21 tests for formatting behavior

## Test plan

- [x] Empty string returns unchanged
- [x] Plain text without special chars unchanged
- [x] Escapes brackets [ ]
- [x] Escapes parentheses ( )
- [x] Escapes special chars . + = > etc.
- [x] Preserves *bold* formatting
- [x] Preserves _italic_ formatting
- [x] Preserves `code` formatting
- [x] Preserves ```pre``` blocks
- [x] Preserves [text](url) links
- [x] Mixed formatting and special chars handled correctly
- [x] escape_all mode escapes everything
- [x] Edge cases: nested, unclosed, multiline

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)