### PR TITLE
fix: Preserve text content in image+text entries (#421)

### DIFF
--- a/src/entries/handlers.rs
+++ b/src/entries/handlers.rs
@@ -203,6 +203,16 @@ pub async fn create_entry(
         let relative_path =
             media::save_media(&state.config.media_dir, &user.id, &file_id, &ext, &bytes).await?;
 
+        // Trim content and enforce length limit; treat empty as None
+        let trimmed_content = content
+            .map(|c| c.trim().to_string())
+            .filter(|c| !c.is_empty());
+        if let Some(ref text) = trimmed_content {
+            if text.len() > MAX_TEXT_LENGTH {
+                return Ok(StatusCode::PAYLOAD_TOO_LARGE.into_response());
+            }
+        }
+
         let entry = models::create_media_entry(
             &state.db,
             &user.id,
@@ -210,6 +220,7 @@ pub async fn create_entry(
             &relative_path,
             &detected_mime,
             bytes.len() as i64,
+            trimmed_content.as_deref(),
         )
         .await?;
 

--- a/src/entries/models.rs
+++ b/src/entries/models.rs
@@ -89,16 +89,18 @@ pub async fn create_media_entry(
     media_path: &str,
     media_mime: &str,
     media_size: i64,
+    content: Option<&str>,
 ) -> Result<Entry, sqlx::Error> {
     let id = uuid::Uuid::new_v4().to_string();
     let transcription_status = if entry_type == "image" { "none" } else { "pending" };
     sqlx::query(
-        r#"INSERT INTO entries (id, user_id, entry_type, media_path, media_mime, media_size, transcription_status)
-           VALUES (?, ?, ?, ?, ?, ?, ?)"#,
+        r#"INSERT INTO entries (id, user_id, entry_type, content, media_path, media_mime, media_size, transcription_status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)"#,
     )
     .bind(&id)
     .bind(user_id)
     .bind(entry_type)
+    .bind(content)
     .bind(media_path)
     .bind(media_mime)
     .bind(media_size)

--- a/templates/partials/entry.html
+++ b/templates/partials/entry.html
@@ -33,6 +33,11 @@
                 {% endif %}
             {% endif %}
 
+            {# Caption text (content submitted alongside media) #}
+            {% if let Some(caption) = entry.content %}
+                <p class="entry-caption">{{ caption }}</p>
+            {% endif %}
+
             {# Transcription status #}
             {% if entry.transcription_status == "pending" || entry.transcription_status == "processing" %}
                 <p class="entry-transcription transcribing"

--- a/templates/partials/entry_expanded.html
+++ b/templates/partials/entry_expanded.html
@@ -29,6 +29,11 @@
                 {% endif %}
             {% endif %}
 
+            {# Caption text (content submitted alongside media) #}
+            {% if let Some(caption) = entry.content %}
+                <p class="entry-caption">{{ caption }}</p>
+            {% endif %}
+
             {% if let Some(transcript) = entry.transcript %}
             <p class="entry-transcription">{{ transcript }}</p>
             {% endif %}


### PR DESCRIPTION
## Summary

- Fix `create_entry` handler to pass text content through when media is also present, instead of silently dropping it
- Add `content: Option<&str>` parameter to `create_media_entry` model function and include it in the INSERT statement
- Render `entry.content` as a caption paragraph below media in both collapsed and expanded entry templates

Closes #421

## Test plan

- [ ] Submit form with both an image and text — verify both `media_path` and `content` are set on the resulting Entry row
- [ ] Submit form with only an image (no text) — verify `content` remains NULL
- [ ] Submit form with only text (no image) — verify text-only path still works
- [ ] Verify caption text renders below image in collapsed timeline card
- [ ] Verify caption text renders below image in expanded timeline card
- [ ] Verify tags parsed from caption text of a combined image+text entry are linked correctly
- [ ] `cargo check` and `cargo test` pass with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)