### PR TITLE
feat(entries): Add inline edit for entries via HTMX (#422)

### DIFF
--- a/src/entries/handlers.rs
+++ b/src/entries/handlers.rs
@@ -55,6 +55,12 @@ struct TimelinePageTemplate {
     has_more: bool,
 }
 
+#[derive(Template, WebTemplate)]
+#[template(path = "partials/entry_edit.html")]
+struct EntryEditTemplate {
+    entry: Entry,
+}
+
 // ── Handlers ──────────────────────────────────────────────
 
 /// GET / — full page timeline
@@ -274,6 +280,59 @@ pub async fn delete_entry(
 
     models::delete_entry(&state.db, &id, &user.id).await?;
     Ok(StatusCode::OK.into_response())
+}
+
+/// GET /entries/:id/edit — inline edit form
+pub async fn edit_entry_form(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let entry = models::get_entry(&state.db, &id)
+        .await?
+        .filter(|e| e.user_id == user.id)
+        .ok_or_else(|| anyhow::anyhow!("Entry not found"))?;
+
+    Ok(EntryEditTemplate { entry }.into_response())
+}
+
+/// PATCH /entries/:id/edit — update entry content
+pub async fn update_entry(
+    user: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<Response, AppError> {
+    let mut content: Option<String> = None;
+    while let Some(field) = multipart.next_field().await? {
+        if field.name() == Some("content") {
+            content = Some(field.text().await?);
+        }
+    }
+
+    let new_content = content
+        .map(|c| c.trim().to_string())
+        .filter(|c| !c.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Content cannot be empty"))?;
+
+    let entry = models::update_entry(&state.db, &id, &user.id, &new_content)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Entry not found"))?;
+
+    // Re-link tags: clear old, parse new
+    tag_models::unlink_entry_tags(&state.db, &entry.id).await?;
+    let parsed = tag_models::parse_tags_from_text(&new_content);
+    let mut tag_ids = Vec::new();
+    for (name, tag_type) in &parsed {
+        let tag = tag_models::get_or_create_tag(&state.db, &user.id, name, tag_type).await?;
+        tag_ids.push(tag.id);
+    }
+    if !tag_ids.is_empty() {
+        tag_models::link_entry_tags(&state.db, &entry.id, &tag_ids).await?;
+    }
+    let tags = tag_models::get_tags_for_entry(&state.db, &entry.id).await?;
+
+    Ok(EntryCollapsedTemplate { entry, tags }.into_response())
 }
 
 /// GET /media/:user_id/:filename — serve stored media

--- a/src/entries/models.rs
+++ b/src/entries/models.rs
@@ -109,6 +109,27 @@ pub async fn create_media_entry(
     get_entry(pool, &id).await.map(|e| e.unwrap())
 }
 
+pub async fn update_entry(
+    pool: &SqlitePool,
+    id: &str,
+    user_id: &str,
+    content: &str,
+) -> Result<Option<Entry>, sqlx::Error> {
+    let result = sqlx::query(
+        r#"UPDATE entries SET content = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+           WHERE id = ? AND user_id = ?"#,
+    )
+    .bind(content)
+    .bind(id)
+    .bind(user_id)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 {
+        return Ok(None);
+    }
+    get_entry(pool, id).await
+}
+
 pub async fn get_entry(pool: &SqlitePool, id: &str) -> Result<Option<Entry>, sqlx::Error> {
     sqlx::query_as::<_, Entry>("SELECT * FROM entries WHERE id = ?")
         .bind(id)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -31,6 +31,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/entries/{id}", get(entries::get_entry).delete(entries::delete_entry))
         .route("/entries/{id}/expand", get(entries::expand_entry))
         .route("/entries/{id}/collapse", get(entries::collapse_entry))
+        .route("/entries/{id}/edit", get(entries::edit_entry_form).patch(entries::update_entry))
         // Summary
         .route("/summary/today", get(summary::summary_today))
         .route("/summary/generate", post(summary::generate_summary))

--- a/src/tags/models.rs
+++ b/src/tags/models.rs
@@ -96,6 +96,17 @@ pub async fn link_entry_tags(
     Ok(())
 }
 
+pub async fn unlink_entry_tags(
+    pool: &SqlitePool,
+    entry_id: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM entry_tags WHERE entry_id = ?")
+        .bind(entry_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 pub async fn get_tags_for_entry(
     pool: &SqlitePool,
     entry_id: &str,

--- a/templates/partials/entry.html
+++ b/templates/partials/entry.html
@@ -63,6 +63,12 @@
 
         <div class="entry-actions">
             <span class="entry-type-badge">{{ entry.entry_type }}</span>
+            <button class="btn btn-ghost btn-edit"
+                    hx-get="/entries/{{ entry.id }}/edit"
+                    hx-target="#entry-{{ entry.id }}"
+                    hx-swap="outerHTML">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+            </button>
             <button class="btn btn-ghost btn-delete"
                     hx-delete="/entries/{{ entry.id }}"
                     hx-target="#entry-{{ entry.id }}"

--- a/templates/partials/entry_edit.html
+++ b/templates/partials/entry_edit.html
@@ -1,0 +1,42 @@
+<div class="entry entry-editing" id="entry-{{ entry.id }}">
+    <div class="entry-time">{{ entry.formatted_time() }}</div>
+    <div class="entry-body">
+        <form hx-patch="/entries/{{ entry.id }}/edit"
+              hx-target="#entry-{{ entry.id }}"
+              hx-swap="outerHTML"
+              hx-encoding="multipart/form-data">
+            {% if entry.entry_type != "text" %}
+                {# Show media as read-only #}
+                {% if entry.entry_type == "image" %}
+                    {% if let Some(path) = entry.media_path %}
+                    <img src="/media/{{ path }}" class="entry-image" loading="lazy" alt="Journal image">
+                    {% endif %}
+                {% elif entry.entry_type == "audio" %}
+                    {% if let Some(path) = entry.media_path %}
+                    <audio controls preload="metadata" class="entry-audio">
+                        <source src="/media/{{ path }}" type="{{ entry.media_mime.as_deref().unwrap_or("audio/webm") }}">
+                    </audio>
+                    {% endif %}
+                {% else %}
+                    {% if let Some(path) = entry.media_path %}
+                    <video controls preload="metadata" class="entry-video">
+                        <source src="/media/{{ path }}" type="{{ entry.media_mime.as_deref().unwrap_or("video/webm") }}">
+                    </video>
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+
+            <textarea name="content" class="edit-textarea" rows="4" autofocus>{% if entry.entry_type == "text" %}{{ entry.content.as_deref().unwrap_or("") }}{% else %}{{ entry.transcript.as_deref().or(entry.content.as_deref()).unwrap_or("") }}{% endif %}</textarea>
+
+            <div class="edit-actions">
+                <button type="submit" class="btn btn-primary">Save</button>
+                <button type="button" class="btn btn-ghost"
+                        hx-get="/entries/{{ entry.id }}/collapse"
+                        hx-target="#entry-{{ entry.id }}"
+                        hx-swap="outerHTML">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/templates/partials/entry_expanded.html
+++ b/templates/partials/entry_expanded.html
@@ -53,6 +53,12 @@
 
         <div class="entry-actions">
             <span class="entry-type-badge">{{ entry.entry_type }}</span>
+            <button class="btn btn-ghost btn-edit"
+                    hx-get="/entries/{{ entry.id }}/edit"
+                    hx-target="#entry-{{ entry.id }}"
+                    hx-swap="outerHTML">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+            </button>
             <button class="btn btn-ghost btn-delete"
                     hx-delete="/entries/{{ entry.id }}"
                     hx-target="#entry-{{ entry.id }}"


### PR DESCRIPTION
## Summary

- Adds inline editing of journal entries using existing HTMX swap pattern
- Clicking the pencil icon replaces the entry with an edit form; saving PATCHes content and re-links tags
- Media entries show media read-only with editable caption/transcript textarea

## Changes

| File | Change |
|------|--------|
| `src/tags/models.rs` | Add `unlink_entry_tags` helper |
| `src/entries/models.rs` | Add `update_entry` function |
| `src/entries/handlers.rs` | Add `EntryEditTemplate`, `edit_entry_form` (GET), `update_entry` (PATCH) |
| `src/routes.rs` | Register `/entries/{id}/edit` route |
| `templates/partials/entry_edit.html` | New inline edit form partial |
| `templates/partials/entry.html` | Add Edit button |
| `templates/partials/entry_expanded.html` | Add Edit button |

## Test plan

- [x] `cargo build` passes with no new warnings
- [ ] Manual test: click Edit on text entry, verify form appears with content
- [ ] Manual test: edit content, save, verify entry updates and tags re-link
- [ ] Manual test: click Cancel, verify original entry restored
- [ ] Manual test: edit media entry caption, verify save works

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)