### PR TITLE
Add AI-powered cumulative tag reports via Gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ target/
 media/
 .DS_Store
 *.log
+
+# Ignore AI agent-specific directories
+.claude/
+
+# Ignore git worktrees directory
+worktrees/

--- a/migrations/006_tag_reports.sql
+++ b/migrations/006_tag_reports.sql
@@ -1,0 +1,10 @@
+CREATE TABLE tag_reports (
+    id              TEXT PRIMARY KEY NOT NULL,
+    tag_id          TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    report          TEXT NOT NULL,
+    entry_count     INTEGER NOT NULL DEFAULT 0,
+    generated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE(tag_id)
+);
+CREATE INDEX idx_tag_reports_user ON tag_reports(user_id);

--- a/migrations/006_tag_reports.sql
+++ b/migrations/006_tag_reports.sql
@@ -5,6 +5,6 @@ CREATE TABLE tag_reports (
     report          TEXT NOT NULL,
     entry_count     INTEGER NOT NULL DEFAULT 0,
     generated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    UNIQUE(tag_id)
+    UNIQUE(tag_id, user_id)
 );
 CREATE INDEX idx_tag_reports_user ON tag_reports(user_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ async fn run_migrations(pool: &sqlx::SqlitePool) -> anyhow::Result<()> {
         ("003_add_image_type", include_str!("../migrations/003_add_image_type.sql")),
         ("004_tags", include_str!("../migrations/004_tags.sql")),
         ("005_daily_summaries", include_str!("../migrations/005_daily_summaries.sql")),
+        ("006_tag_reports", include_str!("../migrations/006_tag_reports.sql")),
     ];
 
     // Recover from partial migration 003 run (entries_new exists, entries dropped)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -35,6 +35,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/tags/autocomplete", get(tags::autocomplete))
         .route("/tags/{id}", put(tags::rename_tag).delete(tags::delete_tag))
         .route("/tags/{id}/entries", get(tags::tag_entries))
+        .route("/tags/{id}/report", get(tags::tag_report))
+        .route("/tags/{id}/report/generate", post(tags::generate_tag_report_handler))
         // Media
         .route("/media/{user_id}/{filename}", get(entries::serve_media))
         // Static files

--- a/src/tags/handlers.rs
+++ b/src/tags/handlers.rs
@@ -12,10 +12,28 @@ use crate::entries::handlers::EntryWithTags;
 use crate::error::AppError;
 use crate::state::AppState;
 use crate::tags::models::{self, Tag};
+use super::report::{self, TagReport};
 
 const PAGE_SIZE: i64 = 20;
 
 // ── Templates ──────────────────────────────────────────────
+
+#[derive(Template, WebTemplate)]
+#[template(path = "tag_report.html")]
+struct TagReportPageTemplate {
+    username: String,
+    tag: Tag,
+    report: Option<TagReport>,
+    has_gemini_key: bool,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "partials/tag_report_panel.html")]
+struct TagReportPanelTemplate {
+    tag: Tag,
+    report: Option<TagReport>,
+    has_gemini_key: bool,
+}
 
 #[derive(Template, WebTemplate)]
 #[template(path = "tags.html")]
@@ -168,4 +186,62 @@ pub async fn tag_entries(
         entries,
         has_more,
     })
+}
+
+/// GET /tags/{id}/report
+pub async fn tag_report(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let tag = models::get_tag(&state.db, &id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Tag not found"))?;
+    // Ownership check
+    if tag.user_id != user.id {
+        return Err(anyhow::anyhow!("Tag not found").into());
+    }
+    let report = report::get_tag_report(&state.db, &id, &user.id).await?;
+    let has_gemini_key = state.config.gemini_api_key.as_ref().is_some_and(|k| !k.is_empty());
+
+    Ok(TagReportPageTemplate {
+        username: user.username,
+        tag,
+        report,
+        has_gemini_key,
+    })
+}
+
+/// POST /tags/{id}/report/generate
+pub async fn generate_tag_report_handler(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let api_key = match &state.config.gemini_api_key {
+        Some(key) if !key.is_empty() => key.clone(),
+        _ => return Ok(StatusCode::SERVICE_UNAVAILABLE.into_response()),
+    };
+
+    let tag = models::get_tag(&state.db, &id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Tag not found"))?;
+    if tag.user_id != user.id {
+        return Err(anyhow::anyhow!("Tag not found").into());
+    }
+
+    match report::generate_tag_report(&state.db, &api_key, &id, &user.id).await {
+        Ok(_) => {},
+        Err(e) => {
+            tracing::error!(error = %e, "Tag report generation failed");
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, format!("Report generation failed: {}", e)).into_response());
+        }
+    }
+
+    let report = report::get_tag_report(&state.db, &id, &user.id).await?;
+    Ok(TagReportPanelTemplate {
+        tag,
+        report,
+        has_gemini_key: true,
+    }.into_response())
 }

--- a/src/tags/mod.rs
+++ b/src/tags/mod.rs
@@ -1,2 +1,3 @@
 pub mod handlers;
 pub mod models;
+pub mod report;

--- a/src/tags/report.rs
+++ b/src/tags/report.rs
@@ -1,0 +1,127 @@
+use sqlx::SqlitePool;
+
+use crate::entries::models::Entry;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TagReport {
+    pub id: String,
+    pub tag_id: String,
+    pub user_id: String,
+    pub report: String,
+    pub entry_count: i32,
+    pub generated_at: String,
+}
+
+pub async fn get_tag_report(
+    pool: &SqlitePool,
+    tag_id: &str,
+    user_id: &str,
+) -> Result<Option<TagReport>, sqlx::Error> {
+    sqlx::query_as::<_, TagReport>(
+        "SELECT * FROM tag_reports WHERE tag_id = ? AND user_id = ?",
+    )
+    .bind(tag_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+}
+
+pub async fn upsert_tag_report(
+    pool: &SqlitePool,
+    tag_id: &str,
+    user_id: &str,
+    report: &str,
+    entry_count: i32,
+) -> Result<TagReport, sqlx::Error> {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        r#"INSERT INTO tag_reports (id, tag_id, user_id, report, entry_count)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(tag_id) DO UPDATE SET
+               report = excluded.report,
+               entry_count = excluded.entry_count,
+               generated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"#,
+    )
+    .bind(&id)
+    .bind(tag_id)
+    .bind(user_id)
+    .bind(report)
+    .bind(entry_count)
+    .execute(pool)
+    .await?;
+
+    get_tag_report(pool, tag_id, user_id)
+        .await
+        .map(|opt| opt.unwrap())
+}
+
+pub fn build_tag_report_prompt(
+    tag_name: &str,
+    tag_type: &str,
+    entries: &[Entry],
+    existing_report: Option<&str>,
+) -> String {
+    let sigil = if tag_type == "person" { "@" } else { "#" };
+    let mut prompt = format!(
+        "You maintain a cumulative knowledge report for the tag `{}{name}` in a personal log. \
+         Update the existing report by integrating the new entries below. \
+         Preserve prior knowledge, resolve contradictions, and synthesise everything into a \
+         single coherent document. Do not include a title or heading — just the report text.\n\n",
+        sigil,
+        name = tag_name,
+    );
+
+    if let Some(existing) = existing_report {
+        prompt.push_str("Current report:\n");
+        prompt.push_str(existing);
+        prompt.push_str("\n\n---\n\n");
+    }
+
+    prompt.push_str("Entries:\n\n");
+    for entry in entries {
+        let text = entry.display_text().unwrap_or("[no text]");
+        let text = if text.len() > 1000 { &text[..1000] } else { text };
+        prompt.push_str(&format!("[{}] {}\n\n", entry.created_at, text));
+    }
+
+    prompt
+}
+
+pub async fn generate_tag_report(
+    pool: &SqlitePool,
+    api_key: &str,
+    tag_id: &str,
+    user_id: &str,
+) -> anyhow::Result<TagReport> {
+    // 1. Fetch the tag
+    let tag = super::models::get_tag(pool, tag_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Tag not found"))?;
+
+    // 2. Verify ownership
+    if tag.user_id != user_id {
+        anyhow::bail!("Tag not found");
+    }
+
+    // 3. Fetch all entries for this tag (up to 500)
+    let entries = super::models::list_entries_for_tag(pool, tag_id, user_id, None, 500).await?;
+
+    if entries.is_empty() {
+        anyhow::bail!("No entries found for this tag");
+    }
+
+    // 4. Get existing report
+    let existing = get_tag_report(pool, tag_id, user_id).await?;
+    let existing_text = existing.as_ref().map(|r| r.report.as_str());
+
+    // 5. Build prompt
+    let prompt = build_tag_report_prompt(&tag.name, &tag.tag_type, &entries, existing_text);
+
+    // 6. Call Gemini
+    let report_text = crate::summary::gemini::call_gemini_api(api_key, &prompt).await?;
+
+    // 7. Upsert and return
+    let report = upsert_tag_report(pool, tag_id, user_id, &report_text, entries.len() as i32).await?;
+
+    Ok(report)
+}

--- a/src/tags/report.rs
+++ b/src/tags/report.rs
@@ -37,7 +37,7 @@ pub async fn upsert_tag_report(
     sqlx::query(
         r#"INSERT INTO tag_reports (id, tag_id, user_id, report, entry_count)
            VALUES (?, ?, ?, ?, ?)
-           ON CONFLICT(tag_id) DO UPDATE SET
+           ON CONFLICT(tag_id, user_id) DO UPDATE SET
                report = excluded.report,
                entry_count = excluded.entry_count,
                generated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"#,
@@ -52,7 +52,7 @@ pub async fn upsert_tag_report(
 
     get_tag_report(pool, tag_id, user_id)
         .await
-        .map(|opt| opt.unwrap())
+        .and_then(|opt| opt.ok_or(sqlx::Error::RowNotFound))
 }
 
 pub fn build_tag_report_prompt(
@@ -80,7 +80,7 @@ pub fn build_tag_report_prompt(
     prompt.push_str("Entries:\n\n");
     for entry in entries {
         let text = entry.display_text().unwrap_or("[no text]");
-        let text = if text.len() > 1000 { &text[..1000] } else { text };
+        let text = text.char_indices().nth(1000).map_or(text, |(i, _)| &text[..i]);
         prompt.push_str(&format!("[{}] {}\n\n", entry.created_at, text));
     }
 

--- a/templates/partials/tag_report_panel.html
+++ b/templates/partials/tag_report_panel.html
@@ -1,0 +1,37 @@
+<div id="tag-report-panel" class="summary-panel">
+    {% if let Some(r) = report %}
+    <div class="summary-header">
+        <h3 class="summary-title">{% if tag.tag_type == "person" %}@{% else %}#{% endif %}{{ tag.name }} — Knowledge Report</h3>
+        {% if has_gemini_key %}
+        <button class="btn btn-ghost"
+                hx-post="/tags/{{ tag.id }}/report/generate"
+                hx-target="#tag-report-panel"
+                hx-swap="outerHTML"
+                hx-indicator="#report-loading">
+            Regenerate
+        </button>
+        {% endif %}
+    </div>
+    <div class="summary-text">{{ r.report }}</div>
+    <div class="summary-meta" style="margin-top: 0.5rem; font-size: 0.85rem; opacity: 0.7;">
+        {{ r.entry_count }} entries · Generated {{ r.generated_at }}
+    </div>
+    {% else %}
+    <div class="summary-header">
+        <h3 class="summary-title">{% if tag.tag_type == "person" %}@{% else %}#{% endif %}{{ tag.name }} — Knowledge Report</h3>
+    </div>
+    {% if has_gemini_key %}
+    <p class="summary-empty">No report generated yet for this tag.</p>
+    <button class="btn btn-primary btn-sm"
+            hx-post="/tags/{{ tag.id }}/report/generate"
+            hx-target="#tag-report-panel"
+            hx-swap="outerHTML"
+            hx-indicator="#report-loading">
+        Generate Report
+    </button>
+    {% else %}
+    <p class="summary-empty">Set GEMINI_API_KEY to enable AI-powered tag reports.</p>
+    {% endif %}
+    {% endif %}
+    <div id="report-loading" class="htmx-indicator summary-loading">Generating report...</div>
+</div>

--- a/templates/partials/tag_row.html
+++ b/templates/partials/tag_row.html
@@ -3,6 +3,7 @@
         {% if tag.tag_type == "person" %}@{% else %}#{% endif %}<span class="tag-name-text">{{ tag.name }}</span>
     </a>
     <div class="tag-row-actions">
+        <a href="/tags/{{ tag.id }}/report" class="btn btn-ghost">Report</a>
         <button class="btn btn-ghost" onclick="startRenameTag('{{ tag.id }}', '{{ tag.name }}')">Rename</button>
         <button class="btn btn-ghost btn-delete-tag"
                 hx-delete="/tags/{{ tag.id }}"

--- a/templates/tag_entries.html
+++ b/templates/tag_entries.html
@@ -14,6 +14,7 @@
             <span class="header-subtitle">{% if tag.tag_type == "person" %}@{% else %}#{% endif %}{{ tag.name }}</span>
         </div>
         <div class="header-right">
+            <a href="/tags/{{ tag.id }}/report" class="btn btn-ghost">View Report</a>
             <a href="/tags" class="btn btn-ghost">All Tags</a>
             <a href="/" class="btn btn-ghost">Back to Log</a>
             <span class="username">{{ username }}</span>

--- a/templates/tag_report.html
+++ b/templates/tag_report.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}{% if tag.tag_type == "person" %}@{% else %}#{% endif %}{{ tag.name }} Report — Klabautermann{% endblock %}
+
+{% block body %}
+<div class="app-container">
+    <header class="app-header">
+        <div class="header-left">
+            <h1 class="logo">Klabautermann</h1>
+            <span class="header-subtitle">{% if tag.tag_type == "person" %}@{% else %}#{% endif %}{{ tag.name }} — Report</span>
+        </div>
+        <div class="header-right">
+            <a href="/tags/{{ tag.id }}/entries" class="btn btn-ghost">Entries</a>
+            <a href="/tags" class="btn btn-ghost">All Tags</a>
+            <a href="/" class="btn btn-ghost">Back to Log</a>
+            <span class="username">{{ username }}</span>
+            <form method="POST" action="/logout" class="inline-form">
+                <button type="submit" class="btn btn-ghost">Disembark</button>
+            </form>
+        </div>
+    </header>
+
+    <main class="timeline-container">
+        {% include "partials/tag_report_panel.html" %}
+    </main>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add AI-powered cumulative knowledge reports for `#tags` and `@person` mentions using Google Gemini
- Each tag gets a dedicated report page (`/tags/{id}/report`) that synthesizes all linked entries into a coherent summary
- Reports are generated on-demand and updated incrementally (existing report passed as context to Gemini)
- HTMX-powered generate/regenerate button with in-place panel updates

## Changes
- **Migration**: `006_tag_reports.sql` — new `tag_reports` table with `UNIQUE(tag_id)` for upsert semantics
- **Model**: `src/tags/report.rs` — `TagReport` struct, get/upsert/generate functions, prompt builder
- **Handlers**: `GET /tags/{id}/report` (full page), `POST /tags/{id}/report/generate` (HTMX partial)
- **Templates**: `tag_report.html` (full page), `partials/tag_report_panel.html` (HTMX panel)
- **Navigation**: Report links added to `tag_row.html` and `tag_entries.html`

## Edge Cases Handled
- Missing `GEMINI_API_KEY` → 503 Service Unavailable
- Tag with no entries → error message (no API call)
- User ownership validation on all endpoints
- Entry text truncated to 1000 chars per entry in prompt

## Test Plan
- [x] `cargo build` passes cleanly
- [ ] Verify migration 006 applies on fresh and existing database
- [ ] Verify GET `/tags/{id}/report` renders with and without existing report
- [ ] Verify POST generates report and HTMX swaps panel correctly
- [ ] Verify Report links appear in tag management and tag entries pages

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)